### PR TITLE
PHP 8.5 changelog entries for readline functions

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -859,6 +859,13 @@ searched for within the <link xmlns="http://docbook.org/ns/docbook" linkend="ini
  </entry>
 </row>'>
 
+<!ENTITY return.type.true.85 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.5.0</entry>
+ <entry>
+  The return type is &true; now; previously, it was <type>bool</type>.
+ </entry>
+</row>'>
+
 <!ENTITY return.falseforfailure ' or &false; on failure'>
 <!ENTITY return.falseforfailure.style.procedural '&style.procedural; returns &false; on failure.'>
 

--- a/reference/readline/functions/readline-add-history.xml
+++ b/reference/readline/functions/readline-add-history.xml
@@ -37,6 +37,24 @@
    &return.true.always;
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -57,6 +57,23 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -99,23 +116,6 @@ echo "Prompting disabled. All done.\n";
 ]]>
    </programlisting>
   </example>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     &return.type.true.85;
-    </tbody>
-   </tgroup>
-  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -101,15 +101,6 @@ echo "Prompting disabled. All done.\n";
   </example>
  </refsect1>
 
- <refsect1 role="seealso">
-  &reftitle.seealso;
-  <simplelist>
-   <member><function>readline_callback_handler_remove</function></member>
-   <member><function>readline_callback_read_char</function></member>
-   <member><function>stream_select</function></member>
-  </simplelist>
- </refsect1>
-
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -125,6 +116,15 @@ echo "Prompting disabled. All done.\n";
     </tbody>
    </tgroup>
   </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>readline_callback_handler_remove</function></member>
+   <member><function>readline_callback_read_char</function></member>
+   <member><function>stream_select</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -110,6 +110,23 @@ echo "Prompting disabled. All done.\n";
   </simplelist>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/readline/functions/readline-clear-history.xml
+++ b/reference/readline/functions/readline-clear-history.xml
@@ -28,6 +28,24 @@
    &return.true.always;
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Add changelog sections documenting return type changes in PHP 8.5 for readline functions 

 - readline_add_history
 - readline_callback_handler_install
 - readline_clear_history). 

Also define the reusable return.type.true.85 entity which also exists for 84.