### PR TITLE
Remove 72 unused entities from language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3,20 +3,8 @@
 
 <!ENTITY installation.enabled.disable 'This extension is enabled by default. It may be disabled by using the following option at compile time: '>
 
-<!-- Not used in EN anymore -->
 <!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>The random
 number generator is seeded automatically.</entry></row>'>
-
-<!ENTITY warn.deprecated.feature-5-3-0.removed-6-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
-<emphasis>DEPRECATED</emphasis> as of PHP 5.3.0. Relying on this feature is
-highly discouraged.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-6-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
-<emphasis>DEPRECATED</emphasis> as of PHP 5.3.0. Relying on this feature is
-highly discouraged.</simpara></warning>'>
-
 <!-- Cautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -95,7 +83,6 @@ an underscore, but instead fails to extract such files.</simpara></note>'>
 <!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara>Instead of a function name, an
 array containing an object reference and a method name can also be
 supplied.</simpara></note>'>
-
 <!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>Callbacks registered
 with functions such as <function>call_user_func</function> and <function>call_user_func_array</function> will not be
 called if there is an uncaught exception thrown in a previous callback.</simpara></note>'>
@@ -103,11 +90,6 @@ called if there is an uncaught exception thrown in a previous callback.</simpara
 <!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>If the arguments are passed by reference,
 any changes to the arguments will be reflected in the values returned by this function. As of PHP 7
 the current values will also be returned if the arguments are passed by value.</simpara></note>'>
-
-<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>Because this function depends on the
-current scope to determine parameter details, it cannot be used as a
-function parameter in versions prior to 5.3.0. If this value must be passed, the results should be assigned
-to a variable, and that variable should be passed.</simpara></note>'>
 
 <!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara>As of PHP 8.0.0, the func_*() family of
 functions is intended to be mostly transparent with regard to named arguments,
@@ -231,7 +213,6 @@ the output of this function, and save it in a
 <!ENTITY tip.userlandnaming '<tip xmlns="http://docbook.org/ns/docbook"><simpara>See also the
 <xref linkend="userlandnaming" />.</simpara></tip>'>
 
-
 <!-- Warnings -->
 
 <!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><simpara>When allowing user-supplied data to be
@@ -249,43 +230,18 @@ This extension should be used at your own risk.</simpara></warning>'>
 <!ENTITY deprecated.function 'Deprecated this function.'>
 <!ENTITY removed.function 'Removed this function.'>
 
-<!ENTITY warn.deprecated.feature-5-3-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
-<emphasis>DEPRECATED</emphasis> as of PHP 5.3.0. Relying on this feature
-is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
 <emphasis>DEPRECATED</emphasis> as of PHP 5.3.0 and <emphasis>REMOVED</emphasis>
 as of PHP 5.4.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-5-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
-<emphasis>DEPRECATED</emphasis> as of PHP 5.3.0 and <emphasis>REMOVED</emphasis> as of PHP 5.4.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
-<emphasis>DEPRECATED</emphasis> as of PHP 5.5.0. Relying on this feature
-is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-6-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
 <emphasis>DEPRECATED</emphasis> as of PHP 5.6.0. Relying on this feature
 is highly discouraged.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
-<emphasis>DEPRECATED</emphasis> as of PHP 7.0.0. Relying on this feature
-is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-7-1-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
 <emphasis>DEPRECATED</emphasis> as of PHP 7.1.0. Relying on this feature
-is highly discouraged.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-7-1-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
-<emphasis>DEPRECATED</emphasis> as of PHP 7.1.0. Relying on this function
 is highly discouraged.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-0-0.removed-8-0-0 '<warning
@@ -304,15 +260,9 @@ is highly discouraged.</simpara></warning>'>
 xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
 <emphasis>DEPRECATED</emphasis> as of PHP 7.2.0. Relying on this feature
 is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-7-2-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
 <emphasis>DEPRECATED</emphasis> as of PHP 7.2.0, and <emphasis>REMOVED</emphasis> as of PHP 8.0.0. Relying on this feature
-is highly discouraged.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-7-2-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
-<emphasis>DEPRECATED</emphasis> as of PHP 7.2.0. Relying on this function
 is highly discouraged.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-2-0.removed-8-0-0 '<warning
@@ -325,26 +275,15 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
 <emphasis>DEPRECATED</emphasis> as of PHP 7.3.0. Relying on this feature
 is highly discouraged.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.function-7-3-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
