### PR TITLE
Fix copy-pasted descriptions referencing the wrong function

### DIFF
--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>limited</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Retrieves cached information and meta-data from APC's data store.
+   Retrieves cached information and meta-data from APCu's data store.
   </simpara>
  </refsect1>
 
@@ -42,7 +42,7 @@
   <note>
    <simpara>
     <function>apcu_cache_info</function> will raise a warning if it is unable to
-    retrieve APC cache data. This typically occurs when APC is not enabled.
+    retrieve APCu cache data. This typically occurs when APCu is not enabled.
    </simpara>
   </note>
  </refsect1>

--- a/reference/apcu/functions/apcu-key-info.xml
+++ b/reference/apcu/functions/apcu-key-info.xml
@@ -26,7 +26,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <simpara>
-      Get detailed information about the cache key
+      The key to retrieve information for.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/cubrid/functions/cubrid-lob2-import.xml
+++ b/reference/cubrid/functions/cubrid-lob2-import.xml
@@ -17,7 +17,7 @@
    The <function>cubrid_lob2_import</function> function is used to save the
    contents of BLOB/CLOB data from a file. To use this function, you must use
    <function>cubrid_lob2_new</function> or fetch a lob object from CUBRID database
-   first. If the file already exists, the operation will fail.
+   first. If the file does not exist, the operation will fail.
    This function will not influence the cursor position of the lob object.
    It operates the entire lob object.
   </simpara>

--- a/reference/cubrid/functions/cubrid-pconnect.xml
+++ b/reference/cubrid/functions/cubrid-pconnect.xml
@@ -77,7 +77,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>cubrid_connect</function> example</title>
+   <title><function>cubrid_pconnect</function> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/cubrid/functions/cubrid-seq-insert.xml
+++ b/reference/cubrid/functions/cubrid-seq-insert.xml
@@ -17,7 +17,7 @@
    <methodparam><type>string</type><parameter>seq_element</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-    The <function>cubrid_col_insert</function> function is used to insert an
+    The <function>cubrid_seq_insert</function> function is used to insert an
     element to a sequence type attribute in a requested location.
   </simpara>
  </refsect1>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-chown">
  <refnamediv>
   <refname>eio_chown</refname>
-  <refpurpose>Change file/directory permissions</refpurpose>
+  <refpurpose>Change file/directory ownership</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,9 @@
    <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-  Changes file, or directory permissions.
+  <function>eio_chown</function> changes ownership of a file, or directory. The
+  new owner is specified by <parameter>uid</parameter>, and the group by
+  <parameter>gid</parameter>.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -77,7 +77,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_chmod</function> returns request resource on success,&return.falseforfailure;.
+   <function>eio_fchown</function> returns request resource on success,&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -59,14 +59,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_busy</function> returns request resource on success,&return.falseforfailure;.
+   <function>eio_fstat</function> returns request resource on success,&return.falseforfailure;.
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>eio_lstat</function> example</title>
+   <title><function>eio_fstat</function> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/eio/functions/eio-nready.xml
+++ b/reference/eio/functions/eio-nready.xml
@@ -35,7 +35,6 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>eio_nreqs</function></member>
-   <member><function>eio_nready</function></member>
    <member><function>eio_nthreads</function></member>
   </simplelist>
  </refsect1>

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -68,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_busy</function> returns request resource on success,&return.falseforfailure;.
+   <function>eio_truncate</function> returns request resource on success,&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-suggest">
  <refnamediv>
   <refname>enchant_dict_suggest</refname>
-  <refpurpose>Will return a list of values if any of those pre-conditions are not met</refpurpose>
+  <refpurpose>Suggest spellings for a word</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ev/evchild/createstopped.xml
+++ b/reference/ev/evchild/createstopped.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evchild.createstopped">
  <refnamediv>
   <refname>EvChild::createStopped</refname>
