### PR TITLE
Update canbepassedbyvalue.xml

### DIFF
--- a/reference/reflection/reflectionclass/gettraits.xml
+++ b/reference/reflection/reflectionclass/gettraits.xml
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>array</type><methodname>ReflectionClass::getTraits</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Get the array of traits used by this class.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -25,11 +25,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns an array with trait names in keys and instances of trait's
    <classname>ReflectionClass</classname> in values.
-   Returns &null; in case of an error.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
+++ b/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
@@ -21,9 +21,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; if the parameter can be passed by value, &false; otherwise.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
+++ b/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
@@ -23,7 +23,6 @@
   &reftitle.returnvalues;
   <para>
    Returns &true; if the parameter can be passed by value, &false; otherwise.
-   Returns &null; in case of an error.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Fix inaccurate return type description as per:
https://github.com/php/php-src/blob/master/ext/reflection/php_reflection.c#L2872 (master)

It seems it might have returned null in the past:
https://github.com/php/php-src/blob/PHP-7.3.19/ext/reflection/php_reflection.c#L2690 (PHP 7.3).

How do we best handle this?