-<emphasis>DEPRECATED</emphasis> as of PHP 7.3.0. Relying on this function
-is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-7-3-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 7.3.0, and <emphasis>REMOVED</emphasis> as of PHP 8.0.0. Relying on this function
-is highly discouraged.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-7-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
-<emphasis>DEPRECATED</emphasis> as of PHP 7.4.0. Relying on this feature
 is highly discouraged.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 7.4.0. Relying on this function
 is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-7-4-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 7.4.0, and <emphasis>REMOVED</emphasis> as of PHP 8.0.0. Relying on this function
@@ -384,11 +323,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.3.0. Relying on this function
 is highly discouraged.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-8-4-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature has been
-<emphasis>DEPRECATED</emphasis> as of PHP 8.4.0. Relying on this feature
-is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-8-4-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
 <emphasis>DEPRECATED</emphasis> as of PHP 8.4.0. Relying on this function
@@ -407,54 +341,12 @@ is highly discouraged.</simpara></warning>'>
 <!ENTITY removed.php.future 'This deprecated feature <emphasis xmlns="http://docbook.org/ns/docbook">will</emphasis>
 certainly be <emphasis xmlns="http://docbook.org/ns/docbook">removed</emphasis> in the future.'>
 
-<!ENTITY warn.deprecated.function.removed-5-3-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
-<emphasis>DEPRECATED</emphasis> and <emphasis>REMOVED</emphasis> as of PHP 5.3.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function.removed-5-5-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
-<emphasis>DEPRECATED</emphasis> and <emphasis>REMOVED</emphasis> as of PHP 5.5.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>This alias has been <emphasis>DEPRECATED</emphasis> as of PHP 5.3.0.  Relying
-on this alias is highly discouraged.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.func-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>This function has been <emphasis>DEPRECATED</emphasis> as of PHP 5.4.0.  Relying
-on this function is highly discouraged.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook">
 <simpara>This alias has been <emphasis>DEPRECATED</emphasis> as of PHP 5.4.0.  Relying
 on this alias is highly discouraged.</simpara></warning>'>
 
-<!ENTITY warn.deprecated.func-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>This function has been <emphasis>DEPRECATED</emphasis> as of PHP 5.5.0.  Relying
-on this function is highly discouraged.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature was
-<emphasis>DEPRECATED</emphasis> in PHP 5.5.0, and <emphasis>REMOVED</emphasis> as of PHP 7.0.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-5-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function was
-<emphasis>DEPRECATED</emphasis> in PHP 5.5.0, and <emphasis>REMOVED</emphasis> as of PHP 7.0.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-4-1-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function was
-<emphasis>DEPRECATED</emphasis> in PHP 4.1.0, and <emphasis>REMOVED</emphasis> as of PHP 7.0.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This function was
-<emphasis>DEPRECATED</emphasis> in PHP 5.3.0, and <emphasis>REMOVED</emphasis> as of PHP 7.0.0.</simpara></warning>'>
-
 <!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>This alias was
 <emphasis>DEPRECATED</emphasis> in PHP 5.3.0, and <emphasis>REMOVED</emphasis> as of PHP 7.0.0.</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-6-0.removed-7-0-0 '<warning
-xmlns="http://docbook.org/ns/docbook"><simpara>This feature was
-<emphasis>DEPRECATED</emphasis> in PHP 5.6.0, and
-<emphasis>REMOVED</emphasis> as of PHP 7.0.0.</simpara></warning>'>
-
 <!ENTITY warn.removed.function-7-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>This function was
 <emphasis>REMOVED</emphasis> in PHP 7.0.0.</simpara></warning>'>
@@ -519,81 +411,13 @@ warning. When using <function>fsockopen</function> to create an
 <literal>ssl://</literal> socket, the developer is responsible for detecting
 and suppressing this warning.</simpara></warning>'>
 
-<!ENTITY warn.undocumented.class '
-<warning xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  This class is currently undocumented; only a list of its properties and
-  methods is available.
- </simpara>
-</warning>
-'>
-
 <!ENTITY warn.undocumented.func '<warning xmlns="http://docbook.org/ns/docbook"><simpara>This function is
 currently not documented; only its argument list is available.
 </simpara></warning>'>
 
