### PR TITLE
Nits: incomplete and broken sentences

### DIFF
--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -208,14 +208,14 @@ $arr[] = 2;
  <sect2 xml:id="migration81.deprecated.hash">
   <title>Hash</title>
 
-  <para>
+  <simpara>
    The <function>mhash</function>,
    <function>mhash_keygen_s2k</function>,
    <function>mhash_count</function>,
    <function>mhash_get_block_size</function>,
-   and <function>mhash_get_hash_name</function> have been deprecated.
+   and <function>mhash_get_hash_name</function> functions have been deprecated.
    Use the <literal>hash_*()</literal> functions instead.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration81.deprecated.imap">

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -287,12 +287,12 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
    EC private keys will now be exported in <acronym>PKCS</acronym>#8 format rather than
    traditional format, just like all other keys.
   </para>
-  <para>
+  <simpara>
    <function>openssl_pkcs7_encrypt</function> and
-   <function>openssl_cms_encrypt</function> will now to default using
+   <function>openssl_cms_encrypt</function> will now default to using
    AES-128-CBC rather than RC2-40. The RC2-40 cipher is considered
    insecure and not enabled by default by OpenSSL 3.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration81.incompatible.pdo">

--- a/faq/build.xml
+++ b/faq/build.xml
@@ -157,13 +157,13 @@
      </para>
     </question>
     <answer>
-     <para>
-      Some old versions of make that don't correctly put the compiled
+     <simpara>
+      Some old versions of make don't correctly put the compiled
       versions of the files in the functions directory into that same
       directory. Try running <command>cp *.o functions</command> and then
       re-running <command>make</command> to see if that helps. If it does, you should really
       upgrade to a recent version of GNU make.
-     </para>
+     </simpara>
     </answer>
    </qandaentry>
 

