### PR TITLE
setStub.xml Change the parameter type

### DIFF
--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -9,7 +9,7 @@
   &reftitle.description;
   <methodsynopsis role="PharData">
    <modifier>public</modifier> <type>true</type><methodname>PharData::setStub</methodname>
-   <methodparam><type>string</type><parameter>stub</parameter></methodparam>
+   <methodparam><type class="union"><type>resource</type><type>string</type></type><parameter>stub</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
 


### PR DESCRIPTION
It seems that it is better to specify the formal type `resource|string` for the `stub` parameter:

https://github.com/php/php-src/blob/21c2318e2952098a421e7fdff70c8fab9262686c/ext/phar/phar_object.stub.php#L479