-  <refpurpose>Create instance of a stopped EvCheck watcher</refpurpose>
+  <refpurpose>Create instance of a stopped EvChild watcher</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ev/evsignal/construct.xml
+++ b/reference/ev/evsignal/construct.xml
@@ -31,7 +31,7 @@
   </constructorsynopsis>
   <simpara>
    Constructs EvSignal watcher object and starts it automatically. For a
-   stopped periodic watcher consider using
+   stopped signal watcher consider using
    <methodname>EvSignal::createStopped</methodname>
    method.
   </simpara>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -171,7 +171,7 @@
       <simpara>
        This flag indicates an event that becomes active when the provided file
        descriptor(usually a stream resource, or socket) is ready for writing.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="event.constants.signal">

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -168,7 +168,7 @@
       <constant>Event::WRITE</constant>
      </term>
      <listitem>
-      <para>
+      <simpara>
        This flag indicates an event that becomes active when the provided file
        descriptor(usually a stream resource, or socket) is ready for writing.
       </para>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -170,7 +170,7 @@
      <listitem>
       <para>
        This flag indicates an event that becomes active when the provided file
-       descriptor(usually a stream resource, or socket) is ready for reading.
+       descriptor(usually a stream resource, or socket) is ready for writing.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/eventhttprequest/getbufferevent.xml
+++ b/reference/event/eventhttprequest/getbufferevent.xml
@@ -10,7 +10,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <type>EventBufferEvent</type>
-   <methodname>EventHttpRequest::closeConnection</methodname>
+   <methodname>EventHttpRequest::getBufferEvent</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/fann/functions/fann-get-activation-function.xml
+++ b/reference/fann/functions/fann-get-activation-function.xml
@@ -57,10 +57,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   <link linkend="constants.fann-train">Learning functions</link> constant or -1
+  <simpara>
+   <link linkend="constants.fann-activation-funcs">Activation functions</link> constant or -1
    if the neuron is not defined in the neural network, or &false; on error.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-get-rprop-decrease-factor.xml
+++ b/reference/fann/functions/fann-get-rprop-decrease-factor.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.fann-get-rprop-decrease-factor" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_get_rprop_decrease_factor</refname>
-  <refpurpose>Returns the increase factor used during RPROP training</refpurpose>
+  <refpurpose>Returns the decrease factor used during RPROP training</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -45,7 +45,7 @@
       periodically.
       The timeout value guarantees that there is at least this amount of milliseconds between
       invocations of the callback function.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -30,7 +30,7 @@
    <varlistentry>
     <term><parameter>cb_func</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Callback function to invoke when the timer fires. Returning false
       or a value that evaluates to false from this function will cause the 
       device to stop.

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -34,7 +34,7 @@
       Callback function to invoke when the timer fires. Returning false
       or a value that evaluates to false from this function will cause the 
       device to stop.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -31,7 +31,7 @@
     <term><parameter>cb_func</parameter></term>
     <listitem>
      <para>
-      Callback function to invoke when the device is idle. Returning false
+      Callback function to invoke when the timer fires. Returning false
       or a value that evaluates to false from this function will cause the 
       device to stop.
      </para>
@@ -41,8 +41,8 @@
     <term><parameter>timeout</parameter></term>
     <listitem>
      <para>
-      How often to invoke the idle callback in milliseconds. The idle callback is invoked
-      periodically when there is no activity on the device.
+      How often to invoke the timer callback in milliseconds. The timer callback is invoked
+      periodically.
       The timeout value guarantees that there is at least this amount of milliseconds between
       invocations of the callback function.
      </para>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -40,7 +40,7 @@
    <varlistentry>
     <term><parameter>timeout</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       How often to invoke the timer callback in milliseconds. The timer callback is invoked
       periodically.
       The timeout value guarantees that there is at least this amount of milliseconds between


### PR DESCRIPTION
Several reference pages had a refpurpose, return value or example title copy-pasted from a sibling function, so they pointed to the wrong function or concept (e.g. Event::WRITE described as ready for reading, eio_chown documented as changing permissions instead of ownership).