### PR TITLE
Document new key `builtin_default_value` of the array returned by `ini_get_all()` in PHP >= 8.6.0

### DIFF
--- a/reference/info/functions/ini-get-all.xml
+++ b/reference/info/functions/ini-get-all.xml
@@ -55,7 +55,10 @@
    When <parameter>details</parameter> is &true; (default) the array will
    contain <literal>global_value</literal> (set in
    &php.ini;), <literal>local_value</literal> (perhaps set with
-   <function>ini_set</function> or &htaccess;), and
+   <function>ini_set</function> or &htaccess;),
+   <literal>builtin_default_value</literal> (the built-in default value of the
+   directive, or &null; if it has none, independent of values set in
+   &php.ini;, on the command line, or at runtime), and
    <literal>access</literal> (the access level).
   </para>
   <para>
@@ -72,6 +75,31 @@
     why <literal>access</literal> shows the appropriate bitmask values.
    </para>
   </note>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.6.0</entry>
+       <entry>
+        The <literal>builtin_default_value</literal> element was added to the
+        details array returned for each directive.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
  </refsect1>
 
  <refsect1 role="examples">
@@ -96,6 +124,7 @@ Array
         (
             [global_value] => 100000
             [local_value] => 100000
+            [builtin_default_value] => 100000
             [access] => 7
         )
 
@@ -103,6 +132,7 @@ Array
         (
             [global_value] => 100000
             [local_value] => 100000
+            [builtin_default_value] => 100000
             [access] => 7
         )
 
@@ -113,6 +143,7 @@ Array
         (
             [global_value] => 0
             [local_value] => 0
+            [builtin_default_value] => 0
             [access] => 6
         )
 
@@ -120,6 +151,7 @@ Array
         (
             [global_value] => 1
             [local_value] => 1
+            [builtin_default_value] => 1
             [access] => 4
         )
 

--- a/reference/info/functions/ini-get-all.xml
+++ b/reference/info/functions/ini-get-all.xml
@@ -51,7 +51,7 @@
    Returns &false; and raises an <constant>E_WARNING</constant> level error
    if the <parameter>extension</parameter> doesn't exist.
   </para>
-  <para>
+  <simpara>
    When <parameter>details</parameter> is &true; (default) the array will
    contain <literal>global_value</literal> (set in
    &php.ini;), <literal>local_value</literal> (perhaps set with
@@ -60,7 +60,7 @@
    directive, or &null; if it has none, independent of values set in
    &php.ini;, on the command line, or at runtime), and
    <literal>access</literal> (the access level).
-  </para>
+  </simpara>
   <para>
    When <parameter>details</parameter> is &false; the value will be the
    current value of the option.
@@ -79,27 +79,25 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>8.6.0</entry>
-       <entry>
-        The <literal>builtin_default_value</literal> element was added to the
-        details array returned for each directive.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+ <informaltable>
+  <tgroup cols="2">
+   <thead>
+    <row>
+     <entry>&Version;</entry>
+     <entry>&Description;</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry>8.6.0</entry>
+     <entry>
+      The <literal>builtin_default_value</literal> element was added to the
+      details array returned for each directive.
+     </entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
This updates the documentation for `ini_get_all()` after https://github.com/php/php-src/pull/22134.