### PR TITLE
unserialization: Documented allowed-classes option with enums

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -816,10 +816,11 @@ print serialize(Suit::Hearts);
    On deserialization, if an enum and case cannot be found to match a serialized
    value a warning will be issued and &false; returned.</para>
 
-  <para>
+  <simpara>
    The <literal>allowed_classes</literal> option of
-   <function>unserialize</function> does not affect enums.
-  </para>
+   <function>unserialize</function> does not affect 
+   <link linkend="language.enumerations">Enumerations</link>.
+  </simpara>
 
   <para>
    If a Pure Enum is serialized to JSON, an error will be thrown. If a Backed Enum

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -817,6 +817,11 @@ print serialize(Suit::Hearts);
    value a warning will be issued and &false; returned.</para>
 
   <para>
+   The <literal>allowed_classes</literal> option of
+   <function>unserialize</function> does not affect enums.
+  </para>
+
+  <para>
    If a Pure Enum is serialized to JSON, an error will be thrown. If a Backed Enum
    is serialized to JSON, it will be represented by its scalar value only, in the
    appropriate type. The behavior of both may be overridden by implementing

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -818,7 +818,7 @@ print serialize(Suit::Hearts);
 
   <simpara>
    The <literal>allowed_classes</literal> option of
-   <function>unserialize</function> does not affect 
+   <function>unserialize</function> does not affect
    <link linkend="language.enumerations">Enumerations</link>.
   </simpara>
 

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -103,6 +103,9 @@
             Omitting this option is the same as defining it as &true;: PHP
             will attempt to instantiate objects of any class.
            </simpara>
+           <simpara>
+            This option does not affect enums.
+           </simpara>
           </entry>
          </row>
          <row>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -104,7 +104,7 @@
             will attempt to instantiate objects of any class.
            </simpara>
            <simpara>
-            This option does not affect enums.
+            This option does not affect <link linkend="language.enumerations">Enumerations</link>.
            </simpara>
           </entry>
          </row>


### PR DESCRIPTION
Following the discussion in https://github.com/php/php-src/issues/22059 

As enums are technically [classes](https://www.php.net/manual/en/language.types.enumerations.php), and the allowed-classes option set to "false" does not affect them this piece of clarification should help document the expected (and current) behavior.