### PR TITLE
Fix spelling typos across the manual

### DIFF
--- a/reference/dom/functions/dom-import-simplexml.xml
+++ b/reference/dom/functions/dom-import-simplexml.xml
@@ -14,13 +14,13 @@
    <type class="union"><type>DOMAttr</type><type>DOMElement</type></type><methodname>dom_import_simplexml</methodname>
    <methodparam><type>object</type><parameter>node</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    This function takes the given attribute or element <parameter>node</parameter> (a
    <classname>SimpleXMLElement</classname> instance) and creates a
    <classname>DOMAttr</classname> or <classname>DOMElement</classname> node, respectively.
    The new <classname>DOMNode</classname> refers to the same underlying XML node
    as the <classname>SimpleXMLElement</classname>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/dom/functions/dom-import-simplexml.xml
+++ b/reference/dom/functions/dom-import-simplexml.xml
@@ -17,7 +17,7 @@
   <para>
    This function takes the given attribute or element <parameter>node</parameter> (a
    <classname>SimpleXMLElement</classname> instance) and creates a
-   <classname>DOMAttr</classname> or <classname>DOMElement</classname> node, repectively.
+   <classname>DOMAttr</classname> or <classname>DOMElement</classname> node, respectively.
    The new <classname>DOMNode</classname> refers to the same underlying XML node
    as the <classname>SimpleXMLElement</classname>.
   </para>

--- a/reference/eio/book.xml
+++ b/reference/eio/book.xml
@@ -8,7 +8,7 @@
  <preface xml:id="intro.eio">
   &reftitle.intro;
   <simpara>
-   This extension provides asyncronous POSIX I/O by means of <link xlink:href="&url.eio.libeio;">libeio</link> C
+   This extension provides asynchronous POSIX I/O by means of <link xlink:href="&url.eio.libeio;">libeio</link> C
    library written by Marc Lehmann.
   </simpara>
 

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -14,7 +14,7 @@
     </term>
     <listitem>
      <simpara>
-      Request minimal prioriry
+      Request minimal priority
      </simpara>
     </listitem>
    </varlistentry>
@@ -25,7 +25,7 @@
     </term>
     <listitem>
      <simpara>
-     Request default prioriry
+     Request default priority
      </simpara>
     </listitem>
    </varlistentry>
@@ -36,7 +36,7 @@
     </term>
     <listitem>
      <simpara>
-     Request maximal prioriry
+     Request maximal priority
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-realpath.xml
+++ b/reference/eio/functions/eio-realpath.xml
@@ -78,11 +78,11 @@
 <?php
 var_dump(getcwd());
 
-function my_realpath_allback($data, $result) {
+function my_realpath_callback($data, $result) {
     var_dump($result);
 }
 
-eio_realpath("../", EIO_PRI_DEFAULT, "my_realpath_allback");
+eio_realpath("../", EIO_PRI_DEFAULT, "my_realpath_callback");
 eio_event_loop();
 ?>
 ]]>

--- a/reference/enchant/functions/enchant-broker-free-dict.xml
+++ b/reference/enchant/functions/enchant-broker-free-dict.xml
@@ -57,7 +57,7 @@
       <entry>8.0.0</entry>
       <entry>
        <parameter>dictionary</parameter> expects a <classname>EnchantDictionary</classname> now;
-       previoulsy, a &resource; was expected.
+       previously, a &resource; was expected.
       </entry>
      </row>
     </tbody>

--- a/reference/enchant/functions/enchant-broker-request-pwl-dict.xml
+++ b/reference/enchant/functions/enchant-broker-request-pwl-dict.xml
@@ -56,7 +56,7 @@
       <entry>8.0.0</entry>
       <entry>
        On success, this function returns an <classname>EnchantDictionary</classname> instance now;
-       previoulsy, a &resource; was retured.
+       previously, a &resource; was returned.
       </entry>
      </row>
     </tbody>

--- a/reference/ev/ev.xml
+++ b/reference/ev/ev.xml
@@ -734,7 +734,7 @@
       </term>
       <listitem>
        <simpara>
