### PR TITLE
Fix various typos across the manual

### DIFF
--- a/appendices/migration56/openssl.xml
+++ b/appendices/migration56/openssl.xml
@@ -134,7 +134,7 @@ array(4) {
     <term><parameter>dh_param</parameter></term>
     <listitem>
      <para>
-      A path to a file containing parametrs for Diffie-Hellman key exchange,
+      A path to a file containing parameters for Diffie-Hellman key exchange,
       such as that created by the following command:
      </para>
      <programlisting role="shell">

--- a/appendices/migration80/new-classes.xml
+++ b/appendices/migration80/new-classes.xml
@@ -105,7 +105,7 @@
  </sect2>
 
  <sect2 xml:id="migration80.new-classes.sysv">
-  <title>Systen V</title>
+  <title>System V</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -83,7 +83,7 @@
 <![CDATA[
 <?php
 /*
-On /path/to/user.ini contains the following settings:
+/path/to/user.ini contains the following settings:
 
 listen = localhost:${DRUPAL_FPM_PORT:-9000}
 */

--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -350,7 +350,7 @@ class _MyClass {}
 
   <simpara>
    Calling <methodname>ReflectionMethod::__construct</methodname>
-   with one arguments is deprecated.
+   with one argument is deprecated.
    Use <methodname>ReflectionMethod::createFromMethodName</methodname> instead.
   </simpara>
  </sect2>

--- a/chmonly/integration.xml
+++ b/chmonly/integration.xml
@@ -85,7 +85,7 @@
    (<filename>function.mysql-close.html</filename>) automatically. You can
    provide the full path of this file if your IDE supports context sensitive
    help, and provide the IDE specified string as the parameter. An example
-   for this is the UltraEdit 9 intergation (see the edition's website).
+   for this is the UltraEdit 9 integration (see the edition's website).
   </para>
   <para>
    The index of the manual (accessible via the index tab on the navigation

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -13,7 +13,7 @@
   Enabling PHP using the instructions below is meant for quickly setting up
   a local development environment.  It's <emphasis>highly recommended</emphasis>
   to always upgrade PHP to the newest version. Like most live software,
-  newer versions are created to fix bugs and add features and PHP being is
+  newer versions are created to fix bugs and add features and PHP is
   no different.  See the appropriate macOS installation documentation for
   further details. The following instructions are geared towards a beginner
   with details provided for getting a default setup to work. All users are

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -92,7 +92,7 @@
     <filename>/etc/php/7.4/conf.d/*.ini</filename>, etc. and depending on
     the extension will add entries similar to <literal>extension=foo.so</literal>.
     However, restarting the web server (like Apache) is required before these
-    changes take affect.
+    changes take effect.
    </simpara>
  </sect2>
  <sect2 xml:id="install.unix.debian.faq">

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -90,7 +90,7 @@
    <filename>/etc/php/8.3/conf.d/*.ini</filename>, etc. and depending on
    the extension will add entries similar to <literal>extension=foo.so</literal>.
    However, restarting the web server (like Apache) is required before these
-   changes take affect.
+   changes take effect.
   </simpara>
  </sect2>
 </sect1>

--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -138,7 +138,7 @@ echo "Last statement\n";
    <para>
     <note>
      <para>
-      If PHP is embeded within XML or XHTML the normal PHP
+      If PHP is embedded within XML or XHTML the normal PHP
       <code>&lt;?php ?&gt;</code> must be used to remain compliant
       with the standards.
      </para>

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -136,7 +136,7 @@ for($i = 0; $i < count($people); ++$i) {
  </para>
  <simpara>
   The above code can be slow, because the array size is fetched on
-  every iteration. Since the size never changes, the loop be easily
+  every iteration. Since the size never changes, the loop can be easily
   optimized by using an intermediate variable to store the size instead
   of repeatedly calling <function>count</function>:
  </simpara>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -769,7 +769,7 @@ use const some\namespace\ConstA;
 use const some\namespace\ConstB;
 use const some\namespace\ConstC;
 
-// is equivalent to the following groupped use declaration
+// is equivalent to the following grouped use declaration
 use some\namespace\{ClassA, ClassB, ClassC as C};
 use function some\namespace\{fn_a, fn_b, fn_c};
 use const some\namespace\{ConstA, ConstB, ConstC};

--- a/language/oop5/lazy-objects.xml
+++ b/language/oop5/lazy-objects.xml
@@ -323,7 +323,7 @@ var_dump($post->id);
      <link linkend="object.sleep">__sleep()</link> trigger initialization.
     </member>
     <member>
-     Calling to <methodname>ReflectionObject::__toString</methodname>.
+     Calling <methodname>ReflectionObject::__toString</methodname>.
     </member>
     <member>
      Using <function>var_dump</function> or

--- a/language/predefined/fiber/isrunning.xml
+++ b/language/predefined/fiber/isrunning.xml
@@ -26,7 +26,7 @@
    Returns &true; only if the fiber is running. A fiber is considered running after a call to
    <methodname>Fiber::start</methodname>, <methodname>Fiber::resume</methodname>, or
    <methodname>Fiber::throw</methodname> that has not yet returned.
-   Return &false; if the fiber is not running.
+   Returns &false; if the fiber is not running.
   </para>
  </refsect1>
 

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -66,7 +66,7 @@ class IPv4Address implements Stringable {
 }
 
 function showStuff(string|Stringable $value) {
-    // For a Stringable, this will implicitliy call __toString().
+    // For a Stringable, this will implicitly call __toString().
     print $value;
 }
 

--- a/reference/apcu/apcuiterator/current.xml
+++ b/reference/apcu/apcuiterator/current.xml
@@ -26,7 +26,7 @@
   &reftitle.returnvalues;
   <simpara>
    Returns the current item on success, or &false; if no
-   more items or exist, or on failure.
+   more items exist, or on failure.
   </simpara>
  </refsect1>
 

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -79,7 +79,7 @@
       <entry><link linkend="ini.apcu.entries-hint">apc.entries_hint</link></entry>
       <entry>512 * apc.shm_size</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>Prior to APcu 5.1.25, the default was 4096</entry>
+      <entry>Prior to APCu 5.1.25, the default was 4096</entry>
      </row>
      <row>
       <entry><link linkend="ini.apcu.ttl">apc.ttl</link></entry>

--- a/reference/array/functions/each.xml
+++ b/reference/array/functions/each.xml
@@ -158,7 +158,7 @@ c => cranberry
   <warning>
    <para>
     <function>each</function> will also accept objects, but may return unexpected 
-    results. It's therefore not recommended to iterate though object properties 
+    results. It's therefore not recommended to iterate through object properties
     with <function>each</function>.
    </para>
   </warning>

--- a/reference/calendar/constants.xml
+++ b/reference/calendar/constants.xml
@@ -102,7 +102,7 @@
     <simpara>
      For <function>cal_days_in_month</function>,
      <function>cal_from_jd</function>, <function>cal_info</function> and
-     <function>cal_to_jd</function>: use the French Repuclican calendar.
+     <function>cal_to_jd</function>: use the French Republican calendar.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/calendar/functions/juliantojd.xml
+++ b/reference/calendar/functions/juliantojd.xml
@@ -20,7 +20,7 @@
    Although this function can handle dates all the way back to 4713
    B.C., such use may not be meaningful. The calendar was created in
    46 B.C., but the details did not stabilize until at least 8 A.D.,
-   and perhaps as late at the 4th century. Also, the beginning of a
+   and perhaps as late as the 4th century. Also, the beginning of a
    year varied from one culture to another - not all accepted
    January as the first month.
   </para>

--- a/reference/com/dotnet/construct.xml
+++ b/reference/com/dotnet/construct.xml
@@ -34,7 +34,7 @@
     <term><parameter>datatype_name</parameter></term>
     <listitem>
      <simpara>
-      Specifices which class in that assembly to instantiate.
+      Specifies which class in that assembly to instantiate.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/com/functions/variant-date-to-timestamp.xml
+++ b/reference/com/functions/variant-date-to-timestamp.xml
@@ -14,7 +14,7 @@
   <para>
    Converts <parameter>variant</parameter> from a <constant>VT_DATE</constant>
    (or similar) value into a Unix timestamp.  This allows easier
-   interopability between the Unix-ish parts of PHP and COM.
+   interoperability between the Unix-ish parts of PHP and COM.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/cubrid/cubridmysql/cubrid-affected-rows.xml
+++ b/reference/cubrid/cubridmysql/cubrid-affected-rows.xml
@@ -28,7 +28,7 @@
   <varlistentry>
    <term><parameter>conn_identifier</parameter></term>
    <listitem><simpara>The CUBRID connection. If the connection identifier is not
-     specified, the last link opend by <function>cubrid_connect</function> is
+     specified, the last link opened by <function>cubrid_connect</function> is
    assumed.</simpara></listitem>
   </varlistentry>
   <varlistentry>

--- a/reference/cubrid/cubridmysql/cubrid-ping.xml
+++ b/reference/cubrid/cubridmysql/cubrid-ping.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns &true; if the connection to the server CUBRID server is working, otherwise &false;.
+   Returns &true; if the connection to the CUBRID server is working, otherwise &false;.
   </simpara>
  </refsect1>
 

--- a/reference/cubrid/functions/cubrid-bind.xml
+++ b/reference/cubrid/functions/cubrid-bind.xml
@@ -34,7 +34,7 @@
     argument should be the enum element which is in string format.
    </simpara>
    <simpara>
-    In CUBRID shard envrioment, the <parameter>bind_value_type</parameter> must be included in
+    In CUBRID shard environment, the <parameter>bind_value_type</parameter> must be included in
     the <function>cubrid_bind</function> function.
    </simpara>
   </note>
@@ -42,7 +42,7 @@
   The following table shows the types of substitute values.
   </simpara>
   <table>
-   <title>CUBRID Bind Date Types</title>
+   <title>CUBRID Bind Data Types</title>
    <tgroup cols="3">
     <thead>
      <row>

--- a/reference/cubrid/functions/cubrid-execute.xml
+++ b/reference/cubrid/functions/cubrid-execute.xml
@@ -37,7 +37,7 @@
      asynchronous mode. <constant>CUBRID_INCLUDE_OID</constant> and <constant>CUBRID_ASYNC</constant> (or
      <constant>CUBRID_EXEC_QUERY_ALL</constant> if you want to execute multiple SQL statements) can
      be specified by using a bitwise OR operator. If not specified, neither of
-     them isselected. If the flag <constant>CUBRID_EXEC_QUERY_ALL</constant> is set, a synchronous
+     them is selected. If the flag <constant>CUBRID_EXEC_QUERY_ALL</constant> is set, a synchronous
      mode (sync_mode) is used to retrieve query results, and in such cases the
      following rules are applied:
     </simpara>

--- a/reference/cubrid/functions/cubrid-set-autocommit.xml
+++ b/reference/cubrid/functions/cubrid-set-autocommit.xml
@@ -19,7 +19,7 @@
   </simpara>
   <simpara>
    In CUBRID PHP, auto-commit mode is disabled by default for transaction
-   management. When auto-commit mode is truned from off to on, any pending work is
+   management. When auto-commit mode is turned from off to on, any pending work is
    automatically committed.
   </simpara>
  </refsect1>

--- a/reference/datetime/dateperiod.xml
+++ b/reference/datetime/dateperiod.xml
@@ -139,7 +139,7 @@
      <term><varname>recurrences</varname></term>
      <listitem>
       <para>
-       The minimum amount of instances as retured by the iterator.
+       The minimum amount of instances as returned by the iterator.
       </para>
       <para>
        If the number of recurrences has been explicitly passed through the

--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -110,7 +110,7 @@
           <entry>
            <literal>Mon</literal> through <literal>Sun</literal> or
            <literal>Sunday</literal> through <literal>Saturday</literal>. If
-           the day name given is different then the day name belonging to a
+           the day name given is different than the day name belonging to a
            parsed (or default) date is different, then an overflow occurs to
            the <emphasis>next</emphasis> date with the given day name. See the
            examples below for an explanation.

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -72,7 +72,7 @@
   <para>
    If relative time elements are present in the
    <parameter>datetime</parameter> string such as <literal>+3 days</literal>,
-   the then returned array includes a nested array with the key
+   the returned array includes a nested array with the key
    <literal>relative</literal>. This array then contains the keys
    <literal>year</literal>, <literal>month</literal>, <literal>day</literal>,
    <literal>hour</literal>, <literal>minute</literal>,

--- a/reference/dio/functions/dio-fcntl.xml
+++ b/reference/dio/functions/dio-fcntl.xml
@@ -87,7 +87,7 @@
       <para>
        <parameter>args</parameter> is an associative array, when
        <parameter>cmd</parameter> is <constant>F_SETLK</constant> or
-       <constant>F_SETLLW</constant>, with the following keys:
+       <constant>F_SETLKW</constant>, with the following keys:
        <itemizedlist>
         <listitem>
          <para>

--- a/reference/dio/functions/dio-tcsetattr.xml
+++ b/reference/dio/functions/dio-tcsetattr.xml
@@ -92,7 +92,7 @@ dio_tcsetattr($fd, array(
 
 while (true) {
     $data = dio_read($fd, 256);
-    if ($data !== null && $date !== '') {
+    if ($data !== null && $data !== '') {
         echo $data;
     }
 } 

--- a/reference/dom/domdocument/adoptnode.xml
+++ b/reference/dom/domdocument/adoptnode.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The node that was transfered, or &false; on error.
+   The node that was transferred, or &false; on error.
   </para>
  </refsect1>
 


### PR DESCRIPTION
groups 25 single-word typo fixes across 24 files (no semantic or structural changes). Each correction is the kind of single-letter or single-word slip easy to miss in review (`parametrs`, `Systen`, `embeded`, `groupped`, `implicitliy`, `APcu`, `though`/`through`, `Repuclican`, `Specifices`, `interopability`, `opend`, `envrioment`, `truned`, `retured`, `transfered`, `F_SETLLW`/`F_SETLKW`, ...).