### PR TITLE
Document #[\NoDiscard] behavior on interface, abstract, and overriding methods

### DIFF
--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -40,7 +40,9 @@
      does not emit a warning, because the method that is invoked is the
      implementing or overriding method. Likewise, a method that overrides a
      <code>#[\NoDiscard]</code> method does not emit the warning unless it is
-     itself marked with the attribute.
+     itself marked with the attribute. In contrast, a method imported from a
+     trait keeps the attribute, because the trait method is copied into the
+     using class as if declared there.
     </simpara>
    </note>
   </section>

--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -31,6 +31,18 @@
      consider using a variable like <code>$_</code>.
     </simpara>
    </note>
+   <note>
+    <simpara>
+     <code>#[\NoDiscard]</code> applies to the specific function or method
+     declaration it is written on, and the warning is emitted based on the
+     declaration that is actually called. As a result, adding
+     <code>#[\NoDiscard]</code> to an interface method or an abstract method
+     does not emit a warning, because the method that is invoked is the
+     implementing or overriding method. Likewise, a method that overrides a
+     <code>#[\NoDiscard]</code> method does not emit the warning unless it is
+     itself marked with the attribute.
+    </simpara>
+   </note>
   </section>
 
   <section xml:id="nodiscard.synopsis">


### PR DESCRIPTION
Adds a note to the `#[NoDiscard]` attribute page documenting that the warning is emitted based on the method declaration that is actually called.

It's easy to assume `#[\NoDiscard]` on an interface or abstract method applies to its implementations, or that it carries over to an overriding method. It doesn't...the warning fires only for the declaration that is actually
invoked, so `#[\NoDiscard]` on an interface or abstract method or on a parent method that is overridden without re-applying it emits no warning.

The current documentation doesn't mention this, and it surprised me in practice.

I raised this with @TimWolla (co-author of the original `#[NoDiscard]` RFC).
We discussed whether the engine should surface it, but that risks backward-compatibility concerns. So we landed on a documentation note as the appropriate fix, which this PR adds.