--- a/install/unix/lighttpd-14.xml
+++ b/install/unix/lighttpd-14.xml
@@ -51,7 +51,7 @@ fastcgi.server = ( ".php" =>
    </screen>
   </example>
 
-  <para>
+  <simpara>
    The <filename>bin-path</filename> directive allows lighttpd to spawn FastCGI processes dynamically.
    PHP will spawn children according to the <envar>PHP_FCGI_CHILDREN</envar> environment
    variable. The <literal>bin-environment</literal> directive sets the environment for the
@@ -60,9 +60,9 @@ fastcgi.server = ( ".php" =>
    <literal>min-procs</literal> and <literal>max-procs</literal> should generally be avoided with PHP. PHP
    manages its own children and opcode caches like APC will only share among
    children managed by PHP. If <literal>min-procs</literal> is set to something greater than <literal>1</literal>,
-   the total number of php responders will be multiplied <envar>PHP_FCGI_CHILDREN</envar>
+   the total number of php responders will be multiplied by <envar>PHP_FCGI_CHILDREN</envar>
    (2 min-procs * 16 children gives 32 responders).
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="install.unix.lighttpd-14.spawn-fcgi">

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -489,7 +489,7 @@ class PositivePoint extends Point
    <simpara>
     Each hook overrides parent implementations independently of each other.
     If a child class adds hooks, any default value set on the property is removed, and must be redeclared.
-    That is the same consistent with how inheritance works on hook-less properties.
+    That is consistent with how inheritance works on hook-less properties.
    </simpara>
   </sect3>
   <sect3>

--- a/language/types/type-system.xml
+++ b/language/types/type-system.xml
@@ -171,7 +171,7 @@
 
   <sect3 xml:id="language.types.type-system.composite.union">
    <title>Union types</title>
-   <para>
+   <simpara>
     A union type accepts values of multiple different types,
     rather than a single one.
     Individual types which form the union type are joined by the
@@ -179,9 +179,9 @@
     of the types <literal>T</literal>, <literal>U</literal>, and
     <literal>V</literal> will be written as <literal>T|U|V</literal>.
     If one of the types is an intersection type, it needs to be bracketed
-    with parenthesis for it to written in <acronym>DNF</acronym>:
+    with parenthesis for it to be written in <acronym>DNF</acronym>:
     <literal>T|(X&amp;Y)</literal>.
-   </para>
+   </simpara>
   </sect3>
  </sect2>
 

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -36,6 +36,7 @@
     <listitem>
      <para>
       The callback function to call to check each element, which must be
+      of the following signature:
       <methodsynopsis>
        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -36,6 +36,7 @@
     <listitem>
      <para>
       The callback function to call to check each element, which must be
+      of the following signature:
       <methodsynopsis>
        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -36,6 +36,7 @@
     <listitem>
      <para>
       The callback function to call to check each element, which must be
+      of the following signature:
       <methodsynopsis>
        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -36,6 +36,7 @@
     <listitem>
      <para>
       The callback function to call to check each element, which must be
+      of the following signature:
       <methodsynopsis>
        <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>

--- a/reference/com/constants.xml
+++ b/reference/com/constants.xml
@@ -323,7 +323,7 @@
    </term>
    <listitem>
     <simpara>
-     A pointer to an object that implements the IUnknown interface.
+     A pointer to an object that implements the <interfacename>IUnknown</interfacename> interface.
     </simpara>
    </listitem>
   </varlistentry>
@@ -334,7 +334,7 @@
    </term>
    <listitem>
     <simpara>
-     A pointer to a pointer to an object was specified.
+     A pointer to an object that implements the <interfacename>IDispatch</interfacename> interface.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/cubrid/constants.xml
+++ b/reference/cubrid/constants.xml
@@ -64,7 +64,7 @@
       </row>
       <row>
        <entry><constant>CUBRID_OBJECT</constant></entry>
-       <entry>Get query result an object.</entry>
+       <entry>Get query result as an object.</entry>
       </row>
       <row>
        <entry><constant>CUBRID_LOB</constant></entry>

--- a/reference/cubrid/functions/cubrid-connect-with-url.xml
+++ b/reference/cubrid/functions/cubrid-connect-with-url.xml
@@ -76,7 +76,7 @@
    </member>
    <member>
     query_timeout : Timeout value (unit: msec.) for query request. Upon timeout,
-    a message to cancel requesting a query transferred to server is sent. The return
+    a message to cancel the requested query is sent to the server. The return
     value can depend on the disconnect_on_query_timeout configuration; even though the
     message to cancel a request is sent to server, that request may succeed.
    </member>

--- a/reference/ds/ds.hashable.xml
+++ b/reference/ds/ds.hashable.xml
@@ -11,13 +11,13 @@
 <!-- {{{ Ds\Hashable intro -->
   <section xml:id="ds-hashable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
         Hashable is an interface which allows objects to be used as keys.
         It’s an alternative to <function>spl_object_hash</function>,
         which determines an object’s hash based on its handle:
         this means that two objects that are considered equal by an implicit
-        definition would not treated as equal because they are not the same instance.
-   </para>
+        definition would not be treated as equal because they are not the same instance.
+   </simpara>
    <para>
         <function>hash</function> is used to return a scalar value to be used as
         the object's hash value, which determines where it goes in the hash table.

--- a/reference/ds/ds/deque/allocate.xml
+++ b/reference/ds/ds/deque/allocate.xml
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>void</type><methodname>Ds\Deque::allocate</methodname>
    <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Ensures that enough memory is allocated for a required capacity.
-    This removes the need to reallocate the internal as values are added.
-  </para>
+    This removes the need to reallocate the internal buffer as values are added.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ds/ds/map/haskey.xml
+++ b/reference/ds/ds/map/haskey.xml
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-    Returns &true; if the key could found, &false; otherwise.
-  </para>
+  <simpara>
+    Returns &true; if the key could be found, &false; otherwise.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/ds/ds/map/hasvalue.xml
+++ b/reference/ds/ds/map/hasvalue.xml
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-    Returns &true; if the value could found, &false; otherwise.
-  </para>
+  <simpara>
+    Returns &true; if the value could be found, &false; otherwise.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/ds/ds/map/toarray.xml
+++ b/reference/ds/ds/map/toarray.xml
@@ -19,9 +19,9 @@
     Converts the map to an &array;.
   </para>
   <caution>
-        <para>
-            Maps where non-scalar keys are can't be converted to an &array;.
-        </para>
+        <simpara>
+            Maps with non-scalar keys can't be converted to an &array;.
+        </simpara>
     </caution>
     <caution>
         <para>

--- a/reference/ds/ds/priorityqueue/allocate.xml
+++ b/reference/ds/ds/priorityqueue/allocate.xml
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>void</type><methodname>Ds\PriorityQueue::allocate</methodname>
    <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Ensures that enough memory is allocated for a required capacity.
-    This removes the need to reallocate the internal as values are added.
-  </para>
+    This removes the need to reallocate the internal buffer as values are added.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ds/ds/queue/allocate.xml
+++ b/reference/ds/ds/queue/allocate.xml
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>void</type><methodname>Ds\Queue::allocate</methodname>
    <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Ensures that enough memory is allocated for a required capacity.
-    This removes the need to reallocate the internal as values are added.
-  </para>
+    This removes the need to reallocate the internal buffer as values are added.
+  </simpara>
   <note>
     <para>
         Capacity will always be rounded up to the nearest power of 2.

--- a/reference/ds/ds/sequence/allocate.xml
+++ b/reference/ds/ds/sequence/allocate.xml
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>Ds\Sequence::allocate</methodname>
    <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Ensures that enough memory is allocated for a required capacity.
-    This removes the need to reallocate the internal as values are added.
-  </para>
+    This removes the need to reallocate the internal buffer as values are added.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ds/ds/stack/allocate.xml
+++ b/reference/ds/ds/stack/allocate.xml
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>void</type><methodname>Ds\Stack::allocate</methodname>
    <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Ensures that enough memory is allocated for a required capacity.
-    This removes the need to reallocate the internal as values are added.
-  </para>
+    This removes the need to reallocate the internal buffer as values are added.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/ds/ds/vector/allocate.xml
+++ b/reference/ds/ds/vector/allocate.xml
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>void</type><methodname>Ds\Vector::allocate</methodname>
    <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Ensures that enough memory is allocated for a required capacity.
-    This removes the need to reallocate the internal as values are added.
-  </para>
+    This removes the need to reallocate the internal buffer as values are added.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/eio/functions/eio-fallocate.xml
+++ b/reference/eio/functions/eio-fallocate.xml
@@ -70,7 +70,7 @@
     <term><parameter>length</parameter></term>
     <listitem>
      <simpara>
-     Specifies length the byte range.
+     Specifies length of the byte range.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-open.xml
+++ b/reference/eio/functions/eio-open.xml
@@ -19,7 +19,8 @@
   </methodsynopsis>
   <simpara>
   <function>eio_open</function> opens file specified by
-  <parameter>path</parameter> in access mode <parameter>mode</parameter> with
+  <parameter>path</parameter> in access mode <parameter>mode</parameter> with the
+  given <parameter>flags</parameter>.
   </simpara>
 
 

--- a/reference/eio/functions/eio-poll.xml
+++ b/reference/eio/functions/eio-poll.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-poll">
  <refnamediv>
   <refname>eio_poll</refname>
-  <refpurpose>Can be to be called whenever there are pending requests that need finishing</refpurpose>
+  <refpurpose>Can be called whenever there are pending requests that need finishing</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/enchant/functions/enchant-broker-dict-exists.xml
+++ b/reference/enchant/functions/enchant-broker-dict-exists.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-dict-exists">
  <refnamediv>
   <refname>enchant_broker_dict_exists</refname>
-  <refpurpose>Whether a dictionary exists or not. Using non-empty tag</refpurpose>
+  <refpurpose>Whether a dictionary exists or not</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/enchant/functions/enchant-broker-init.xml
+++ b/reference/enchant/functions/enchant-broker-init.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-init">
  <refnamediv>
   <refname>enchant_broker_init</refname>
-  <refpurpose>Create a new broker object capable of requesting</refpurpose>
+  <refpurpose>Create a new broker object</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/enchant/functions/enchant-broker-request-pwl-dict.xml
+++ b/reference/enchant/functions/enchant-broker-request-pwl-dict.xml
@@ -13,7 +13,7 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Creates a dictionary using a PWL file. A PWL file is personal word file one word per line.
+   Creates a dictionary using a PWL file. A PWL file is a personal word file with one word per line.
   </simpara>
 
  </refsect1>

--- a/reference/ev/ev/recommendedbackends.xml
+++ b/reference/ev/ev/recommendedbackends.xml
@@ -29,7 +29,7 @@
    systems and will not be auto-detected unless it is requested explicitly.
    This is the set of backends that
    <literal>libev</literal>
-   will probe no backends specified explicitly.
+   will probe when no backends are specified explicitly.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/ev/evprepare/construct.xml
+++ b/reference/ev/evprepare/construct.xml
@@ -25,7 +25,7 @@
   </constructorsynopsis>
   <simpara>
    Constructs EvPrepare watcher object. And starts the watcher automatically.
-   If need a stopped watcher consider using
+   If a stopped watcher is needed, consider using
    <methodname>EvPrepare::createStopped</methodname>
   </simpara>
  </refsect1>

--- a/reference/event/event/getsupportedmethods.xml
+++ b/reference/event/event/getsupportedmethods.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="event.getsupportedmethods" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Event::getSupportedMethods</refname>
-  <refpurpose>Returns array with of the names of the methods supported in this version of Libevent</refpurpose>
+  <refpurpose>Returns array of the names of the methods supported in this version of Libevent</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -14,10 +14,10 @@
    <methodname>Event::getSupportedMethods</methodname>
    <void />
   </methodsynopsis>
-  <para>
-   Returns array with of the names of the methods(backends) supported in this
+  <simpara>
+   Returns array of the names of the methods(backends) supported in this
    version of Libevent.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/eventconfig/setflags.xml
+++ b/reference/event/eventconfig/setflags.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="eventconfig.setflags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventConfig::setFlags</refname>
-  <refpurpose>Sets one or more flags to configure the eventual EventBase will be initialized</refpurpose>
+  <refpurpose>Sets one or more flags that configure how the eventual EventBase will be initialized</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/event/eventhttp/setallowedmethods.xml
+++ b/reference/event/eventhttp/setallowedmethods.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="eventhttp.setallowedmethods" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventHttp::setAllowedMethods</refname>
-  <refpurpose>Sets the what HTTP methods are supported in requests accepted by this server, and passed to user callbacks</refpurpose>
+  <refpurpose>Sets which HTTP methods are supported in requests accepted by this server, and passed to user callbacks</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -16,10 +16,10 @@
     <parameter>methods</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
-   Sets the what HTTP methods are supported in requests accepted by this
+  <simpara>
+   Sets which HTTP methods are supported in requests accepted by this
    server, and passed to user callbacks
-  </para>
+  </simpara>
   <para>
    If not supported they will generate a
    <literal>"405 Method not

--- a/reference/event/eventhttprequest/findheader.xml
+++ b/reference/event/eventhttprequest/findheader.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="eventhttprequest.findheader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventHttpRequest::findHeader</refname>
-  <refpurpose>Finds the value belonging a header</refpurpose>
+  <refpurpose>Finds the value belonging to a header</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -20,9 +20,9 @@
     <parameter>type</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
-   Finds the value belonging a header.
-  </para>
+  <simpara>
+   Finds the value belonging to a header.
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/fann/functions/fann-train-epoch.xml
+++ b/reference/fann/functions/fann-train-epoch.xml
@@ -18,11 +18,11 @@
    Train one epoch with the training data stored in data. One epoch is
    where all of the training data is considered exactly once.
   </para>
-  <para>
+  <simpara>
    This function returns the MSE error as it is calculated either before or during the actual training.
-   This is not the actual MSE after the training epoch, but since calculating this will require to go
-   through the entire training set once more. It is more than adequate to use this value during training.
-  </para>
+   This is not the actual MSE after the training epoch, but since calculating this would require going
+   through the entire training set once more, it is more than adequate to use this value during training.
+  </simpara>
   <para>
    The training algorithm used by this function is chosen by <function>fann_set_training_algorithm</function>
    function.

--- a/reference/fdf/functions/fdf-errno.xml
+++ b/reference/fdf/functions/fdf-errno.xml
@@ -16,7 +16,7 @@
    Gets the error code set by the last FDF function call.
   </simpara>
   <simpara>
-   A textual description of the error may be obtained using with
+   A textual description of the error may be obtained using
    <function>fdf_error</function>.
   </simpara>
  </refsect1>

--- a/reference/fdf/functions/fdf-set-ap.xml
+++ b/reference/fdf/functions/fdf-set-ap.xml
@@ -45,7 +45,7 @@
     <term><parameter>face</parameter></term>
     <listitem>
      <simpara>
-      The possible values <constant>FDFNormalAP</constant>,
+      The possible values are <constant>FDFNormalAP</constant>,
       <constant>FDFRolloverAP</constant> and
       <constant>FDFDownAP</constant>.
      </simpara>

--- a/reference/gmp/functions/gmp-random-bits.xml
+++ b/reference/gmp/functions/gmp-random-bits.xml
@@ -17,10 +17,10 @@
    <literal>0</literal> and
    <literal>2<superscript>$bits</superscript> - 1</literal>.
   </para>
-  <para>
-   <parameter>bits</parameter> must greater than 0,
+  <simpara>
+   <parameter>bits</parameter> must be greater than 0,
    and the maximum value is restricted by available memory.
-  </para>
+  </simpara>
   &caution.cryptographically-insecure;
  </refsect1>
 

--- a/reference/intl/intlcalendar/getavailablelocales.xml
+++ b/reference/intl/intlcalendar/getavailablelocales.xml
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   An <type>array</type> of <type>string</type>s, one for which locale. 
-  </para>
+  <simpara>
+   An <type>array</type> of <type>string</type>s, one for each locale.
+  </simpara>
  </refsect1>
 
 

--- a/reference/mongodb/mongodb/driver/session.xml
+++ b/reference/mongodb/mongodb/driver/session.xml
@@ -15,7 +15,7 @@
     The <classname>MongoDB\Driver\Session</classname> class represents a
     client session and is returned by
     <methodname>MongoDB\Driver\Manager::startSession</methodname>. Commands,
-    queries, and write operations may then be associated the session.
+    queries, and write operations may then be associated with the session.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/pdo/pdo/connect.xml
+++ b/reference/pdo/pdo/connect.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Creates an instance of a <classname>PDO</classname> subclass for the
-   database being connection if it exists,
+   database being connected to, if it exists,
    otherwise return a generic <classname>PDO</classname> instance.
   </simpara>
  </refsect1>

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -84,7 +84,7 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       The default value of is now <constant>SOMAXCONN</constant>.
+       The default value of <parameter>backlog</parameter> is now <constant>SOMAXCONN</constant>.
        Previously it was <literal>128</literal>.
       </entry>
      </row>

--- a/reference/spl/arrayiterator/next.xml
+++ b/reference/spl/arrayiterator/next.xml
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>void</type><methodname>ArrayIterator::next</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   The iterator to the next entry.
-  </para>
+  <simpara>
+   Moves the iterator to the next entry.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/svn/functions/svn-fs-apply-text.xml
+++ b/reference/svn/functions/svn-fs-apply-text.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.svn-fs-apply-text">
  <refnamediv>
   <refname>svn_fs_apply_text</refname>
-  <refpurpose>Creates and returns a stream that will be used to replace</refpurpose>
+  <refpurpose>Creates and returns a stream that will be used to replace the contents of a file</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <simpara>
-   Creates and returns a stream that will be used to replace
+   Creates and returns a stream that will be used to replace the contents of a file.
   </simpara>
  </refsect1>
 <!--

--- a/reference/swoole/swoole/table/next.xml
+++ b/reference/swoole/swoole/table/next.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="swoole-table.next" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Table::next</refname>
-  <refpurpose>Iterator the next row</refpurpose>
+  <refpurpose>Advance the iterator to the next row</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/xml/functions/xml-parser-set-option.xml
+++ b/reference/xml/functions/xml-parser-set-option.xml
@@ -126,12 +126,11 @@
    Throws a <classname>ValueError</classname> when an invalid value is passed
    to <parameter>option</parameter>.
   </para>
-  <para>
-   Prior to PHP 8.0.0, the function returned false when passing an invalid
-   value to
-   <parameter>option</parameter> generated a <constant>E_WARNING</constant>
-   as well as making the function return &false;.
-  </para>
+  <simpara>
+   Prior to PHP 8.0.0, passing an invalid value to
+   <parameter>option</parameter> generated an <constant>E_WARNING</constant>
+   and made the function return &false;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -64,7 +64,7 @@
 <?php
 function callback($retval, $callinfo) {
      if ($callinfo == NULL) {
-        echo "Now, all requests are sent, and no any response available\n";
+        echo "Now, all requests are sent, and no response available\n";
      } else {
         echo "This is a remote call response, the method name is", $callinfo["method"], 
              ". calling sequence is " , $callinfo["sequence"] , "\n";
@@ -92,7 +92,7 @@ Yar_Concurrent_Client::loop("callback", "error_callback"); //send the requests,
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Now, all requests are sent, and no any response available
+Now, all requests are sent, and no response available
 This is a remote call response, the method name issome_method. calling sequence is 4
 string(11) "some_method"
 This is a remote call response, the method name issome_method. calling sequence is 1

--- a/reference/yaz/functions/yaz-es.xml
+++ b/reference/yaz/functions/yaz-es.xml
@@ -21,11 +21,11 @@
     <type>array</type><parameter>args</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    This function prepares for an Extended Service Request.
-   Extended Services is family of various Z39.50 facilities, such
+   Extended Services is a family of various Z39.50 facilities, such
    as Record Update, Item Order, Database administration etc.
-  </para>
+  </simpara>
   <note>
    <para>
     Many Z39.50 Servers do not support Extended Services.

--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="zookeeper.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Zookeeper::connect</refname>
-  <refpurpose>Create a handle to used communicate with zookeeper</refpurpose>
+  <refpurpose>Create a handle used to communicate with zookeeper</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">


### PR DESCRIPTION
Fixes a batch of incomplete or broken sentences (missing words or verbs, fragments) spotted while comparing the English and French manuals.

Each change is a minimal grammar fix that preserves the original meaning. The inline-only paragraphs touched by these fixes are switched from para to simpara. A few sibling files carrying the identical broken sentence are included for consistency (`array_all`/`array_find`/`array_find_key`, `Ds\Deque::allocate`).