### PR TITLE
The grapheme_strlen function returns null on encoding failures

### DIFF
--- a/reference/intl/grapheme/grapheme-strlen.xml
+++ b/reference/intl/grapheme/grapheme-strlen.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The length of the string on success, &return.falseforfailure;. 
+   The length of the string on success,  &null; or &false; on failure.
   </para>
  </refsect1>
  

--- a/reference/intl/grapheme/grapheme-strlen.xml
+++ b/reference/intl/grapheme/grapheme-strlen.xml
@@ -36,9 +36,9 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   The length of the string on success,  &null; or &false; on failure.
-  </para>
+  <simpara>
+   The length of the string on success, &null; or &false; on failure.
+  </simpara>
  </refsect1>
  
  <refsect1 role="examples">


### PR DESCRIPTION
The documentation only mentions false for grapheme_strlen failures but in reality it also returns null for encoding failures (which is the more common failure case).
Mention this additional return value in the corresponding section.

Fixes #5554