-
 <!-- Deprecation and removal warnings designed for use with a list of
      alternatives. See en/reference/regex/functions/ereg.xml and
      en/reference/regex/reference.xml for examples of these in action. -->
-
-<!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- This function was <emphasis>DEPRECATED</emphasis> in PHP 4.1.0, and
- <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Alternatives to this function include:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- This feature was <emphasis>DEPRECATED</emphasis> in PHP 5.3.0, and
- <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Alternatives to this feature include:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- This function was <emphasis>DEPRECATED</emphasis> in PHP 5.3.0, and
- <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Alternatives to this function include:
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- This function was <emphasis>DEPRECATED</emphasis> in PHP 5.5.0, and
- <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Alternatives to this function include:
-</simpara>
-'>
-
-<!ENTITY warn.removed.feature.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- This feature was <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Alternatives to this feature include:
-</simpara>
-'>
-
-<!ENTITY warn.removed.function.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- This function was <emphasis>REMOVED</emphasis> in PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Alternatives to this function include:
-</simpara>
-'>
 
 <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -628,8 +452,6 @@ is highly discouraged.</simpara></warning>
 
 <!ENTITY version.exists.asof 'This exists as of PHP '>
 
-<!ENTITY version.trunk.changelog 'Future'>
-
 <!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">This function has no parameters.</simpara>'>
 
 <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">The above example will output:</simpara>'>
@@ -637,9 +459,7 @@ is highly discouraged.</simpara></warning>
 <!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5:</simpara>'>
 
 <!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.3:</simpara>'>
-
 <!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.4:</simpara>'>
-
 <!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.5:</simpara>'>
 
 <!ENTITY example.outputs.56 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 5.6:</simpara>'>
@@ -649,8 +469,6 @@ is highly discouraged.</simpara></warning>
 <!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.0:</simpara>'>
 
 <!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.1:</simpara>'>
-
-<!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.2:</simpara>'>
 
 <!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 7.3:</simpara>'>
 
@@ -674,8 +492,6 @@ is highly discouraged.</simpara></warning>
 
 <!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.4 is similar to:</simpara>'>
 
-<!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.5:</simpara>'>
-
 <!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example in PHP 8.5 is similar to:</simpara>'>
 
 <!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above example on 32 bit machines:</simpara>'>
@@ -686,10 +502,6 @@ is highly discouraged.</simpara></warning>
 something similar to:</simpara>'>
 
 <!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">The above examples will output:</simpara>'>
-
-<!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above examples on 32 bit machines:</simpara>'>
-
-<!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Output of the above examples on 64 bit machines:</simpara>'>
 
 <!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">The above examples will output
 something similar to:</simpara>'>
@@ -812,11 +624,6 @@ deprecated alias may be used: '>
 <!ENTITY info.function.alias 'This function is an alias of: '>
 
 <!ENTITY info.method.alias 'This method is an alias of: '>
-
-<!ENTITY info.function.alias.deprecated '<simpara xmlns="http://docbook.org/ns/docbook">This function alias is
-deprecated and only exists for backwards compatibility reasons. The use of this
-function is not recommended, as it may be removed from PHP in the future.
-</simpara>'>
 
 <!ENTITY ext.windows.path.dll 'In order for this extension to work, there are
 <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> files that must be available to the Windows
@@ -944,19 +751,7 @@ function.</simpara></warning>'>
  </listitem>
 </varlistentry>'>
 
-<!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
- <term><parameter>key</parameter></term>
- <listitem>
-  <simpara>
-   See <link linkend="openssl.certparams">Public/Private Key parameters</link> for a list of valid values.
-  </simpara>
- </listitem>
-</varlistentry>'>
-
 <!-- Image (GD) Notes -->
-<!ENTITY note.config.t1lib '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is only available
-if PHP is compiled using <option role="configure">--with-t1lib[=DIR]</option>.
-</simpara></note>'>
 
 <!ENTITY note.freetype '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is only available if
 PHP is compiled with freetype support (<option role="configure">--with-freetype-dir=DIR</option>)
@@ -1106,10 +901,6 @@ $font = 'SomeFont';
     Used together with <function>imagesetinterpolation</function>, available as of PHP 5.5.0.
 </simpara>'>
 
