### PR TITLE
Document new OpenSSL constants (PHP 8.5)

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -157,6 +157,18 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.openssl-pkcs1-pss-padding">
+   <term>
+    <constant>OPENSSL_PKCS1_PSS_PADDING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     RSA-PSS padding.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
  </section>
 
@@ -377,6 +389,46 @@
           Available as of PHP 8.3.0.
           Sets the content-type to <literal>application/pkcs7-mime</literal> instead of
           <literal>application/x-pkcs7-mime</literal> to encrypt a message.
+         </entry>
+        </row>
+        <row xml:id="constant.pkcs7-nosmimecap">
+         <entry>
+          <constant>PKCS7_NOSMIMECAP</constant>
+          (<type>int</type>)
+         </entry>
+         <entry>
+          Available as of PHP 8.5.0.
+          Do not include the S/MIME capabilities (SMIMECapabilities) in the signature.
+         </entry>
+        </row>
+        <row xml:id="constant.pkcs7-crlfeol">
+         <entry>
+          <constant>PKCS7_CRLFEOL</constant>
+          (<type>int</type>)
+         </entry>
+         <entry>
+          Available as of PHP 8.5.0.
+          Use <literal>CRLF</literal> as the end of line in the output.
+         </entry>
+        </row>
+        <row xml:id="constant.pkcs7-nocrl">
+         <entry>
+          <constant>PKCS7_NOCRL</constant>
+          (<type>int</type>)
+         </entry>
+         <entry>
+          Available as of PHP 8.5.0.
+          Do not include the CRLs in the PKCS7 structure.
+         </entry>
+        </row>
+        <row xml:id="constant.pkcs7-no-dual-content">
+         <entry>
+          <constant>PKCS7_NO_DUAL_CONTENT</constant>
+          (<type>int</type>)
+         </entry>
+         <entry>
+          Available as of PHP 8.5.0.
+          Do not include the duplicate content, avoiding the duplication of the signed content.
          </entry>
         </row>
        </tbody>


### PR DESCRIPTION
Documents the OpenSSL constants added in PHP 8.5: OPENSSL_PKCS1_PSS_PADDING (RSA-PSS padding) and the PKCS7 flags PKCS7_NOSMIMECAP, PKCS7_CRLFEOL, PKCS7_NOCRL and PKCS7_NO_DUAL_CONTENT.