### PR TITLE
reflection: ReflectionFunction::__construct() example expects bool param

### DIFF
--- a/reference/reflection/reflectionfunction/construct.xml
+++ b/reference/reflection/reflectionfunction/construct.xml
@@ -87,12 +87,12 @@ function dumpReflectionFunction($func)
     );
 
     // Print documentation comment
-    printf("---> Documentation:\n %s\n", var_export($func->getDocComment(), 1));
+    printf("---> Documentation:\n %s\n", var_export($func->getDocComment(), true));
 
     // Print static variables if existent
     if ($statics = $func->getStaticVariables())
     {
-        printf("---> Static variables: %s\n", var_export($statics, 1));
+        printf("---> Static variables: %s\n", var_export($statics, true));
     }
 }
 


### PR DESCRIPTION
The example on https://www.php.net/manual/en/reflectionfunction.construct.php uses `var_export` with the second argument as `1` but `var_export` accepts a boolean as its second argument. Using the code as provided causes
`TypeError: var_export(): Argument #2 ($return) must be of type bool, int given`
if strict_types is enabled.

Changed the second argument to the two `var_export` calls to "true".