-<!ENTITY gd.changlog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
-    <entry>7.0.0</entry><entry>T1Lib support was removed from PHP, thus this function was removed.</entry>
-</row>'>
-
 <!ENTITY gd.deprecated.gd-formats '<warning xmlns="http://docbook.org/ns/docbook"><simpara>The GD
 and GD2 image formats are proprietary image formats of libgd. They have to be regarded
 <emphasis>obsolete</emphasis>, and should only be used for development and testing
@@ -1132,12 +923,6 @@ purposes.</simpara></warning>'>
  <literal>"\\"</literal> so it is recommended to set it to the empty string explicitly.
  The default value will change in a future version of PHP, no earlier than PHP 9.0.
 </simpara></warning>'>
-
-<!-- DBM notes -->
-
-<!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>dbm_identifier</parameter></term><listitem><simpara>The DBM link identifier,
-returned by <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
@@ -1280,9 +1065,6 @@ returned by <function>dbmopen</function>.</simpara></listitem></varlistentry>'>
 <parameter>imap</parameter></term><listitem><simpara>An <classname>IMAP\Connection</classname> instance.</simpara></listitem></varlistentry>'>
 
 <!-- Deprecated -->
-<!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>imap</parameter></term><listitem><simpara>An IMAP stream returned by
-<function>imap_open</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Specifies where in the mailbox hierarchy
 to start searching.</simpara><simpara xmlns="http://docbook.org/ns/docbook">There are two special characters you can
@@ -1436,17 +1218,9 @@ encoding value will be used.</simpara>'>
 
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_ciphername</constant> constants, or the name of the algorithm as string.</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv '<simpara xmlns="http://docbook.org/ns/docbook">Used for the initialization in CBC, CFB, OFB modes, and in some algorithms in STREAM mode. If you do not supply an IV, while it is needed for an algorithm, the function issues a warning and uses an IV with all its bytes set to "<literal>\0</literal>".</simpara>'>
-
 <!ENTITY mcrypt.parameter.iv.strict '<simpara xmlns="http://docbook.org/ns/docbook">Used for the initialization in CBC, CFB, OFB modes, and in some algorithms in STREAM mode. If the provided IV size is not supported by the chaining mode or no IV was provided, but the chaining mode requires one, the function will emit a warning and return &false;.</simpara>'>
 
 <!ENTITY mcrypt.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">One of the <constant>MCRYPT_MODE_modename</constant> constants, or one of the following strings: "ecb", "cbc", "cfb", "ofb", "nofb" or "stream".</simpara>'>
-
- <!-- MCVE notes -->
-
-<!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>conn</parameter></term><listitem><simpara>An MCVE_CONN resource returned by
-<function>m_initengine</function>.</simpara></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
@@ -1552,8 +1326,6 @@ encoding value will be used.</simpara>'>
 
 <!ENTITY gearman.parameter.workload 'Serialized data to be processed'>
 
-<!ENTITY gearman.parameter.data 'Additional data that may be needed to complete the work'>
-
 <!ENTITY gearman.parameter.context 'Application context to associate with a task'>
 
 <!ENTITY gearman.parameter.unique 'A unique ID used to identify a particular task'>
@@ -1637,12 +1409,6 @@ Furthermore, these timezones may be removed from the IANA timezone database at a
  <literal>Australia/Perth</literal> for the above examples.
 </simpara>'>
 
-<!ENTITY date.timezone.abbrev-volatile '<simpara xmlns="http://docbook.org/ns/docbook">
-These timezone abbreviations have to be regarded as highly volatile, i.e. they
-might be different for each timezonedb release, and should not be relied upon.
-It is strongly recommended to avoid timezone abbreviations.
-</simpara>'>
-
 <!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
 Every call to a date/time function will generate a <constant>E_WARNING</constant>
 if the time zone is not valid. See also <function>date_default_timezone_set</function></simpara>'>
@@ -1650,7 +1416,6 @@ if the time zone is not valid. See also <function>date_default_timezone_set</fun
 <!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
 Now issues the <constant>E_STRICT</constant> and <constant>E_NOTICE</constant>
 time zone errors.</simpara></entry></row>'>
-
 <!ENTITY date.timestamp.description '
 <varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
 The optional <parameter>timestamp</parameter> parameter is an
@@ -1672,9 +1437,7 @@ The function modifies this object.</simpara></listitem></varlistentry>'>
 <parameter>object</parameter></term><listitem><simpara>Procedural style only: A <classname>DateTimeZone</classname> object
 returned by <function>timezone_open</function></simpara></listitem></varlistentry>'>
 
