### PR TITLE
Fix radius_get_vendor_attr return type hint

### DIFF
--- a/reference/radius/functions/radius-get-vendor-attr.xml
+++ b/reference/radius/functions/radius-get-vendor-attr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- splitted from ./en/functions/radius.xml, last change in rev 1.9 -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.radius-get-vendor-attr">
+<refentry xml:id="function.radius-get-vendor-attr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>radius_get_vendor_attr</refname>
   <refpurpose>Extracts a vendor specific attribute</refpurpose>

--- a/reference/radius/functions/radius-get-vendor-attr.xml
+++ b/reference/radius/functions/radius-get-vendor-attr.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>radius_get_vendor_attr</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>radius_get_vendor_attr</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <simpara>


### PR DESCRIPTION
As the return description says, `radius_get_vendor_attr` returns `false` on error. This PR fixes the return type hint by changing it to an union of an array and false.