### PR TITLE
Fix non-runnable code examples (undefined variables, syntax errors)

### DIFF
--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -94,8 +94,8 @@ class A
 class B extends A
 {
     // Fatal error: Could not check compatibility between B::method():C and
-    // A::method(): A, because class С is not available
-    public function method(): С {}
+    // A::method(): A, because class C is not available
+    public function method(): C {}
 }
 
 class C extends B {}

--- a/reference/ev/evperiodic/construct.xml
+++ b/reference/ev/evperiodic/construct.xml
@@ -125,7 +125,7 @@
 // Tick each 10.5 seconds
 
 function reschedule_cb ($watcher, $now) {
- return $now + (10.5. - fmod($now, 10.5));
+ return $now + (10.5 - fmod($now, 10.5));
 }
 
 $w = new EvPeriodic(0., 0., "reschedule_cb", function ($w, $revents) {

--- a/reference/imagick/imagick/mergeimagelayers.xml
+++ b/reference/imagick/imagick/mergeimagelayers.xml
@@ -60,7 +60,7 @@
 <?php
 function mergeImageLayers($layerMethodType, $imagePath1, $imagePath2) {
 
-    $imagick = new \Imagick(realpath($imagePath));
+    $imagick = new \Imagick(realpath($imagePath1));
 
     $imagick2 = new \Imagick(realpath($imagePath2));
     $imagick->addImage($imagick2);

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/replaceone.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/replaceone.xml
@@ -121,7 +121,7 @@
 $manager = new MongoDB\Driver\Manager;
 
 $bulk = new MongoDB\Driver\BulkWriteCommand;
-$bulk->replaceOne('db.coll', ['x' => 1], ['x' => 1, 'y' = 2]);
+$bulk->replaceOne('db.coll', ['x' => 1], ['x' => 1, 'y' => 2]);
 
 $result = $manager->executeBulkWriteCommand($bulk);
 

--- a/reference/rar/rarentry/getunpackedsize.xml
+++ b/reference/rar/rarentry/getunpackedsize.xml
@@ -70,7 +70,7 @@ $rar_file = rar_open('example.rar') or die("Failed to open Rar archive");
 
 $entry = rar_entry_get($rar_file, 'Dir/file.txt') or die("Failed to find such entry");
 
-echo "Unpacked size of " . $entry->getName() . " = " . $entry->getPackedSize() . " bytes";
+echo "Unpacked size of " . $entry->getName() . " = " . $entry->getUnpackedSize() . " bytes";
 
 ?>
 ]]>

--- a/reference/solr/solrdismaxquery/setqueryalt.xml
+++ b/reference/solr/solrdismaxquery/setqueryalt.xml
@@ -51,7 +51,7 @@
 <![CDATA[
 <?php
 
-$dismaxQuery = new DisMaxQuery();
+$dismaxQuery = new SolrDisMaxQuery();
 $dismaxQuery->setQueryAlt('*:*');
 
 ?>

--- a/reference/spl/splfileinfo/getgroup.xml
+++ b/reference/spl/splfileinfo/getgroup.xml
@@ -45,7 +45,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo info->getFilename() . ' belongs to group id ' . $info->getGroup() . "\n";
+echo $info->getFilename() . ' belongs to group id ' . $info->getGroup() . "\n";
 print_r(posix_getgrgid($info->getGroup()));
 ?>
 ]]>

--- a/reference/spl/splfileinfo/getowner.xml
+++ b/reference/spl/splfileinfo/getowner.xml
@@ -45,7 +45,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo info->getFilename() . ' belongs to owner id ' . $info->getOwner() . "\n";
+echo $info->getFilename() . ' belongs to owner id ' . $info->getOwner() . "\n";
 print_r(posix_getpwuid($info->getOwner()));
 ?>
 ]]>

--- a/reference/spl/splfileinfo/getsize.xml
+++ b/reference/spl/splfileinfo/getsize.xml
@@ -45,7 +45,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo $fileinfo->getFilename() . " " . $fileinfo->getSize();
+echo $info->getFilename() . " " . $info->getSize();
 ?>
 ]]>
     </programlisting>