-<!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Returns the modified <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> object for method chaining&return.falseforfailure;.'>
 <!ENTITY date.datetime.return.modifiedobject 'Returns the modified <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> object for method chaining.'>
-<!ENTITY date.datetimeimmutable.return.modifiedobjectorfalseforfailure 'Returns a new <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> object with the modified data &return.falseforfailure;.'>
 <!ENTITY date.datetimeimmutable.return.modifiedobject 'Returns a new <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> object with the modified data.'>
 
 <!ENTITY date.timezone.dbversion 'This list is based upon the timezone database version'>
@@ -1690,7 +1453,6 @@ returned by <function>timezone_open</function></simpara></listitem></varlistentr
 <!ENTITY date.timezone.indian 'Indian'>
 <!ENTITY date.timezone.pacific 'Pacific'>
 <!ENTITY date.timezone.others 'Others'>
-<!ENTITY date.timezone.abbreviations 'Abbreviations'>
 
 <!ENTITY date.formats 'Valid formats are explained in <link xmlns="http://docbook.org/ns/docbook" linkend="datetime.formats">Date and Time Formats</link>.'>
 <!ENTITY date.formats.parameter 'A date/time string. &date.formats;'>
@@ -1758,12 +1520,9 @@ it is inserted with (e.g.) <function xmlns="http://docbook.org/ns/docbook">DOMNo
  </listitem>
 </itemizedlist>'>
 
-
-
 <!-- Dom Examples -->
 <!ENTITY dom.book.example '<simpara xmlns="http://docbook.org/ns/docbook">The following examples use <filename>book.xml</filename> which contains the following:</simpara>
 <programlisting role="xml" xmlns="http://docbook.org/ns/docbook">
