### PR TITLE
Fix changelog row markup in DateInterval::createFromDateString

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -83,6 +83,8 @@
        Now has a tentative return type of <type>DateInterval</type>.
        Previously it was <type class="union"><type>DateInterval</type><type>false</type></type>.
       </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> now throws


### PR DESCRIPTION
9eb962113c (#4064) inserted the 8.4.0 changelog entry into the existing 8.3.0 row:

<img width="849" height="379" alt="image" src="https://github.com/user-attachments/assets/78cee7bf-0ef3-437b-bd2d-6e81efe44dd3" />
