### PR TITLE
Fix example output (screen) inconsistent with code

### DIFF
--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -97,9 +97,9 @@ class Bar extends Foo
 $foo = new Foo();
 $bar = new Bar();
 $foo->printItem('baz'); // Output: 'Foo: baz'
-$foo->printPHP();       // Output: 'PHP is great' 
+$foo->printPHP();       // Output: 'PHP is great.'
 $bar->printItem('baz'); // Output: 'Bar: baz'
-$bar->printPHP();       // Output: 'PHP is great'
+$bar->printPHP();       // Output: 'PHP is great.'
 
 ?>
 ]]>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -254,11 +254,11 @@ print date('c', $nextyear) . "\n";
   <para>
    <example>
     <title>Last day of a month</title>
-    <para>
+    <simpara>
      The last day of any given month can be expressed as the "0" day
      of the next month, not the -1 day. Both of the following examples
      will produce the string "Last day in Feb 2000 is: 29".
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -257,7 +257,7 @@ print date('c', $nextyear) . "\n";
     <para>
      The last day of any given month can be expressed as the "0" day
      of the next month, not the -1 day. Both of the following examples
-     will produce the string "The last day in Feb 2000 is: 29".
+     will produce the string "Last day in Feb 2000 is: 29".
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/dom/domelement/construct.xml
+++ b/reference/dom/domelement/construct.xml
@@ -68,7 +68,7 @@ $dom = new DOMDocument('1.0', 'iso-8859-1');
 $element = $dom->appendChild(new DOMElement('root'));
 $element_ns = new DOMElement('pr:node1', 'thisvalue', 'http://xyz');
 $element->appendChild($element_ns);
-echo $dom->saveXML(); /* <?xml version="1.0" encoding="utf-8"?>
+echo $dom->saveXML(); /* <?xml version="1.0" encoding="iso-8859-1"?>
 <root><pr:node1 xmlns:pr="http://xyz">thisvalue</pr:node1></root> */
 
 ?>

--- a/reference/ds/ds/map/ksort.xml
+++ b/reference/ds/ds/map/ksort.xml
@@ -15,9 +15,9 @@
    <modifier>public</modifier> <type>void</type><methodname>Ds\Map::ksort</methodname>
    <methodparam choice="opt"><type>callable</type><parameter>comparator</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Sorts the map in-place by key, using an optional <parameter>comparator</parameter> function.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
     &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/ds/ds/map/ksort.xml