-<!-- Warning: The CDATA markup here is a little tricky. Please DO NOT BREAK it! -->
 <![CDATA[
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE books [
@@ -1950,9 +1709,6 @@ that is typically created using <function>fopen</function>.</simpara>'>
 <function>gnupg_init</function> or <classname>gnupg</classname>.</simpara>'>
 
 <!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">The fingerprint key.</simpara>'>
-
-<!-- HaruDoc -->
-<!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Throws a <classname>HaruException</classname> on error.</simpara>'>
 
 <!-- ODBC -->
 <!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">The ODBC connection object,
@@ -2148,7 +1904,6 @@ increasing <link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link
 or using <function>oci_set_prefetch</function>.
 </simpara>'>
 
-
 <!ENTITY oci.arg.statement.id
 "<simpara xmlns='http://docbook.org/ns/docbook'>A valid OCI8 statement
 identifier created by <function>oci_parse</function> and executed
@@ -2168,7 +1923,6 @@ pdf by either Acrobat Distiller™ or Ghostview.</simpara>'>
 <!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function is affected by <link
 linkend="ini.open-basedir">open_basedir</link>.</simpara></note>'>
 
-
 <!ENTITY note.language-construct '<note xmlns="http://docbook.org/ns/docbook"><simpara>Because this is a
 language construct and not a function, it cannot be called using
 <link linkend="functions.variable-functions">variable functions</link>,
@@ -2186,8 +1940,6 @@ functions; they are part of the PHP core.</simpara>'>
 <!-- Used in every chapter that has directive descriptions -->
 <!ENTITY ini.descriptions.title '<simpara xmlns="http://docbook.org/ns/docbook">Here&apos;s a short explanation of
 the configuration directives.</simpara>'>
-
-<!-- Common pieces for reference part BEGIN-->
 
 <!-- Used in reference/$extname/ini.xml -->
 <!ENTITY extension.runtime '<simpara xmlns="http://docbook.org/ns/docbook">
@@ -2207,13 +1959,6 @@ been compiled into PHP or dynamically loaded at runtime.
 <!-- For STANDARD Constants used in reference/$extname/constants.xml -->
 <!ENTITY extension.constants.core '<simpara xmlns="http://docbook.org/ns/docbook">
 The constants below are always available as part of the PHP core.
-</simpara>'>
-
-<!-- Used in reference/$extname/classes.xml -->
-<!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook">
-The classes below are defined by this extension, and
-will only be available when the extension has either
-been compiled into PHP or dynamically loaded at runtime.
 </simpara>'>
 
 <!-- PDO entities -->
@@ -2242,8 +1987,6 @@ is set to <constant>PDO::ERRMODE_EXCEPTION</constant>.
 <!-- PECL entities -->
 <!ENTITY pecl.moved 'This &link.pecl; extension is not bundled with PHP.'>
 
-<!ENTITY pecl.bundled 'This &link.pecl; extension is bundled with PHP.'>
-
 <!ENTITY pecl.info 'Information for installing this PECL extension may be
 found in the manual chapter titled <link xmlns="http://docbook.org/ns/docbook" linkend="install.pecl">Installation
 of PECL extensions</link>. Additional information such as new releases,
@@ -2265,8 +2008,6 @@ section.'>
 
 <!ENTITY pecl.windows.download.avail 'Windows binaries (<acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> files)
 for this <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> extension are available from the PECL website.'>
-
-<!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
 
 <!ENTITY pecl.moved-ver 'This extension has been moved to the &link.pecl;
 repository and is no longer bundled with PHP as of PHP '>
@@ -2346,13 +2087,11 @@ while <constant>PGSQL_BOTH</constant> will return both numerical and associative
 
 <!-- Common pieces for reference part END -->
 
-
 <!ENTITY windows.builtin '<simpara xmlns="http://docbook.org/ns/docbook">The Windows version of PHP has built-in
 support for this extension. You do not need to load any additional
 extensions in order to use these functions.</simpara>'>
 
 <!-- These are here as helpers for manual consistency and brievety-->
-<!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">safe mode</link>'>
 
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">SQL safe mode</link>'>
 
@@ -2444,36 +2183,6 @@ a primary PHP FastCGI implementation containing some features (mostly) useful fo
 iterative properties to most methods. They cannot be viewed using <function>var_dump</function>
 or anything else which can examine objects.</simpara></note>'>
 
-<!-- SQLite Notes -->
-<!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">The column names returned by
-<constant>SQLITE_ASSOC</constant> and <constant>SQLITE_BOTH</constant> will be
-case-folded according to the value of the
-<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link> configuration
-option.</simpara>'>
-
-<!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">When the <parameter>decode_binary</parameter>
-parameter is set to &true; (the default), PHP will decode the binary encoding
-it applied to the data if it was encoded using the
-<function>sqlite_escape_string</function>.  You should normally leave this
-value at its default, unless you are interoperating with databases created by
-other sqlite capable applications.</simpara>'>
-
-<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function cannot be used with
-unbuffered result handles.</simpara></note>'>
-
-<!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Two alternative syntaxes are
-supported for compatibility with other database extensions (such as MySQL).
-The preferred form is the first, where the <parameter>dbhandle</parameter>
-parameter is the first parameter to the function.</simpara></note>'>
-
-<!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">The optional <parameter>result_type</parameter>
-parameter accepts a constant and determines how the returned array will be
-indexed. Using <constant>SQLITE_ASSOC</constant> will return only associative
-indices (named fields) while <constant>SQLITE_NUM</constant> will return
-only numerical indices (ordinal field numbers). <constant>SQLITE_BOTH</constant>
-will return both associative and numerical indices.
-<constant>SQLITE_BOTH</constant> is the default for this function.</simpara>'>
-
 <!-- Database Notes -->
 <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Field names returned by this function
 are <emphasis>case-sensitive</emphasis>.</simpara></note>'>
@@ -2481,7 +2190,6 @@ are <emphasis>case-sensitive</emphasis>.</simpara></note>'>
 <!ENTITY database.fetch-null '<note xmlns="http://docbook.org/ns/docbook"><simpara>This function sets NULL fields to
 the PHP &null; value.</simpara></note>'>
 
-<!-- MySQL Notes -->
 <!-- The mysql.*.description entities are used in the parameters refsect1 -->
 <!ENTITY mysql.linkid.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
 <parameter>link_identifier</parameter></term><listitem><simpara>The MySQL connection. If the
@@ -2534,12 +2242,6 @@ Instead, use either the actively developed <link linkend="book.mysqli">MySQLi</l
 See also the <link linkend="mysqlinfo.api.choosing">MySQL: choosing an API</link> guide.
 Alternatives to this function include:</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">This function was deprecated in PHP 5.5.0, and it
-and the entire <link linkend="book.mysql">original MySQL extension</link> was removed in PHP 7.0.0.
-Instead, use either the actively developed <link linkend="book.mysqli">MySQLi</link> or <link linkend="ref.pdo-mysql">PDO_MySQL</link> extensions.
-See also the <link linkend="mysqlinfo.api.choosing">MySQL: choosing an API</link> guide.
-Alternatives to this function include:</simpara>'>
-
 <!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
 Open non-persistent MySQL connections and result sets are automatically destroyed when a
 PHP script finishes its execution. So, while explicitly closing open
@@ -2562,21 +2264,6 @@ brackets—for example, <literal>tcp://[fe80::1]:80</literal>.</simpara></note>'
 
 <!-- Notes for tidy -->
 <!ENTITY tidy.object 'The <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname> object.'>
-
-<!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">The <parameter>config</parameter> parameter
-can be passed either as an array or as a string. If a string is passed,
-it is interpreted as the name of the configuration file, otherwise, it is
-interpreted as the options themselves. Check
-<link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.tidy.conf;">&url.tidy.conf;</link>
-for an explanation about each option.</simpara><simpara>The
-<parameter>encoding</parameter> parameter sets the encoding for input/output
-documents. The possible values for <parameter>encoding</parameter> are:
-<literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
-<literal>raw</literal>, <literal>utf8</literal>, <literal>iso2022</literal>,
-<literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
-<literal>utf16</literal>, <literal>utf16le</literal>,
-<literal>utf16be</literal>, <literal>big5</literal> and
-<literal>shiftjis</literal>.</simpara>'>
 
 <!-- Snippets for the installation section -->
 <!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>We do not recommend using a
@@ -2690,9 +2377,6 @@ The <classname>XMLWriter</classname> instance that is being modified. This objec
 <!-- Imagick generic return types -->
 <!ENTITY imagick.return.success 'Returns &true; on success.'>
 <!ENTITY imagick.imagick.throws 'Throws ImagickException on error.'>
-<!ENTITY imagick.imagickdraw.throws 'Throws ImagickDrawException on error.'>
-<!ENTITY imagick.imagickpixel.throws 'Throws ImagickPixelException on error.'>
-<!ENTITY imagick.imagickpixeliterator.throws 'Throws ImagickPixelIteratorException on error.'>
 
 <!-- Imagick version infos -->
 <!ENTITY imagick.method.available.0x629 'This method is available if Imagick has been compiled against ImageMagick version 6.2.9 or newer.'>
@@ -2703,14 +2387,10 @@ The <classname>XMLWriter</classname> instance that is being modified. This objec
 <!ENTITY imagick.method.available.0x638 'This method is available if Imagick has been compiled against ImageMagick version 6.3.8 or newer.'>
 <!ENTITY imagick.method.available.0x639 'This method is available if Imagick has been compiled against ImageMagick version 6.3.9 or newer.'>
 <!ENTITY imagick.method.available.0x640 'This method is available if Imagick has been compiled against ImageMagick version 6.4.0 or newer.'>
-<!ENTITY imagick.method.available.0x641 'This method is available if Imagick has been compiled against ImageMagick version 6.4.1 or newer.'>
-<!ENTITY imagick.method.available.0x642 'This method is available if Imagick has been compiled against ImageMagick version 6.4.2 or newer.'>
-<!ENTITY imagick.method.available.0x643 'This method is available if Imagick has been compiled against ImageMagick version 6.4.3 or newer.'>
 <!ENTITY imagick.method.available.0x644 'This method is available if Imagick has been compiled against ImageMagick version 6.4.4 or newer.'>
 <!ENTITY imagick.method.available.0x645 'This method is available if Imagick has been compiled against ImageMagick version 6.4.5 or newer.'>
 <!ENTITY imagick.method.available.0x647 'This method is available if Imagick has been compiled against ImageMagick version 6.4.7 or newer.'>
 <!ENTITY imagick.method.available.0x649 'This method is available if Imagick has been compiled against ImageMagick version 6.4.9 or newer.'>
-<!ENTITY imagick.method.available.0x653 'This method is available if Imagick has been compiled against ImageMagick version 6.5.3 or newer.'>
 <!ENTITY imagick.method.available.0x657 'This method is available if Imagick has been compiled against ImageMagick version 6.5.7 or newer.'>
 
 <!ENTITY imagick.method.not.available.0x700 'This method is not available if Imagick has been compiled against ImageMagick version 7.0.0 or newer.'>
@@ -2831,7 +2511,6 @@ property is updated if a valid context is passed to the caller function.</simpar
 <!ENTITY stream.bucket.return 'This function returns a <classname>StreamBucket</classname> instance now; previously, an <classname>stdClass</classname> was returned.'>
 
 <!-- Gmagick -->
-<!ENTITY gmagick.return.success 'Returns &true; on success.'>
 <!ENTITY gmagick.gmagickexception.throw 'Throws an
 <classname xmlns="http://docbook.org/ns/docbook">GmagickException</classname> on error.'>
 
@@ -2881,7 +2560,6 @@ to be references, then they must be references in the passed argument list.'>
 
 <!-- Win32Service -->
 <!ENTITY win32service.false.error ', &false; if there is a problem with the parameters or a <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">Win32 Error Code</link> on failure.'>
-<!ENTITY win32service.success.false.error 'Returns &true; on success&win32service.false.error;'>
 <!ENTITY win32service.noerror.false.error 'returned <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> on success&win32service.false.error;'>
 
 <!-- SNMP -->
@@ -3026,7 +2704,6 @@ paths</simpara></warning>
 <!ENTITY trader.arg.fast.ma.type 'Type of Moving Average for fast MA. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.slow.ma.type 'Type of Moving Average for slow MA. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.fastd.ma.type 'Type of Moving Average for Fast-D. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
-<!ENTITY trader.arg.fastk.ma.type 'Type of Moving Average for Fast-K. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.slowd.ma.type 'Type of Moving Average for Slow-D. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.slowk.ma.type 'Type of Moving Average for Slow-K. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
 <!ENTITY trader.arg.signal.ma.type 'Type of Moving Average for signal line. <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> series of constants should be used.'>
@@ -3734,7 +3411,6 @@ local: {
 <!ENTITY mongodb.throws.unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Throws <classname>MongoDB\Driver\Exception\LogicException</classname> if the write was not acknowledged.</member>'>
 
 <!-- Not used in EN anymore -->
-<!ENTITY mongodb.note.queryable-encryption-preview ''>
 
 <!ENTITY mongodb.note.decimal128 '
    <note xmlns="http://docbook.org/ns/docbook">
@@ -4455,18 +4131,6 @@ local: {
  </entry>
 </row>'>
 
-<!ENTITY strings.changelog.encoding '
- <row xmlns="http://docbook.org/ns/docbook">
-  <entry>5.6.0</entry>
-  <entry>
-   The default value for the <parameter>encoding</parameter> parameter was
-   changed to be the value of the
-   <link linkend="ini.default-charset">default_charset</link> configuration
-   option.
-  </entry>
- </row>
-'>
-
 <!ENTITY strings.changelog.ascii-case-conversion '
  <row xmlns="http://docbook.org/ns/docbook">
   <entry>8.2.0</entry>
@@ -4634,30 +4298,6 @@ local: {
    No particular meaning can be reliably inferred from the value aside
    from its sign.
   </simpara>
-'>
-
-<!-- filter snippets -->
-<!-- TODO: Remove -->
-<!ENTITY filter.param.filter '
- <varlistentry xmlns="http://docbook.org/ns/docbook">
-  <term><parameter>filter</parameter></term>
-  <listitem>
-   <simpara>
-    The filter to apply.
-    Can be a validation filter by using one of the
-    <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>
-    constants, a sanitization filter by using one of the
-    <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant>
-    or <constant>FILTER_UNSAFE_RAW</constant>, or a custom filter by using
-    <constant>FILTER_CALLBACK</constant>.
-   </simpara>
-   <simpara>
-    The default is <constant>FILTER_DEFAULT</constant>,
-    which is an alias of <constant>FILTER_UNSAFE_RAW</constant>.
-    This will result in no filtering taking place by default.
-   </simpara>
-  </listitem>
- </varlistentry>
 '>
 
 <!-- csprng snippets -->


### PR DESCRIPTION
Auditing `language-snippets.ent` surfaced unused entity declarations that are not referenced anywhere, directly or transitively: deprecation banners for old PHP cycles, snippets for removed extensions (mcrypt, sqlite, t1lib, safemode, ...) and stale helpers.

This removes the 72 that no translation references either. The 11 entities still referenced by some translations are split into a separate PR.

Pure cleanup, no rendered output changes.