--- a/reference/uri/uri/rfc3986/uri/parse.xml
+++ b/reference/uri/uri/rfc3986/uri/parse.xml
@@ -61,7 +61,7 @@ $uri = \Uri\Rfc3986\Uri::parse("https://example.com");
 if ($uri !== null) {
     echo "Valid URI: " . $uri->toString();
 } else {
-    echo "Invalid URI"
+    echo "Invalid URI";
 }
 ?>
 ]]>

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -71,7 +71,7 @@ $url = \Uri\WhatWg\Url::parse("https://example.com");
 if ($url !== null) {
     echo "Valid URL: " . $url->toAsciiString();
 } else {
-    echo "Invalid URL"
+    echo "Invalid URL";
 }
 ?>
 ]]>

--- a/reference/xattr/functions/xattr-list.xml
+++ b/reference/xattr/functions/xattr-list.xml
@@ -81,7 +81,7 @@ foreach ($root_attributes as $attr_name) {
 }
 
 echo "\n User attributes: \n";
-foreach ($attributes as $attr_name) {
+foreach ($user_attributes as $attr_name) {
     printf("%s\n", $attr_name);
 }
 

--- a/reference/xlswriter/xlsx-kernel/auto-filter.xml
+++ b/reference/xlswriter/xlsx-kernel/auto-filter.xml
@@ -52,7 +52,7 @@ $config = [
 
 $fileObject  = new \Vtiful\Kernel\Excel($config);
 
-$file = $excel->fileName('test.xlsx')
+$file = $fileObject->fileName('test.xlsx')
         ->header(['name', 'age'])
         ->data($data)
         ->autoFilter('A1:B11')  // auto filter

--- a/reference/xlswriter/xlsx-kernel/const-memory.xml
+++ b/reference/xlswriter/xlsx-kernel/const-memory.xml
@@ -61,7 +61,7 @@ $config = [
 
 $fileObject = new \Vtiful\Kernel\Excel($config);
 
-$file = $instance->constMemory('tutorial.xlsx', 'sheet');
+$file = $fileObject->constMemory('tutorial.xlsx', 'sheet');
 ?>
 ]]>
    </programlisting>

--- a/reference/xlswriter/xlsx-kernel/file-name.xml
+++ b/reference/xlswriter/xlsx-kernel/file-name.xml
@@ -61,7 +61,7 @@ $config = [
 
 $fileObject = new \Vtiful\Kernel\Excel($config);
 
-$file = $instance->fileName('tutorial.xlsx', 'sheet');
+$file = $fileObject->fileName('tutorial.xlsx', 'sheet');
 ?>
 ]]>
    </programlisting>

--- a/reference/xlswriter/xlsx-kernel/insert-text.xml
+++ b/reference/xlswriter/xlsx-kernel/insert-text.xml
@@ -87,7 +87,7 @@ for ($index = 0; $index < 10; $index++) {
     $file->insertText($index+1, 1, 10000, '#,##0');
 }
 
-$textFile->output();
+$file->output();
 ]]>
    </programlisting>
   </example>

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -66,7 +66,7 @@
       <title>Make sure the item is stored</title>
       <programlisting role="php">
        <![CDATA[
-       while(!$yac->set("key", "vale));
+       while(!$yac->set("key", "value"));
        ]]>
       </programlisting> 
      </example>

--- a/reference/yaf/yaf_route_rewrite/assemble.xml
+++ b/reference/yaf/yaf_route_rewrite/assemble.xml
@@ -54,7 +54,7 @@
    <title><function>Yaf_Route_Rewrite::assemble</function>example</title>
    <programlisting role="php">
 <![CDATA[
-router = new Yaf_Router();
+$router = new Yaf_Router();
 
 $route  = new Yaf_Route_Rewrite(
                 "/product/:name/:id/*",


### PR DESCRIPTION
This fixes a batch of code examples that cannot run as written:

- undefined variables (a missing `$` sigil, or a variable name that does not
  match the one declared just above);
- a few syntax errors: a missing `;`, a stray `.` that turns a subtraction
  into string concatenation, a `=` instead of `=>`, an unterminated string;
- a Cyrillic homoglyph (`С`, U+0421) used in a type hint instead of the Latin
  `C` class;
- a couple of examples instantiating or calling the wrong class/method name.

Each change only touches the example so it parses and runs as intended.
