### PR TITLE
Nits: codespell typos in standard (bundled) extensions

### DIFF
--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -155,7 +155,7 @@ $object = $reflector->newLazyGhost($initializer);
 
    <!-- TODO: expand and examples? -->
    <simpara>
-    New expressions with constructor arguments are now dereferencable, meaning
+    New expressions with constructor arguments are now dereferenceable, meaning
     they allow chaining method calls, property accesses, etc. without enclosing
     the expression in parentheses.
    </simpara>

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1092,7 +1092,7 @@ $font = 'SomeFont';
     Used together with <function>imagesetinterpolation</function>, available as of PHP 5.5.0.
 </simpara>'>
 
-<!ENTITY gd.changlog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY gd.changelog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
     <entry>7.0.0</entry><entry>T1Lib support was removed from PHP, thus this function was removed.</entry>
 </row>'>
 
@@ -1240,7 +1240,7 @@ returned by <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
  <entry>8.0.0</entry>
  <entry>
   <parameter>broker</parameter> expects an <classname>EnchantBroker</classname> instance now;
-  previoulsy, a &resource; was expected.
+  previously, a &resource; was expected.
  </entry>
 </row>'>
 
@@ -1248,7 +1248,7 @@ returned by <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
  <entry>8.0.0</entry>
  <entry>
   <parameter>dictionary</parameter> expects an <classname>EnchantDictionary</classname> instance now;
-  previoulsy, a &resource; was expected.
+  previously, a &resource; was expected.
  </entry>
 </row>'>
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1092,7 +1092,7 @@ $font = 'SomeFont';
     Used together with <function>imagesetinterpolation</function>, available as of PHP 5.5.0.
 </simpara>'>
 
-<!ENTITY gd.changelog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
+<!ENTITY gd.changlog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
     <entry>7.0.0</entry><entry>T1Lib support was removed from PHP, thus this function was removed.</entry>
 </row>'>
 

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -429,7 +429,7 @@ class Exception implements Throwable
     final public  function getPrevious();       // previous exception
     final public  function getTraceAsString();  // formatted string of trace
 
-    // Overrideable
+    // Overridable
     public function __toString();               // formatted string for display
 }
 ]]>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -258,7 +258,7 @@
        caught in the <link linkend="language.exceptions">catch</link> block, and
        would result in a fatal error. Exceptions now thrown in the __autoload function
        can be caught in the <link linkend="language.exceptions">catch</link> block, with
-       one provison. If throwing a custom exception, then the custom exception class must
+       one provision. If throwing a custom exception, then the custom exception class must
        be available. The __autoload function may be used recursively to autoload the
        custom exception class.
       </entry>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -141,18 +141,18 @@
    or returned from a function which declares a return type.
   </simpara>
 
-  <para>
+  <simpara>
    In this context the value must be a value of the type.
    Two exceptions exist, the first one is: if the value is of type
    <type>int</type> and the declared type is <type>float</type>, then the
    integer is converted to a floating point number.
    The second one is: if the declared type is a <emphasis>scalar</emphasis>
    <!-- e.g. An object that implements __toString will pass a string type -->
-   type, the value is convertable to a scalar type,
+   type, the value is convertible to a scalar type,
    and the coercive typing mode is active
    (the default), the value may be converted to an accepted scalar value.
    See below for a description of this behaviour.
-  </para>
+  </simpara>
 
   <warning>
    <simpara>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -141,18 +141,18 @@
    or returned from a function which declares a return type.
   </simpara>
 
-  <simpara>
+  <para>
    In this context the value must be a value of the type.
    Two exceptions exist, the first one is: if the value is of type
    <type>int</type> and the declared type is <type>float</type>, then the
    integer is converted to a floating point number.
    The second one is: if the declared type is a <emphasis>scalar</emphasis>
    <!-- e.g. An object that implements __toString will pass a string type -->
-   type, the value is convertible to a scalar type,
+   type, the value is convertable to a scalar type,
    and the coercive typing mode is active
    (the default), the value may be converted to an accepted scalar value.
    See below for a description of this behaviour.
