### PR TITLE
Clarified PECL deprecation

### DIFF
--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -3,6 +3,7 @@
 
 <chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation of PECL extensions</title>
+ &pecl.moving.to.pie;
 
  <sect1 xml:id="install.pecl.intro">
   <title>Introduction to PECL Installations</title>
@@ -121,6 +122,7 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
 
  <sect1 xml:id="install.pecl.windows">
   <title>Installing a PHP extension on Windows</title>
+  &pecl.moving.to.pie;
   <para>
    There are two ways to load a PHP extension on Windows: either compile it into
    PHP, or load the DLL.
@@ -327,6 +329,7 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
 
  <sect1 xml:id="install.pecl.pear">
   <title>Compiling shared PECL extensions with the pecl command</title>
+  &pecl.moving.to.pie;
   <simpara>
    PECL makes it easy to create shared PHP extensions.
    Using the
@@ -377,6 +380,7 @@ $ pecl install extname-0.1
 
  <sect1 xml:id="install.pecl.phpize">
   <title>Compiling shared PECL extensions with phpize</title>
+  &pecl.moving.to.pie;
   <simpara>
    Sometimes, using the <command>pecl</command> installer is not an option.
    This could be because there is a firewall or because the extension being
@@ -427,7 +431,7 @@ $ make
   <title>
    <command>php-config</command>
   </title>
-  
+  &pecl.moving.to.pie;
   <para>
    <command>php-config</command>
    is a simple shell script for obtaining information about the installed PHP
@@ -540,6 +544,7 @@ Options:
 
  <sect1 xml:id="install.pecl.static">
   <title>Compiling PECL extensions statically into PHP</title>
+  &pecl.moving.to.pie;
   <simpara>
    It may be necessary to build a PECL extension statically into the PHP binary.
    To do this, the extension source will need to be placed under the

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2271,7 +2271,7 @@ for this <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> extension
 <!ENTITY pecl.moved-ver 'This extension has been moved to the &link.pecl;
 repository and is no longer bundled with PHP as of PHP '>
 
-<!ENTITY pecl.moving.to.pie '<warning>
+<!ENTITY pecl.moving.to.pie '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   PECL is deprecated.
   PHP Installer for Extensions (<acronym>PIE</acronym>) replaces PECL and is recommended to install extensions.

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2271,13 +2271,13 @@ for this <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> extension
 <!ENTITY pecl.moved-ver 'This extension has been moved to the &link.pecl;
 repository and is no longer bundled with PHP as of PHP '>
 
-<!ENTITY pecl.moving.to.pie '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pecl.moving.to.pie '<warning>
  <simpara>
-  PHP Installer for Extensions (<acronym>PIE</acronym>) is a new tool that will deprecate PECL.
-  We recommend using PIE to install extensions.
+  PECL is deprecated.
+  PHP Installer for Extensions (<acronym>PIE</acronym>) replaces PECL and is recommended to install extensions.
   Find out more at <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://github.com/php/pie">https://github.com/php/pie</link>
  </simpara>
-</note>'>
+</warning>'>
 
 <!ENTITY warn.pecl.unmaintained '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>This extension is <emphasis>unmaintained</emphasis>.</simpara>


### PR DESCRIPTION
According to https://wiki.php.net/rfc/adopt_pie_deprecate_pecl PECL is deprecated since 2025.
This PR aligns the docs with the current reality.

**Optimised:**
- deprecation message did not use the more visible `warning` style as deprecations elsewhere
- not all section under the `install.pecl` namespace had the message assigned
- message was still in pre-deprecation wording ("will" vs. "is")