### PR TITLE
Fix IntlBreakIterator::getPartsIterator() type parameter

### DIFF
--- a/reference/intl/intlbreakiterator/getpartsiterator.xml
+++ b/reference/intl/intlbreakiterator/getpartsiterator.xml
@@ -10,7 +10,7 @@
   &reftitle.description;
   <methodsynopsis role="IntlBreakIterator">
    <modifier>public</modifier> <type>IntlPartsIterator</type><methodname>IntlBreakIterator::getPartsIterator</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>type</parameter><initializer><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlPartsIterator::KEY_SEQUENTIAL</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
 


### PR DESCRIPTION
The `type` parameter is documented as `string` but is an `int`: the accepted `IntlPartsIterator::KEY_*` constants are integers, matching the php-src stub.