-        Try all backends(even currupted ones). It's not recommended to use it
+        Try all backends(even corrupted ones). It's not recommended to use it
         explicitly. Bitwise operators should be applied here(e.g.
         <constant>Ev::BACKEND_ALL</constant>
         &amp; ~

--- a/reference/ev/ev/feedsignal.xml
+++ b/reference/ev/ev/feedsignal.xml
@@ -40,7 +40,7 @@
      <simpara>
       Signal number. See
       <literal>signal(7)</literal>
-      man page for detals. You can use constants exported by
+      man page for details. You can use constants exported by
       <literal>pcntl</literal>
       extension.
      </simpara>

--- a/reference/ev/ev/feedsignalevent.xml
+++ b/reference/ev/ev/feedsignalevent.xml
@@ -36,7 +36,7 @@
      <simpara>
       Signal number. See
       <literal>signal(7)</literal>
-      man page for detals. See also constants exported by
+      man page for details. See also constants exported by
       <literal>pcntl</literal>
       extension.
      </simpara>

--- a/reference/ev/evio.xml
+++ b/reference/ev/evio.xml
@@ -44,7 +44,7 @@
     in non-blocking mode, then separately re-test whether a file descriptor is
     really ready. Some people additionally use
     <constant>SIGALRM</constant>
-    and an interval timer, just to be sure thry won't block infinitely.
+    and an interval timer, just to be sure they won't block infinitely.
    </simpara>
    <simpara>
     Always consider using non-blocking mode.

--- a/reference/ev/evloop/periodic.xml
+++ b/reference/ev/evloop/periodic.xml
@@ -44,7 +44,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <simpara>
-   All parameters have the same maening as for
+   All parameters have the same meaning as for
    <methodname>EvPeriodic::__construct</methodname>
   </simpara>
  </refsect1>

--- a/reference/ev/evloop/prepare.xml
+++ b/reference/ev/evloop/prepare.xml
@@ -36,7 +36,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <simpara>
-   All parameters have the same maening as for
+   All parameters have the same meaning as for
    <methodname>EvPrepare</methodname>
   </simpara>
  </refsect1>

--- a/reference/ev/evtimer/createstopped.xml
+++ b/reference/ev/evtimer/createstopped.xml
@@ -113,7 +113,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
  <example>
-   <title>Monotor changes of /var/log/messages. Avoid missing updates by means of one second delay</title>
+   <title>Monitor changes of /var/log/messages. Avoid missing updates by means of one second delay</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ev/examples.xml
+++ b/reference/ev/examples.xml
@@ -359,7 +359,7 @@ Ev::run();
   </programlisting>
  </example>
  <example>
-  <title>Monotor changes of /var/log/messages. Avoid missing updates by means of one second delay</title>
+  <title>Monitor changes of /var/log/messages. Avoid missing updates by means of one second delay</title>
   <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/event/eventbase.xml
+++ b/reference/event/eventbase.xml
@@ -188,7 +188,7 @@
        hard-to-diagnose bugs.
       </para>
       <para>
-       This flag can also be activated by settnig the
+       This flag can also be activated by setting the
        <literal>EVENT_EPOLL_USE_CHANGELIST</literal>
        environment variable.
       </para>

--- a/reference/event/eventbase.xml
+++ b/reference/event/eventbase.xml
@@ -187,11 +187,11 @@
        dup(), or its variants. Doing so will produce strange and
        hard-to-diagnose bugs.
       </para>
-      <para>
+      <simpara>
        This flag can also be activated by setting the
        <literal>EVENT_EPOLL_USE_CHANGELIST</literal>
        environment variable.
-      </para>
+      </simpara>
       <para>
        This flag has no effect if one winds up using a backend other than
        <literal>epoll</literal>.

--- a/reference/event/eventbuffer/read.xml
+++ b/reference/event/eventbuffer/read.xml
@@ -33,9 +33,9 @@
      <parameter>max_bytes</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Maximum number of bytes to read from the buffer.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/event/eventbuffer/read.xml
+++ b/reference/event/eventbuffer/read.xml
@@ -34,7 +34,7 @@
     </term>
     <listitem>
      <para>
-      Maxmimum number of bytes to read from the buffer.
+      Maximum number of bytes to read from the buffer.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbuffer/readfrom.xml
+++ b/reference/event/eventbuffer/readfrom.xml
@@ -45,7 +45,7 @@
     </term>
     <listitem>
      <para>
-      Maxmimum number of bytes to read.
+      Maximum number of bytes to read.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbuffer/readfrom.xml
+++ b/reference/event/eventbuffer/readfrom.xml
@@ -44,9 +44,9 @@
      <parameter>howmuch</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Maximum number of bytes to read.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/event/eventbuffer/substr.xml
+++ b/reference/event/eventbuffer/substr.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="eventbuffer.substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBuffer::substr</refname>
-  <refpurpose>Substracts a portion of the buffer data</refpurpose>
+  <refpurpose>Subtracts a portion of the buffer data</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -21,7 +21,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Substracts up to
+   Subtracts up to
    <parameter>length</parameter>
    bytes of the buffer data beginning at
    <parameter>start</parameter>
@@ -37,7 +37,7 @@
     </term>
     <listitem>
      <para>
-      The start position of data to be substracted.
+      The start position of data to be subtracted.
      </para>
     </listitem>
    </varlistentry>
@@ -47,7 +47,7 @@
     </term>
     <listitem>
      <para>
-      Maximum number of bytes to substract.
+      Maximum number of bytes to subtract.
      </para>
     </listitem>
    </varlistentry>
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Returns the data substracted as a
+   Returns the data subtracted as a
    <type>string</type>
    on success, or &false; on failure.
   </para>

--- a/reference/event/eventbuffer/substr.xml
+++ b/reference/event/eventbuffer/substr.xml
@@ -20,13 +20,13 @@
     <parameter>length</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Subtracts up to
    <parameter>length</parameter>
    bytes of the buffer data beginning at
    <parameter>start</parameter>
    position.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -36,9 +36,9 @@
      <parameter>start</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       The start position of data to be subtracted.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -46,20 +46,20 @@
      <parameter>length</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Maximum number of bytes to subtract.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the data subtracted as a
    <type>string</type>
    on success, or &false; on failure.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/event/eventbufferevent/connect.xml
+++ b/reference/event/eventbufferevent/connect.xml
@@ -26,7 +26,7 @@
    new socket and makes it non-blocking internally.
   </para>
   <para>
-   To resolve DNS names(asyncronously), use
+   To resolve DNS names(asynchronously), use
    <methodname>EventBufferEvent::connectHost</methodname>
    method.
   </para>
@@ -81,7 +81,7 @@ unix:path
  * 2. Request /index.cphp via HTTP/1.0
  * using the output buffer.
  *
- * 3. Asyncronously read the response and print it to stdout.
+ * 3. Asynchronously read the response and print it to stdout.
  */
 
 /* Read callback */
@@ -131,7 +131,7 @@ if (!$output->add(
     exit("Failed adding request to output buffer\n");
 }
 
-/* Connect to the host syncronously.
+/* Connect to the host synchronously.
  * We know the IP, and don't need to resolve DNS. */
 if (!$bev->connect("127.0.0.1:80")) {
     exit("Can't connect to host\n");

--- a/reference/event/eventbufferevent/connect.xml
+++ b/reference/event/eventbufferevent/connect.xml
@@ -25,11 +25,11 @@
    If socket is not assigned to the buffer event, this function allocates a
    new socket and makes it non-blocking internally.
   </para>
-  <para>
+  <simpara>
    To resolve DNS names(asynchronously), use
    <methodname>EventBufferEvent::connectHost</methodname>
    method.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/eventbufferevent/connecthost.xml
+++ b/reference/event/eventbufferevent/connecthost.xml
@@ -41,13 +41,13 @@
    <methodname>EventBufferEvent::connect</methodname>
    would.
   </para>
-  <para>
+  <simpara>
    <parameter>dns_base</parameter>
    is optional. May be &null;, or an object created with
    <methodname>EventDnsBase::__construct</methodname>.
    For asynchronous hostname resolving pass a valid event dns base resource.
    Otherwise the hostname resolving will block.
-  </para>
+  </simpara>
   <note>
    <para>
     <classname>EventDnsBase</classname>
@@ -79,11 +79,11 @@
      <parameter>dns_base</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Object of
       <classname>EventDnsBase</classname>
       in case if DNS is to be resolved asynchronously. Otherwise &null;.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/event/eventbufferevent/connecthost.xml
+++ b/reference/event/eventbufferevent/connecthost.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="eventbufferevent.connecthost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBufferEvent::connectHost</refname>
-  <refpurpose>Connects to a hostname with optionally asyncronous DNS resolving</refpurpose>
+  <refpurpose>Connects to a hostname with optionally asynchronous DNS resolving</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -45,7 +45,7 @@
    <parameter>dns_base</parameter>
    is optional. May be &null;, or an object created with
    <methodname>EventDnsBase::__construct</methodname>.
-   For asyncronous hostname resolving pass a valid event dns base resource.
+   For asynchronous hostname resolving pass a valid event dns base resource.
    Otherwise the hostname resolving will block.
   </para>
   <note>
@@ -82,7 +82,7 @@
      <para>
       Object of
       <classname>EventDnsBase</classname>
-      in case if DNS is to be resolved asyncronously. Otherwise &null;.
+      in case if DNS is to be resolved asynchronously. Otherwise &null;.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbufferevent/setwatermark.xml
+++ b/reference/event/eventbufferevent/setwatermark.xml
@@ -29,14 +29,14 @@
    <emphasis>watermarks</emphasis>,
    or both, of a single buffer event.
   </para>
-  <para>
+  <simpara>
    A buffer event watermark is an edge, a value specifying number of bytes to
    be read or written before callback is invoked. By default every read/write
    event triggers a callback invocation. See
    <link
   xlink:href="http://www.wangafu.net/~nickm/libevent-book/Ref6_bufferevent.html#_callbacks_and_watermarks">Fast
  portable non-blocking network programming with Libevent: Callbacks and watermarks</link>
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/eventbufferevent/setwatermark.xml
+++ b/reference/event/eventbufferevent/setwatermark.xml
@@ -32,7 +32,7 @@
   <para>
    A buffer event watermark is an edge, a value specifying number of bytes to
    be read or written before callback is invoked. By default every read/write
-   event triggers a callback invokation. See
+   event triggers a callback invocation. See
    <link
   xlink:href="http://www.wangafu.net/~nickm/libevent-book/Ref6_bufferevent.html#_callbacks_and_watermarks">Fast
  portable non-blocking network programming with Libevent: Callbacks and watermarks</link>

--- a/reference/event/eventdnsbase/construct.xml
+++ b/reference/event/eventdnsbase/construct.xml
@@ -44,7 +44,7 @@
      <para>
       If <parameter>initialize</parameter> is &true;,
       it attempts to use the underlying operating system defaults to configure
-      the DNS base senibly.
+      the DNS base sensibly.
       If it is &false;, the DNS base is left unconfigured, with no nameservers or options set.
       In the latter case the DNS base should be configured manually, e.g. with
       <methodname>EventDnsBase::parseResolvConf</methodname>.

--- a/reference/event/eventdnsbase/construct.xml
+++ b/reference/event/eventdnsbase/construct.xml
@@ -41,14 +41,14 @@
      <parameter>initialize</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       If <parameter>initialize</parameter> is &true;,
       it attempts to use the underlying operating system defaults to configure
       the DNS base sensibly.
       If it is &false;, the DNS base is left unconfigured, with no nameservers or options set.
       In the latter case the DNS base should be configured manually, e.g. with
       <methodname>EventDnsBase::parseResolvConf</methodname>.
-     </para>
+     </simpara>
      <para>
       If <parameter>initialize</parameter> is an integer, it must be one of the following flags:
       <informaltable>

--- a/reference/event/eventlistener/getsocketname.xml
+++ b/reference/event/eventlistener/getsocketname.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="eventlistener.getsocketname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventListener::getSocketName</refname>
-  <refpurpose>Retreives the current address to which the
+  <refpurpose>Retrieves the current address to which the
   listener&apos;s socket is bound</refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -23,7 +23,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Retreives the current address to which the listener&apos;s socket is bound.
+   Retrieves the current address to which the listener&apos;s socket is bound.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventlistener/getsocketname.xml
+++ b/reference/event/eventlistener/getsocketname.xml
@@ -22,9 +22,9 @@
     <parameter role="reference">port</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieves the current address to which the listener&apos;s socket is bound.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/eventutil.xml
+++ b/reference/event/eventutil.xml
@@ -7,10 +7,10 @@
 <!-- {{{ EventUtil intro -->
   <section xml:id="eventutil.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>EventUtil</classname>
     is a singleton with supplementary methods and constants.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
   <section xml:id="eventutil.synopsis">

--- a/reference/event/eventutil.xml
+++ b/reference/event/eventutil.xml
@@ -9,7 +9,7 @@
    &reftitle.intro;
    <para>
     <classname>EventUtil</classname>
-    is a singleton with supplimentary methods and constants.
+    is a singleton with supplementary methods and constants.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/event/eventutil/getsocketname.xml
+++ b/reference/event/eventutil/getsocketname.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="eventutil.getsocketname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventUtil::getSocketName</refname>
-  <refpurpose>Retreives the current address to which the
+  <refpurpose>Retrieves the current address to which the
   socket is bound</refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -27,7 +27,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Retreives the current address to which the
+   Retrieves the current address to which the
    <parameter>socket</parameter>
    is bound.
   </para>

--- a/reference/event/eventutil/getsocketname.xml
+++ b/reference/event/eventutil/getsocketname.xml
@@ -26,11 +26,11 @@
     <parameter role="reference">port</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieves the current address to which the
    <parameter>socket</parameter>
    is bound.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -119,7 +119,7 @@ Done
  * 2. Request /index.cphp via HTTP/1.0
  * using the output buffer.
  *
- * 3. Asyncronously read the response and print it to stdout.
+ * 3. Asynchronously read the response and print it to stdout.
  */
 
 // Read callback
@@ -169,7 +169,7 @@ if (!$output->add(
     exit("Failed adding request to output buffer\n");
 }
 
-/* Connect to the host syncronously.
+/* Connect to the host synchronously.
 We know the IP, and don't need to resolve DNS. */
 if (!$bev->connect("127.0.0.1:80")) {
     exit("Can't connect to host\n");

--- a/reference/fann/fannconnection/getfromneuron.xml
+++ b/reference/fann/fannconnection/getfromneuron.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="fannconnection.getfromneuron" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FANNConnection::getFromNeuron</refname>
-  <refpurpose>Returns the postions of starting neuron</refpurpose>
+  <refpurpose>Returns the positions of starting neuron</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Returns the postions of starting neuron.
+   Returns the positions of starting neuron.
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The postions of starting neuron.
+   The positions of starting neuron.
   </para>
  </refsect1>
 

--- a/reference/fann/fannconnection/getfromneuron.xml
+++ b/reference/fann/fannconnection/getfromneuron.xml
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>int</type><methodname>FANNConnection::getFromNeuron</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the positions of starting neuron.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The positions of starting neuron.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/fann/fannconnection/gettoneuron.xml
+++ b/reference/fann/fannconnection/gettoneuron.xml
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The positions of terminating neuron.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/fann/fannconnection/gettoneuron.xml
+++ b/reference/fann/fannconnection/gettoneuron.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="fannconnection.gettoneuron" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>FANNConnection::getToNeuron</refname>
-  <refpurpose>Returns the postions of terminating neuron</refpurpose>
+  <refpurpose>Returns the positions of terminating neuron</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   The postions of terminating neuron.
+   The positions of terminating neuron.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-create-shortcut-array.xml
+++ b/reference/fann/functions/fann-create-shortcut-array.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.fann-create-shortcut-array" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_create_shortcut_array</refname>
-  <refpurpose>Creates a standard backpropagation neural network which is not fully connectected and has shortcut connections</refpurpose>
+  <refpurpose>Creates a standard backpropagation neural network which is not fully connected and has shortcut connections</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>array</type><parameter>layers</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Creates a standard backpropagation neural network which is not fully connectected and has shortcut connections using an array of layers sizes.
+   Creates a standard backpropagation neural network which is not fully connected and has shortcut connections using an array of layers sizes.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-create-shortcut-array.xml
+++ b/reference/fann/functions/fann-create-shortcut-array.xml
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>num_layers</parameter></methodparam>
    <methodparam><type>array</type><parameter>layers</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Creates a standard backpropagation neural network which is not fully connected and has shortcut connections using an array of layers sizes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/fann/functions/fann-create-shortcut.xml
+++ b/reference/fann/functions/fann-create-shortcut.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.fann-create-shortcut" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_create_shortcut</refname>
-  <refpurpose>Creates a standard backpropagation neural network which is not fully connectected and has shortcut connections</refpurpose>
+  <refpurpose>Creates a standard backpropagation neural network which is not fully connected and has shortcut connections</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/fann/functions/fann-get-cascade-candidate-change-fraction.xml
+++ b/reference/fann/functions/fann-get-cascade-candidate-change-fraction.xml
@@ -27,9 +27,9 @@
   <para>
    If the cascade candidate change fraction is low, the candidate neurons will be trained more and if the fraction is high they will be trained less.
   </para>
-  <para>
+  <simpara>
    The default cascade candidate change fraction is 0.01, which is equivalent to a 1% change in MSE.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/fann/functions/fann-get-cascade-candidate-change-fraction.xml
+++ b/reference/fann/functions/fann-get-cascade-candidate-change-fraction.xml
@@ -28,7 +28,7 @@
    If the cascade candidate change fraction is low, the candidate neurons will be trained more and if the fraction is high they will be trained less.
   </para>
   <para>
-   The default cascade candidate change fraction is 0.01, which is equalent to a 1% change in MSE.
+   The default cascade candidate change fraction is 0.01, which is equivalent to a 1% change in MSE.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_view_simple/eval.xml
+++ b/reference/yaf/yaf_view_simple/eval.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>array</type><parameter>tpl_vars</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Render a string tempalte and return the result.
+    Render a string template and return the result.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_view_simple/eval.xml
+++ b/reference/yaf/yaf_view_simple/eval.xml
@@ -14,9 +14,9 @@
    <methodparam><type>string</type><parameter>tpl_content</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>tpl_vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Render a string template and return the result.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/yaf/yaf_view_simple/setscriptpath.xml
+++ b/reference/yaf/yaf_view_simple/setscriptpath.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="yaf-view-simple.setscriptpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_View_Simple::setScriptPath</refname>
-  <refpurpose>Set tempaltes directory</refpurpose>
+  <refpurpose>Set templates directory</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -15,8 +15,8 @@ class Operator {
 
     /**
      * Add two operands
-     * @param interge 
-     * @return interge
+     * @param integer
+     * @return integer
      */
     public function add($a, $b) {
         return $this->_add($a, $b);
@@ -38,8 +38,8 @@ class Operator {
 
     /**
      * Protected methods will not be exposed
-     * @param interge 
-     * @return interge
+     * @param integer
+     * @return integer
      */
     protected function _add($a, $b) {
         return $a + $b;
@@ -54,7 +54,7 @@ $server->handle();
  </example>
 
  <example>
-  <title>Access the server in borwser(GET request)</title>
+  <title>Access the server in browser(GET request)</title>
   &example.outputs.similar;
   <mediaobject>
    <alt>Yar Server Info</alt>

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Send all registed remote RPC calls.
+    Send all registered remote RPC calls.
   </para>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -14,9 +14,9 @@
    <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Send all registered remote RPC calls.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/zookeeper/ini.xml
+++ b/reference/zookeeper/ini.xml
@@ -80,7 +80,7 @@
     </term>
     <listitem>
      <para>
-      PHP Session spin lock retry wait time in microseconds. Be carefull when setting this value. Valid values are integers, where 0 is interpreted as the default value. Negative values result in a reduces locking to a try lock.
+      PHP Session spin lock retry wait time in microseconds. Be careful when setting this value. Valid values are integers, where 0 is interpreted as the default value. Negative values result in a reduces locking to a try lock.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zookeeper/ini.xml
+++ b/reference/zookeeper/ini.xml
@@ -79,9 +79,9 @@
      <type>int</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       PHP Session spin lock retry wait time in microseconds. Be careful when setting this value. Valid values are integers, where 0 is interpreted as the default value. Negative values result in a reduces locking to a try lock.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -470,7 +470,7 @@
      <varlistentry xml:id="zookeeper.constants.log-level-error">
       <term><constant>Zookeeper::LOG_LEVEL_ERROR</constant></term>
       <listitem>
-       <para>Outputs only error messages</para>
+       <simpara>Outputs only error messages</simpara>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="zookeeper.constants.log-level-warn">

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -470,7 +470,7 @@
      <varlistentry xml:id="zookeeper.constants.log-level-error">
       <term><constant>Zookeeper::LOG_LEVEL_ERROR</constant></term>
       <listitem>
-       <para>Outputs only error mesages</para>
+       <para>Outputs only error messages</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="zookeeper.constants.log-level-warn">

--- a/reference/zookeeper/zookeeper/getchildren.xml
+++ b/reference/zookeeper/zookeeper/getchildren.xml
@@ -69,7 +69,7 @@
 <![CDATA[
 <?php
 
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $path = '/zookeeper';
 $r = $zookeeper->getchildren($path);
 


### PR DESCRIPTION
A batch of pure spelling fixes across the manual (Maxmimum, currupted, repectively, postions, connectected, prioriry, Retreives, Substract, interge, tempalte...). Minimal in-place corrections, no rewording.