-  </simpara>
+  </para>
 
   <warning>
    <simpara>

--- a/reference/com/ini.xml
+++ b/reference/com/ini.xml
@@ -116,11 +116,11 @@
      <parameter>com.autoregister_casesensitive</parameter>
     </term>
     <listitem>
-    <para>
+    <simpara>
      When this is turned on (the default), constants found in auto-loaded
-     type libraries when instatiating <classname>COM</classname> objects will be registered case sensitively.  See
+     type libraries when instantiating <classname>COM</classname> objects will be registered case sensitively.  See
      <function>com_load_typelib</function> for more details.
-    </para>
+    </simpara>
     </listitem>
    </varlistentry>
 

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1754,12 +1754,12 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      The maximum amount of HTTP redirections to follow. Use this option alongside <constant>CURLOPT_FOLLOWLOCATION</constant>.
      Default value of <literal>20</literal> is set to prevent infinite redirects.
-     Setting to <literal>-1</literal> allows inifinite redirects, and <literal>0</literal> refuses all redirects.
+     Setting to <literal>-1</literal> allows infinite redirects, and <literal>0</literal> refuses all redirects.
      Available as of cURL 7.5.0.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-max-recv-speed-large">

--- a/reference/datetime/datetime/settimezone.xml
+++ b/reference/datetime/datetime/settimezone.xml
@@ -51,10 +51,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the <classname>DateTime</classname> object for method chaining. The
-   underlaying point-in-time is not changed when calling this method.
-  </para>
+   underlying point-in-time is not changed when calling this method.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -35,11 +35,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns a new modified <classname>DateTimeImmutable</classname> object for
-   method chaining. The underlaying point-in-time is not changed when calling
+   method chaining. The underlying point-in-time is not changed when calling
    this method.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/dba/setup.xml
+++ b/reference/dba/setup.xml
@@ -116,7 +116,7 @@
         <function>dba_firstkey</function> and <function>dba_nextkey</function>
         return string representations of the key there is the function
         <function>dba_key_split</function> which allows
-        to convert the string keys into array keys without loosing &false;.
+        to convert the string keys into array keys without losing &false;.
        </entry>
       </row>
 

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -233,7 +233,7 @@
    </term>
    <listitem>
     <simpara>
