### PR TITLE
Add deprecation notice for mysqli_execute that was added in PHP 8.5

### DIFF
--- a/reference/mysqli/functions/mysqli-execute.xml
+++ b/reference/mysqli/functions/mysqli-execute.xml
@@ -6,20 +6,15 @@
   <refpurpose>&Alias; <function>mysqli_stmt_execute</function></refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
    &info.function.alias; <function>mysqli_stmt_execute</function>.
   </para>
- </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    <function>mysqli_execute</function> is deprecated and will be removed.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
According to Git blame the old notice existed since 2004. But it is formally deprecated in PHP 8.5.
