### PR TITLE
book.xml Add `StreamBucket`

### DIFF
--- a/reference/stream/book.xml
+++ b/reference/stream/book.xml
@@ -64,6 +64,7 @@
  &reference.stream.examples;
  &reference.stream.php-user-filter;
  &reference.stream.streamwrapper;
+ &reference.stream.streambucket;
  &reference.stream.reference;
  
 </book>

--- a/reference/stream/streambucket.xml
+++ b/reference/stream/streambucket.xml
@@ -96,7 +96,7 @@
 
  </partintro>
 
- &reference.stream.entities.streambucket;
+ <!-- &reference.stream.entities.streambucket; -->
 
 </reference>
 <!-- Keep this comment at the end of the file

--- a/reference/stream/streambucket.xml
+++ b/reference/stream/streambucket.xml
@@ -96,8 +96,6 @@
 
  </partintro>
 
- <!-- &reference.stream.entities.streambucket; -->
-
 </reference>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/stream/streambucket.xml
+++ b/reference/stream/streambucket.xml
@@ -75,7 +75,7 @@
       </simpara>
      </listitem>
     </varlistentry>
-    <varlistentry xml:id="streambucket.props.dataLength">
+    <varlistentry xml:id="streambucket.props.datalength">
      <term>int <varname>dataLength</varname></term>
      <listitem>
       <simpara>The length of the string in the bucket.</simpara>


### PR DESCRIPTION
The `streambucket.xml` file was added 4 months ago, but apparently they forgot to add the `&reference.stream.streambucket;` reference to `book.xml`