### PR TITLE
Fix the broken cubrid_prepare description

### DIFF
--- a/reference/cubrid/functions/cubrid-prepare.xml
+++ b/reference/cubrid/functions/cubrid-prepare.xml
@@ -15,16 +15,17 @@
    <methodparam choice="opt"><type>int</type><parameter>option</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-      The <function>cubrid_prepare</function> function is a sort of API which represents SQL statements
-      compiled previously to a given connection handle. This pre-compiled SQL statement will be included
-      in the <function>cubrid_prepare</function>.
+      The <function>cubrid_prepare</function> function compiles a SQL statement for a given
+      connection handle and returns a handle that represents the pre-compiled statement.
   </simpara>
   <simpara>
-      Accordingly, you can use this statement effectively to execute several times repeatedly or to
-      process long data. Only a single statement can be used and a parameter may put a question mark (?)
-      to appropriate area in the SQL statement. Add a parameter when you bind a value in the VALUES
-      clause of INSERT statement or in the WHERE clause. Note that it is allowed to bind a value to a
-      MARK(?) by using the <function>cubrid_bind</function> function only.
+      A prepared statement can be executed several times, which is efficient for repeated
+      execution or for processing long data. Only a single statement can be used, and a
+      parameter can be marked with a question mark (<literal>?</literal>) at the appropriate
+      place in the SQL statement. Add a parameter when binding a value in the
+      <literal>VALUES</literal> clause of an <literal>INSERT</literal> statement or in the
+      <literal>WHERE</literal> clause. Note that a value can be bound to a parameter only by
+      using the <function>cubrid_bind</function> function.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Rewrites the cubrid_prepare description, which was broken and unclear (for example "This pre-compiled SQL statement will be included in the cubrid_prepare.").

Split out of #5583 as requested in review. Keeps the original meaning, removes the ambiguous wording, and marks the SQL keywords and the `?` placeholder with `literal`.