### PR TITLE
intl: document the procedural style of IntlGregorianCalendar methods

### DIFF
--- a/reference/intl/intlgregoriancalendar/getgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/getgregorianchange.xml
@@ -8,21 +8,33 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>float</type><methodname>IntlGregorianCalendar::getGregorianChange</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis>
+   <type>float</type><methodname>intlgregcal_get_gregorian_change</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Gets the Gregorian Calendar change date. This is the point at which the
+   calendar switches from Julian dates to Gregorian dates, expressed as a UNIX
+   timestamp in milliseconds. It defaults to midnight (UTC) on October 15, 1582.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  &no.function.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>An <classname>IntlGregorianCalendar</classname> instance.</simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/intl/intlgregoriancalendar/getgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/getgregorianchange.xml
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <simpara>
    Gets the Gregorian Calendar change date. This is the point at which the
-   calendar switches from Julian dates to Gregorian dates, expressed as a UNIX
+   calendar switches from Julian dates to Gregorian dates, expressed as a Unix
    timestamp in milliseconds. It defaults to midnight (UTC) on October 15, 1582.
   </simpara>
  </refsect1>

--- a/reference/intl/intlgregoriancalendar/isleapyear.xml
+++ b/reference/intl/intlgregoriancalendar/isleapyear.xml
@@ -8,27 +8,36 @@
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>bool</type><methodname>IntlGregorianCalendar::isLeapYear</methodname>
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlgregcal_is_leap_year</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>year</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Determines whether the given <parameter>year</parameter> is a leap year
+   in the Gregorian calendar.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>An <classname>IntlGregorianCalendar</classname> instance.</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
     <term><parameter>year</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>The year to check.</simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/intl/intlgregoriancalendar/setgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/setgregorianchange.xml
@@ -3,32 +3,45 @@
 <refentry xml:id="intlgregoriancalendar.setgregorianchange" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlGregorianCalendar::setGregorianChange</refname>
-  <refpurpose>Set the Gregorian Calendar the change date</refpurpose>
+  <refpurpose>Set the Gregorian Calendar change date</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
+  <simpara>&style.oop;</simpara>
   <methodsynopsis role="IntlGregorianCalendar">
    <modifier>public</modifier> <type>bool</type><methodname>IntlGregorianCalendar::setGregorianChange</methodname>
    <methodparam><type>float</type><parameter>timestamp</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
-  &warn.undocumented.func;
-
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlgregcal_set_gregorian_change</methodname>
+   <methodparam><type>IntlGregorianCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>float</type><parameter>timestamp</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sets the Gregorian Calendar change date. This is the point at which the
+   calendar switches from Julian dates to Gregorian dates, expressed as a UNIX
+   timestamp in milliseconds.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <simpara>An <classname>IntlGregorianCalendar</classname> instance.</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
     <term><parameter>timestamp</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      The Gregorian Calendar change date, expressed as a UNIX timestamp in
+      milliseconds.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/intl/intlgregoriancalendar/setgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/setgregorianchange.xml
@@ -21,7 +21,7 @@
   </methodsynopsis>
   <simpara>
    Sets the Gregorian Calendar change date. This is the point at which the
-   calendar switches from Julian dates to Gregorian dates, expressed as a UNIX
+   calendar switches from Julian dates to Gregorian dates, expressed as a Unix
    timestamp in milliseconds.
   </simpara>
  </refsect1>

--- a/reference/intl/intlgregoriancalendar/setgregorianchange.xml
+++ b/reference/intl/intlgregoriancalendar/setgregorianchange.xml
@@ -39,7 +39,7 @@
     <term><parameter>timestamp</parameter></term>
     <listitem>
      <simpara>
-      The Gregorian Calendar change date, expressed as a UNIX timestamp in
+      The Gregorian Calendar change date, expressed as a Unix timestamp in
       milliseconds.
      </simpara>
     </listitem>


### PR DESCRIPTION
The procedural functions `intlgregcal_get_gregorian_change`, `intlgregcal_is_leap_year` and `intlgregcal_set_gregorian_change` were undocumented. This adds their procedural synopsis to the existing OO method pages (mirroring the IntlCalendar convention), fills the short descriptions, and drops the `&warn.undocumented.func;` placeholders.

The deprecated `intlgregcal_create_instance` is intentionally left out.