+++ b/reference/ds/ds/map/ksort.xml
@@ -101,7 +101,6 @@ print_r($map);
    <screen>
 <![CDATA[
 Ds\Map Object
-Ds\Map Object
 (
     [0] => Ds\Pair Object
         (

--- a/reference/ds/ds/map/ksorted.xml
+++ b/reference/ds/ds/map/ksorted.xml
@@ -55,7 +55,6 @@ print_r($map->ksorted());
    <screen>
 <![CDATA[
 Ds\Map Object
-Ds\Map Object
 (
     [0] => Ds\Pair Object
         (
@@ -98,7 +97,6 @@ print_r($sorted);
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Ds\Map Object
 Ds\Map Object
 (
     [0] => Ds\Pair Object

--- a/reference/ds/ds/map/ksorted.xml
+++ b/reference/ds/ds/map/ksorted.xml
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>Ds\Map</type><methodname>Ds\Map::ksorted</methodname>
    <methodparam choice="opt"><type>callable</type><parameter>comparator</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Returns a copy sorted by key, using an optional <parameter>comparator</parameter> function.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -33,9 +33,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
     Returns a copy of the map, sorted by key.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/ds/ds/map/pairs.xml
+++ b/reference/ds/ds/map/pairs.xml
@@ -47,7 +47,7 @@ var_dump($map->pairs());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-object(Ds\Map)#8 (3) {
+object(Ds\Vector)#8 (3) {
   [0]=>
   object(Ds\Pair)#5 (2) {
     ["key"]=>
@@ -70,7 +70,6 @@ object(Ds\Map)#8 (3) {
     int(3)
   }
 }
-p
 ]]>
    </screen>
   </example>

--- a/reference/ds/ds/pair/clear.xml
+++ b/reference/ds/ds/pair/clear.xml
@@ -50,9 +50,8 @@ print_r($pair);
 <![CDATA[
 Ds\Pair Object
 (
-    [0] => 1
-    [1] => 2
-    [2] => 3
+    [key] => a
+    [value] => 1
 )
 Ds\Pair Object
 (

--- a/reference/ds/ds/vector/join.xml
+++ b/reference/ds/ds/vector/join.xml
@@ -73,7 +73,7 @@ var_dump($vector->join());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-string(11) "abc123"
+string(6) "abc123"
 ]]>
    </screen>
   </example>

--- a/reference/memcached/memcached/fetch.xml
+++ b/reference/memcached/memcached/fetch.xml
@@ -60,7 +60,7 @@ while ($result = $m->fetch()) {
 array(3) {
   ["key"]=>
   string(3) "int"
-  "value"]=>
+  ["value"]=>
   int(99)
   ["cas"]=>
   float(2363)

--- a/reference/mongodb/functions/bson/fromphp.xml
+++ b/reference/mongodb/functions/bson/fromphp.xml
@@ -100,7 +100,7 @@ echo bin2hex($bson), "\n";
    &example.outputs;
    <screen>
 <![CDATA[
-0e00000010666f6f000100000000cat
+0e00000010666f6f000100000000
 ]]>
    </screen>
   </example>

--- a/reference/mongodb/mongodb/driver/cursor.xml
+++ b/reference/mongodb/mongodb/driver/cursor.xml
@@ -145,7 +145,7 @@ stdClass Object
     [name] => Vesta
     [size] => 525
     [distance] => 2.362
-}
+)
 ]]>
     </screen>
    </example>

--- a/reference/spl/splobjectstorage/rewind.xml
+++ b/reference/spl/splobjectstorage/rewind.xml
@@ -61,8 +61,12 @@ while($s->valid()) {
     &example.outputs.similar;
     <screen>
 <![CDATA[
-int(1)
-int(0)
+object(stdClass)#2 (0) {
+}
+string(2) "d1"
+object(stdClass)#3 (0) {
+}
+string(2) "d2"
 ]]>
     </screen>
    </example>

--- a/reference/uri/uri/whatwg/url/getquery.xml
+++ b/reference/uri/uri/whatwg/url/getquery.xml
@@ -44,7 +44,7 @@ echo $url->getQuery();
    &example.outputs;
    <screen>
 <![CDATA[
-foo=bar
+foo/bar
 ]]>
    </screen>
   </example>

--- a/reference/wincache/functions/wincache-ucache-delete.xml
+++ b/reference/wincache/functions/wincache-ucache-delete.xml
@@ -85,7 +85,7 @@ var_dump(wincache_ucache_delete($array2));
     <screen>
 <![CDATA[
 array(4) { [0]=> string(5) "green" 
-           [1]=> string(4) "Blue" 
+           [1]=> string(4) "blue"
            [2]=> string(6) "yellow" 
            [3]=> string(4) "cyan" } 
 ]]>

--- a/reference/yaf/yaf-config-ini.xml
+++ b/reference/yaf/yaf-config-ini.xml
@@ -151,7 +151,7 @@ var_dump($config->get("database.params.username"));
 <![CDATA[
 string(15) "dev.example.com"
 string(6) "dbname"
-string(7) "devuser
+string(7) "devuser"
 ]]>
    </screen>
   </example>

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -78,7 +78,7 @@ var_dump($client->add(1, 2));
 var_dump($client->call("add", array(3, 2)));
 
 
-/* _add can not be called */
+/* _add cannot be called */
 var_dump($client->_add(1, 2));
 ?>
 ]]>

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -78,7 +78,7 @@ var_dump($client->add(1, 2));
 var_dump($client->call("add", array(3, 2)));
 
 
-/* __add can not be called */
+/* _add can not be called */
 var_dump($client->_add(1, 2));
 ?>
 ]]>


### PR DESCRIPTION
Several example output blocks did not match what the code produces (found during a doc-fr vs doc-en comparison). Each change was verified against the actual code, most of them run empirically.

Covers: oop5 inheritance, mktime, dom construct, Ds (map/pair/vector), memcached fetch, mongodb bson/cursor, spl rewind, uri getQuery, wincache delete, yaf config-ini, yar examples.