### PR TITLE
Document new cURL constants (PHP 8.5)

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -212,6 +212,52 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-all">
+   <term>
+    <constant>CURLFOLLOW_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Value for <constant>CURLOPT_FOLLOWLOCATION</constant> that enables following
+     redirects and keeps a custom request method set with
+     <constant>CURLOPT_CUSTOMREQUEST</constant> in use for all requests, even
+     after redirects.
+     Available as of PHP 8.5.0 and cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-obeycode">
+   <term>
+    <constant>CURLFOLLOW_OBEYCODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Value for <constant>CURLOPT_FOLLOWLOCATION</constant> that enables following
+     redirects while obeying the HTTP response code: a custom request method set
+     with <constant>CURLOPT_CUSTOMREQUEST</constant> is kept, except that it is
+     changed to <literal>GET</literal> on the redirect status codes that require
+     it (such as 301, 302 and 303).
+     Available as of PHP 8.5.0 and cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-firstonly">
+   <term>
+    <constant>CURLFOLLOW_FIRSTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Value for <constant>CURLOPT_FOLLOWLOCATION</constant> that enables following
+     redirects but uses a custom request method set with
+     <constant>CURLOPT_CUSTOMREQUEST</constant> for the first request only;
+     subsequent requests follow the method dictated by the redirect response code.
+     Available as of PHP 8.5.0 and cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlftpauth-default">
    <term>
     <constant>CURLFTPAUTH_DEFAULT</constant>

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -70,6 +70,18 @@
    </simpara>
   </listitem>
  </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-conn-id">
+  <term>
+   <constant>CURLINFO_CONN_ID</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    The ID of the last connection used by the transfer. The connection ID is unique among all connections using the same connection cache and is useful to tell connection reuse apart.
+    Available as of PHP 8.5.0 and cURL 8.2.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
  <varlistentry xml:id="constant.curlinfo-connect-time">
   <term>
    <constant>CURLINFO_CONNECT_TIME</constant>
@@ -248,6 +260,18 @@
   <listitem>
    <simpara>
     Bitmask indicating the authentication method(s) available according to the previous response
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-httpauth-used">
+  <term>
+   <constant>CURLINFO_HTTPAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Bitmask indicating the HTTP authentication method(s) actually used in the previous request.
+    Available as of PHP 8.5.0 and cURL 8.12.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -444,6 +468,18 @@
    </simpara>
   </listitem>
  </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-proxyauth-used">
+  <term>
+   <constant>CURLINFO_PROXYAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Bitmask indicating the proxy authentication method(s) actually used in the previous request.
+    Available as of PHP 8.5.0 and cURL 8.12.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
  <varlistentry xml:id="constant.curlinfo-proxy-error">
   <term>
    <constant>CURLINFO_PROXY_ERROR</constant>
@@ -465,6 +501,18 @@
    <simpara>
     The result of the certificate verification that was requested (using the <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant> option). Only used for HTTPS proxies.
     Available as of PHP 7.3.0 and cURL 7.52.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-queue-time-t">
+  <term>
+   <constant>CURLINFO_QUEUE_TIME_T</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    The time, in microseconds, that the transfer was held in a waiting queue before it started, due to limits set with <constant>CURLMOPT_MAX_TOTAL_CONNECTIONS</constant> or similar options.
+    Available as of PHP 8.5.0 and cURL 8.6.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -773,6 +821,18 @@
    <simpara>
     Total time in microseconds for the previous transfer, including name resolving, TCP connect etc.
     Available as of PHP 7.3.0 and cURL 7.61.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-used-proxy">
+  <term>
+   <constant>CURLINFO_USED_PROXY</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Whether the previous transfer used a proxy; returns <literal>1</literal> if a proxy was used and <literal>0</literal> otherwise.
+    Available as of PHP 8.5.0 and cURL 8.7.0.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1380,6 +1380,21 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-infilesize-large">
+   <term>
+    <constant>CURLOPT_INFILESIZE_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     The expected size, in bytes, of the file when uploading a file to
+     a remote site. This is the 64-bit variant of
+     <constant>CURLOPT_INFILESIZE</constant>, allowing sizes larger than
+     2 GB to be specified.
+     Available as of PHP 8.5.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-interface">
    <term>
     <constant>CURLOPT_INTERFACE</constant>


### PR DESCRIPTION
Documents the cURL constants added in PHP 8.5: CURLFOLLOW_ALL/OBEYCODE/FIRSTONLY (CURLOPT_FOLLOWLOCATION values), CURLINFO_USED_PROXY, CURLINFO_HTTPAUTH_USED, CURLINFO_PROXYAUTH_USED, CURLINFO_CONN_ID, CURLINFO_QUEUE_TIME_T and CURLOPT_INFILESIZE_LARGE. Semantics taken from the libcurl docs.