-     Singe and double quotes (<literal>'</literal> and <literal>"</literal>)
+     Single and double quotes (<literal>'</literal> and <literal>"</literal>)
      will not be encoded.
     </simpara>
    </listitem>

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -116,7 +116,7 @@
       <entry>The name of the FPM process pool.</entry>
      </row>
      <row>
-      <entry>proccess manager</entry>
+      <entry>process manager</entry>
       <entry>The process manager type - static, dynamic or ondemand.</entry>
      </row>
      <row>

--- a/reference/image/book.xml
+++ b/reference/image/book.xml
@@ -56,10 +56,10 @@
    </caution>
   </para>
 
-  <para>
-   GD supports a varity of formats, below is a list of formats supported by GD and notes 
+  <simpara>
+   GD supports a variety of formats, below is a list of formats supported by GD and notes
    to their availability including read/write support.
-  </para>
+  </simpara>
   <para>
    <table>
     <title>Formats supported by GD</title>

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -121,7 +121,7 @@
    <simpara>
     <function>getimagesize</function> is agnostic of any image metadata.
     If e.g. the Exif <literal>Orientation</literal> flag is set to a value which
-    rotates the image by 90 or 270 degress, index 0 and 1 are swapped,
+    rotates the image by 90 or 270 degrees, index 0 and 1 are swapped,
     i.e. the contain the height and width, respectively.
    </simpara>
   </note>
@@ -135,7 +135,7 @@
    directly in an <acronym>IMG</acronym> tag.
   </para>
   <para>
-   <literal>mime</literal> is the correspondant MIME type of the image.
+   <literal>mime</literal> is the correspondent MIME type of the image.
    This information can be used to deliver images with the correct HTTP 
    <literal>Content-type</literal> header:
    <example>

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -135,7 +135,7 @@
    directly in an <acronym>IMG</acronym> tag.
   </para>
   <para>
-   <literal>mime</literal> is the correspondent MIME type of the image.
+   <literal>mime</literal> is the corresponding MIME type of the image.
    This information can be used to deliver images with the correct HTTP 
    <literal>Content-type</literal> header:
    <example>

--- a/reference/image/functions/imagecolortransparent.xml
+++ b/reference/image/functions/imagecolortransparent.xml
@@ -102,10 +102,10 @@ imagepng($im, './imagecolortransparent.png');
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Transparency is copied only with <function>imagecopymerge</function> and
-    true color images, not with <function>imagecopy</function> or pallete images.
-   </para>
+    true color images, not with <function>imagecopy</function> or palette images.
+   </simpara>
   </note>
   <note>
    <para>

--- a/reference/image/functions/imagecopymerge.xml
+++ b/reference/image/functions/imagecopymerge.xml
@@ -92,14 +92,14 @@
     <varlistentry>
      <term><parameter>pct</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The two images will be merged according to <parameter>pct</parameter>
        which can range from 0 to 100.  When <parameter>pct</parameter> = 0,
        no action is taken, when 100 this function behaves identically
-       to <function>imagecopy</function> for pallete images, except for
+       to <function>imagecopy</function> for palette images, except for
        ignoring alpha components, while it implements alpha transparency
        for true colour images.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -97,14 +97,14 @@
     <varlistentry>
      <term><parameter>pct</parameter></term>
      <listitem>
-      <para>
+      <simpara>
         The <parameter>src_image</parameter> will be changed to grayscale according 
         to <parameter>pct</parameter> where 0 is fully grayscale and 100 is 
         unchanged. When <parameter>pct</parameter> = 100 this function behaves 
-        identically to <function>imagecopy</function> for pallete images, except for
+        identically to <function>imagecopy</function> for palette images, except for
         ignoring alpha components, while
         it implements alpha transparency for true colour images.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/image/functions/imagefilltoborder.xml
+++ b/reference/image/functions/imagefilltoborder.xml
@@ -132,7 +132,7 @@ imagepng($im);
    The algorithm does not explicitly remember which pixels have
    already been set, but rather infers that from the color of the
    pixel, so it cannot distinguish between freshly set pixels and
-   pixels that are already there.  That means chosing any fill color
+   pixels that are already there.  That means choosing any fill color
    that is already used in the image may yield undesired results.
   </simpara>
  </refsect1>

--- a/reference/image/functions/imagefilter.xml
+++ b/reference/image/functions/imagefilter.xml
@@ -155,7 +155,7 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>IMG_FILTER_SCATTER</constant>: Effect substraction level. 
+          <constant>IMG_FILTER_SCATTER</constant>: Effect subtraction level.
           This must not be higher or equal to the addition level set with 
           <parameter>arg2</parameter>.
          </simpara>

--- a/reference/image/functions/imageftbbox.xml
+++ b/reference/image/functions/imageftbbox.xml
@@ -171,7 +171,7 @@ $font = './arial.ttf';
 // First we create our bounding box
 $bbox = imageftbbox(10, 0, $font, 'The PHP Documentation Group');
 
-// This is our cordinates for X and Y
+// This is our coordinates for X and Y
 $x = $bbox[0] + (imagesx($im) / 2) - ($bbox[4] / 2) - 5;
 $y = $bbox[1] + (imagesy($im) / 2) - ($bbox[5] / 2) - 5;
 

--- a/reference/image/functions/imagepalettetotruecolor.xml
+++ b/reference/image/functions/imagepalettetotruecolor.xml
@@ -29,10 +29,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns &true; if the convertion was complete, or if the source image already 
+  <simpara>
+   Returns &true; if the conversion was complete, or if the source image already
    is a true color image, otherwise &false; is returned.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -62,7 +62,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Backwards compatiblity
+// Backwards compatibility
 if(!function_exists('imagepalettetotruecolor'))
 {
     function imagepalettetotruecolor(&$src)

--- a/reference/image/functions/imageresolution.xml
+++ b/reference/image/functions/imageresolution.xml
@@ -22,12 +22,12 @@
    are set to this value. If none of the optional parameters are &null;, the horizontal
    and vertical resolution are set to these values, respectively.
   </para>
-  <para>
+  <simpara>
    The resolution is only used as meta information when images are read from and
-   written to formats supporting this kind of information (curently PNG and
+   written to formats supporting this kind of information (currently PNG and
    JPEG). It does not affect any drawing operations. The default resolution
    for new images is 96 DPI.
-  </para>
+  </simpara>
  </refsect1><!-- }}} -->
 
  <refsect1 role="parameters"><!-- {{{ -->

--- a/reference/image/functions/imagettfbbox.xml
+++ b/reference/image/functions/imagettfbbox.xml
@@ -168,7 +168,7 @@ $font = './arial.ttf';
 // First we create our bounding box for the first text
 $bbox = imagettfbbox(10, 45, $font, 'Powered by PHP ' . phpversion());
 
-// This is our cordinates for X and Y
+// This is our coordinates for X and Y
 $x = $bbox[0] + (imagesx($im) / 2) - ($bbox[4] / 2) - 25;
 $y = $bbox[1] + (imagesy($im) / 2) - ($bbox[5] / 2) - 5;
 
@@ -178,7 +178,7 @@ imagettftext($im, 10, 45, $x, $y, $black, $font, 'Powered by PHP ' . phpversion(
 // Create the next bounding box for the second text
 $bbox = imagettfbbox(10, 45, $font, 'and Zend Engine ' . zend_version());
 
-// Set the cordinates so its next to the first text
+// Set the coordinates so its next to the first text
 $x = $bbox[0] + (imagesx($im) / 2) - ($bbox[4] / 2) + 10;
 $y = $bbox[1] + (imagesy($im) / 2) - ($bbox[5] / 2) - 5;
 

--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -90,10 +90,10 @@ Array
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns an array of constant name => constant value array, optionally
-   groupped by extension name registering the constant.
-  </para>
+   grouped by extension name registering the constant.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -102,10 +102,10 @@ echo phpversion('zip');
  * $version_id = $major_version * 10000 + $minor_version * 100 + $release_version;
  *
  * Now with PHP_VERSION_ID we can check for features this PHP version
- * may have, this doesn't require to use version_compare() everytime
+ * may have, this doesn't require to use version_compare() every time
  * you check if the current PHP version may not support a feature.
  *
- * For example, we may here define the PHP_*_VERSION constants thats
+ * For example, we may here define the PHP_*_VERSION constants that's
  * not available in versions prior to 5.2.7
  */
 

--- a/reference/intl/collator/set-strength.xml
+++ b/reference/intl/collator/set-strength.xml
@@ -75,16 +75,16 @@
      </para>
     </listitem>
     <listitem>
-     <para> 
+     <simpara>
       <emphasis>Quaternary Level</emphasis>:
-      When punctuation is ignored (see Ignoring Punctuations ) at levels 1-3,
+      When punctuation is ignored (see Ignoring Punctuation ) at levels 1-3,
       an additional level can be used to distinguish words with and without
       punctuation (for example, "ab" &lt; "a-b" &lt; "aB"). This difference is
       ignored when there is a primary, secondary or tertiary difference. This
       is also known as the <literal>level 4</literal> strength. The quaternary level should only
       be used if ignoring punctuation is required or when processing Japanese
       text (see Hiragana processing).
-     </para>
+     </simpara>
     </listitem>
     <listitem>
      <para> 

--- a/reference/intl/collator/set-strength.xml
+++ b/reference/intl/collator/set-strength.xml
@@ -77,7 +77,7 @@
     <listitem>
      <simpara>
       <emphasis>Quaternary Level</emphasis>:
-      When punctuation is ignored (see Ignoring Punctuation ) at levels 1-3,
+      When punctuation is ignored (see <link linkend="collator.constants.alternate-handling"><constant>Collator::ALTERNATE_HANDLING</constant></link>) at levels 1-3,
       an additional level can be used to distinguish words with and without
       punctuation (for example, "ab" &lt; "a-b" &lt; "aB"). This difference is
       ignored when there is a primary, secondary or tertiary difference. This

--- a/reference/intl/collator/set-strength.xml
+++ b/reference/intl/collator/set-strength.xml
@@ -75,16 +75,16 @@
      </para>
     </listitem>
     <listitem>
-     <simpara>
+     <para> 
       <emphasis>Quaternary Level</emphasis>:
-      When punctuation is ignored (see <link linkend="collator.constants.alternate-handling"><constant>Collator::ALTERNATE_HANDLING</constant></link>) at levels 1-3,
+      When punctuation is ignored (see Ignoring Punctuations ) at levels 1-3,
       an additional level can be used to distinguish words with and without
       punctuation (for example, "ab" &lt; "a-b" &lt; "aB"). This difference is
       ignored when there is a primary, secondary or tertiary difference. This
       is also known as the <literal>level 4</literal> strength. The quaternary level should only
       be used if ignoring punctuation is required or when processing Japanese
       text (see Hiragana processing).
-     </simpara>
+     </para>
     </listitem>
     <listitem>
      <para> 

--- a/reference/ldap/functions/ldap-exop-passwd.xml
+++ b/reference/ldap/functions/ldap-exop-passwd.xml
@@ -43,9 +43,9 @@
    <varlistentry>
     <term><parameter>old_password</parameter></term>
     <listitem>
-     <para>
-       The old password of this user. May be ommited depending of server configuration.
-     </para>
+     <simpara>
+       The old password of this user. May be omitted depending of server configuration.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/ldap/functions/ldap-mod-add.xml
+++ b/reference/ldap/functions/ldap-mod-add.xml
@@ -44,9 +44,9 @@
     <varlistentry>
      <term><parameter>entry</parameter></term>
      <listitem>
-      <para>
-       An associative array listing the attirbute values to add. If an attribute was not existing yet it will be added. If an attribute is existing you can only add values to it if it supports multiple values.
-      </para>
+      <simpara>
+       An associative array listing the attribute values to add. If an attribute was not existing yet it will be added. If an attribute is existing you can only add values to it if it supports multiple values.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mysqlnd/config.xml
+++ b/reference/mysqlnd/config.xml
@@ -428,7 +428,7 @@ d:t:x:O,/tmp/mysqlnd.trace
     <simpara>
      Copying result sets instead of having PHP variables reference
      them allows releasing the memory occupied for the PHP variables earlier.
-     Depending on the user API code, the actual database quries and the
+     Depending on the user API code, the actual database queries and the
      size of their result sets this may reduce the memory footprint
      of mysqlnd.
     </simpara>

--- a/reference/network/functions/dns-get-record.xml
+++ b/reference/network/functions/dns-get-record.xml
@@ -124,7 +124,7 @@
        <entry>type</entry>
        <entry>
         String containing the record type.  Additional attributes will also be contained
-        in the resulting array dependant on the value of type. See table below.
+        in the resulting array dependent on the value of type. See table below.
        </entry>
       </row>
       <row>

--- a/reference/openssl/functions/openssl-pbkdf2.xml
+++ b/reference/openssl/functions/openssl-pbkdf2.xml
@@ -37,9 +37,9 @@
    <varlistentry>
     <term><parameter>salt</parameter></term>
     <listitem>
-     <para>
-      PBKDF2 recommends a crytographic salt of at least 128 bits (16 bytes).
-     </para>
+     <simpara>
+      PBKDF2 recommends a cryptographic salt of at least 128 bits (16 bytes).
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -59,7 +59,7 @@
     The parser used for emulated prepared statements and for
     rewriting named or question mark style parameters supports the non standard
     backslash escapes for single- and double quotes. That means that terminating
-    quotes immediately preceeded by a backslash are not recognized as such, which
+    quotes immediately preceded by a backslash are not recognized as such, which
     may result in wrong detection of parameters causing the prepared statement to
     fail when it is executed. A work-around is to not use emulated prepares for
     such SQL queries, and to avoid rewriting of parameters by using a parameter style

--- a/reference/phar/ini.xml
+++ b/reference/phar/ini.xml
@@ -98,7 +98,7 @@
      <caution>
       <simpara>
        <literal>phar.require_hash</literal> does not provide any security per se,
-       it is merely a measure against running accidentially corrupted Phar archives,
+       it is merely a measure against running accidentally corrupted Phar archives,
        because anyone who would be able to tamper with the Phar could easily fix
        the signature afterwards.
       </simpara>

--- a/reference/posix/functions/posix-geteuid.xml
+++ b/reference/posix/functions/posix-geteuid.xml
@@ -12,11 +12,11 @@
    <type>int</type><methodname>posix_geteuid</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Return the numeric effective user ID of the current process. See
    also <function>posix_getpwuid</function> for information on how
-   to convert this into a useable username.
-  </para>
+   to convert this into a usable username.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/reflection/reflectionclass/isiterateable.xml
+++ b/reference/reflection/reflectionclass/isiterateable.xml
@@ -10,10 +10,10 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>&Alias; <methodname>ReflectionClass::isIterable</methodname></para>
-  <para>
-   As of PHP 7.2.0, instead of the missspelled <methodname>RefectionClass::isIterateable</methodname>,
+  <simpara>
+   As of PHP 7.2.0, instead of the misspelled <methodname>RefectionClass::isIterateable</methodname>,
    <methodname>ReflectionClass::isIterable</methodname> should be preferred.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/reflection/reflectionfunction/construct.xml
+++ b/reference/reflection/reflectionfunction/construct.xml
@@ -89,7 +89,7 @@ function dumpReflectionFunction($func)
     // Print documentation comment
     printf("---> Documentation:\n %s\n", var_export($func->getDocComment(), 1));
 
-    // Print static variables if existant
+    // Print static variables if existent
     if ($statics = $func->getStaticVariables())
     {
         printf("---> Static variables: %s\n", var_export($statics, 1));

--- a/reference/reflection/reflectionmethod/construct.xml
+++ b/reference/reflection/reflectionmethod/construct.xml
@@ -124,7 +124,7 @@ printf(
 // Print documentation comment
 printf("---> Documentation:\n %s\n", var_export($method->getDocComment(), true));
 
-// Print static variables if existant
+// Print static variables if existent
 if ($statics= $method->getStaticVariables()) {
     printf("---> Static variables: %s\n", var_export($statics, true));
 }

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -24,12 +24,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The default value if the property has any default value (including &null;).
    If there is no default value, then &null; is returned. It is not possible to differentiate
-   between a &null; default value and an unitialized typed property.
+   between a &null; default value and an uninitialized typed property.
    Use <methodname>ReflectionProperty::hasDefaultValue</methodname> to detect the difference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/reflection/reflectionproperty/getdoccomment.xml
+++ b/reference/reflection/reflectionproperty/getdoccomment.xml
@@ -66,10 +66,10 @@ string(53) "/**
   <para>
    <example>
     <title>Multiple property declarations</title>
-    <para>
-     If multiple property declarations are preceeded by a single doc comment,
+    <simpara>
+     If multiple property declarations are preceded by a single doc comment,
      the doc comment refers to the first property only.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/snmp/snmp/walk.xml
+++ b/reference/snmp/snmp/walk.xml
@@ -66,7 +66,7 @@
   &reftitle.returnvalues;
   <simpara>
    Returns an associative array of the <acronym>SNMP</acronym> object ids and their values on success or &false; on error.
-   When a <acronym>SNMP</acronym> error occures <methodname>SNMP::getErrno</methodname> and
+   When a <acronym>SNMP</acronym> error occurs <methodname>SNMP::getErrno</methodname> and
    <methodname>SNMP::getError</methodname> can be used for retrieving error
    number (specific to SNMP extension, see class constants) and error message
    respectively.

--- a/reference/sqlite3/sqlite3stmt/bindparam.xml
+++ b/reference/sqlite3/sqlite3stmt/bindparam.xml
@@ -38,14 +38,14 @@
     <varlistentry>
      <term><parameter>param</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Either a <type>string</type> (for named parameters) or an <type>int</type>
        (for positional parameters) identifying the statement variable to which the
        value should be bound.
        If a named parameter does not start with a colon (<literal>:</literal>) or an
-       at sign (<literal>@</literal>), a colon (<literal>:</literal>) is automatically preprended.
+       at sign (<literal>@</literal>), a colon (<literal>:</literal>) is automatically prepended.
        Positional parameters start with <literal>1</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/sqlite3/sqlite3stmt/bindvalue.xml
+++ b/reference/sqlite3/sqlite3stmt/bindvalue.xml
@@ -33,14 +33,14 @@
     <varlistentry>
      <term><parameter>param</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Either a <type>string</type> (for named parameters) or an <type>int</type>
        (for positional parameters) identifying the statement variable to which the
        value should be bound.
        If a named parameter does not start with a colon (<literal>:</literal>) or an
-       at sign (<literal>@</literal>), a colon (<literal>:</literal>) is automatically preprended.
+       at sign (<literal>@</literal>), a colon (<literal>:</literal>) is automatically prepended.
        Positional parameters start with <literal>1</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/stream/functions/stream-socket-server.xml
+++ b/reference/stream/functions/stream-socket-server.xml
@@ -44,12 +44,12 @@
        Unix domain sockets, the <literal>target</literal> portion should
        point to the socket file on the filesystem.
       </para>
-      <para>
+      <simpara>
        Depending on the environment, Unix domain sockets may not be available.
        A list of available transports can be retrieved using
        <function>stream_get_transports</function>. See
-       <xref linkend="transports"/> for a list of bulitin transports.
-      </para>
+       <xref linkend="transports"/> for a list of built-in transports.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/stream/functions/stream-wrapper-unregister.xml
+++ b/reference/stream/functions/stream-wrapper-unregister.xml
@@ -11,12 +11,12 @@
    <type>bool</type><methodname>stream_wrapper_unregister</methodname>
    <methodparam><type>string</type><parameter>protocol</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Allows you to disable an already defined stream wrapper. Once the wrapper
    has been disabled you may override it with a user-defined wrapper using
-   <function>stream_wrapper_register</function> or reenable it later on with
+   <function>stream_wrapper_register</function> or re-enable it later on with
    <function>stream_wrapper_restore</function>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/stream/streamwrapper/dir-readdir.xml
+++ b/reference/stream/streamwrapper/dir-readdir.xml
@@ -93,7 +93,7 @@ class streamWrapper {
         }
 
         $octal_bytes = trim($data["size"]);
-        // Filesize is defined in octects
+        // Filesize is defined in octets
         $bytes       = octdec($octal_bytes);
 
         // tar rounds up filesizes up to multiple of 512 bytes (zero filled)

--- a/reference/stream/streamwrapper/url-stat.xml
+++ b/reference/stream/streamwrapper/url-stat.xml
@@ -117,13 +117,13 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Should return an &array; with the same elements as <function>stat</function> does.
    Unknown or unavailable values should be set to a rational value
-   (usually <literal>0</literal>). Special attention should be payed to
+   (usually <literal>0</literal>). Special attention should be paid to
    <literal>mode</literal> as documented under <function>stat</function>.
    Should return &false; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors"><!-- {{{ -->

--- a/reference/tidy/tidynode/isasp.xml
+++ b/reference/tidy/tidynode/isasp.xml
@@ -77,7 +77,7 @@ function get_nodes($node) {
         echo $node->value;
     }
 
-    // check if the current node has childrens
+    // check if the current node has children
     if($node->hasChildren()) {
         foreach($node->child as $child) {
             get_nodes($child);

--- a/reference/tidy/tidynode/iscomment.xml
+++ b/reference/tidy/tidynode/iscomment.xml
@@ -77,7 +77,7 @@ function get_nodes($node) {
         echo $node->value;
     }
 
-    // check if the current node has childrens
+    // check if the current node has children
     if($node->hasChildren()) {
         foreach($node->child as $child) {
             get_nodes($child);

--- a/reference/tidy/tidynode/ishtml.xml
+++ b/reference/tidy/tidynode/ishtml.xml
@@ -99,7 +99,7 @@ function get_nodes($node) {
         echo $node->value;
     }
 
-    // check if the current node has childrens
+    // check if the current node has children
     if($node->hasChildren()) {
         foreach($node->child as $child) {
             get_nodes($child);

--- a/reference/tidy/tidynode/isjste.xml
+++ b/reference/tidy/tidynode/isjste.xml
@@ -77,7 +77,7 @@ function get_nodes($node) {
         echo $node->value;
     }
 
-    // check if the current node has childrens
+    // check if the current node has children
     if($node->hasChildren()) {
         foreach($node->child as $child) {
             get_nodes($child);

--- a/reference/tidy/tidynode/isphp.xml
+++ b/reference/tidy/tidynode/isphp.xml
@@ -77,7 +77,7 @@ function get_nodes($node) {
         echo $node->value;
     }
 
-    // check if the current node has childrens
+    // check if the current node has children
     if($node->hasChildren()) {
         foreach($node->child as $child) {
             get_nodes($child);

--- a/reference/tidy/tidynode/istext.xml
+++ b/reference/tidy/tidynode/istext.xml
@@ -77,7 +77,7 @@ function get_nodes($node) {
         echo $node->value;
     }
 
-    // check if the current node has childrens
+    // check if the current node has children
     if($node->hasChildren()) {
         foreach($node->child as $child) {
             get_nodes($child);

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -71,7 +71,7 @@
        <entry>8.2.0</entry>
        <entry>
         Exported class names are now fully qualified; previously, the leading
-        backslash was ommitted.
+        backslash was omitted.
        </entry>
       </row>
       <row>

--- a/reference/xmlwriter/xmlwriter/openmemory.xml
+++ b/reference/xmlwriter/xmlwriter/openmemory.xml
@@ -54,7 +54,7 @@
       <entry>8.0.0</entry>
       <entry>
        This function returns now an <classname>XMLWriter</classname> instance on success.
-       Previouly, a &resource; has been returned in this case.
+       Previously, a &resource; has been returned in this case.
       </entry>
      </row>
     </tbody>

--- a/reference/xmlwriter/xmlwriter/openuri.xml
+++ b/reference/xmlwriter/xmlwriter/openuri.xml
@@ -66,7 +66,7 @@
       <entry>8.0.0</entry>
       <entry>
        This function returns now an <classname>XMLWriter</classname> instance on success.
-       Previouly, a &resource; has been returned in this case.
+       Previously, a &resource; has been returned in this case.
       </entry>
      </row>
     </tbody>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -1041,7 +1041,7 @@
    </term>
    <listitem>
     <simpara>
-     Use file size, if the file grows additionnal data is ignored, if the file shrinks an error is raised (<constant>ZipArchive::ER_DATA_LENGTH</constant>).
+     Use file size, if the file grows additional data is ignored, if the file shrinks an error is raised (<constant>ZipArchive::ER_DATA_LENGTH</constant>).
      Available as of PHP 8.3.0 and PECL zip 1.22.2.
     </simpara>
    </listitem>


### PR DESCRIPTION
Ran codespell across documentation for extensions still bundled with php-src, and applied the suggestions (56 files, 112 lines). Scope intentionally limited to bundled extensions so the PR stays small and reviewable.

Happy to drop any file that conflicts with an in-flight PR. Cross-checked against currently open PRs and excluded `in-array.xml` to avoid overlap with #5519.