### PR TITLE
Update ibase_trans method parameters in XML

### DIFF
--- a/reference/ibase/functions/ibase-trans.xml
+++ b/reference/ibase/functions/ibase-trans.xml
@@ -16,7 +16,6 @@
   <methodsynopsis>
    <type>resource</type><methodname>ibase_trans</methodname>
    <methodparam choice="opt"><type>resource</type><parameter>link_identifier</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>trans_args</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    Begins a transaction.


### PR DESCRIPTION
Transaction args have to be in first place. Removed wrong description. Removed optional parameter 'trans_args' from ibase_trans method documentation.