### PR TITLE
pdo_pgsql: document 8.5 deprecations, add examples, fix inconsistencies

### DIFF
--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -247,7 +247,7 @@
    </simpara>
 
    <simpara>
-    A new <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>
+    A new <constant>Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</constant>
     has been added to retrieve the memory usage of query results with
     <methodname>PDO::getAttribute</methodname> for drivers that support it.
    </simpara>
@@ -324,7 +324,7 @@
 
    <simpara>
     Support retrieving the memory usage of queries for
-    <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>.
+    <constant>Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</constant>.
    </simpara>
 
    <simpara>

--- a/reference/pdo_pgsql/constants.xml
+++ b/reference/pdo_pgsql/constants.xml
@@ -12,6 +12,67 @@
    <listitem>
     <simpara>
      &Alias; <constant>Pdo\Pgsql::ATTR_DISABLE_PREPARES</constant>.
+     As of PHP 8.5.0, this constant is deprecated.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-idle">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_IDLE</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalent to <constant>Pdo\Pgsql::TRANSACTION_IDLE</constant>.
+     As of PHP 8.5.0, this constant is deprecated, as it has no effect.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-active">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_ACTIVE</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalent to <constant>Pdo\Pgsql::TRANSACTION_ACTIVE</constant>.
+     As of PHP 8.5.0, this constant is deprecated, as it has no effect.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-intrans">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_INTRANS</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalent to <constant>Pdo\Pgsql::TRANSACTION_INTRANS</constant>.
+     As of PHP 8.5.0, this constant is deprecated, as it has no effect.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-inerror">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_INERROR</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalent to <constant>Pdo\Pgsql::TRANSACTION_INERROR</constant>.
+     As of PHP 8.5.0, this constant is deprecated, as it has no effect.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-unknown">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_UNKNOWN</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Equivalent to <constant>Pdo\Pgsql::TRANSACTION_UNKNOWN</constant>.
+     As of PHP 8.5.0, this constant is deprecated, as it has no effect.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-pgsql" role="class">
+<reference xml:id="class.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" role="class">
  <title>The Pdo\Pgsql class</title>
  <titleabbrev>Pdo\Pgsql</titleabbrev>
 

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -158,36 +158,51 @@
     <varlistentry xml:id="pdo-pgsql.constants.transaction-idle">
      <term><constant>Pdo\Pgsql::TRANSACTION_IDLE</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        This constant has no effect, and is deprecated as of PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-active">
      <term><constant>Pdo\Pgsql::TRANSACTION_ACTIVE</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        This constant has no effect, and is deprecated as of PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-intrans">
      <term><constant>Pdo\Pgsql::TRANSACTION_INTRANS</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        This constant has no effect, and is deprecated as of PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-inerror">
      <term><constant>Pdo\Pgsql::TRANSACTION_INERROR</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        This constant has no effect, and is deprecated as of PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-unknown">
      <term><constant>Pdo\Pgsql::TRANSACTION_UNKNOWN</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        This constant has no effect, and is deprecated as of PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
@@ -77,40 +77,68 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
- <refsect1 role="errors">
-  &reftitle.errors;
-  <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
-  </simpara>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>rows</parameter> now also accepts a
+       <classname>Traversable</classname>; previously only an
+       <type>array</type> was accepted.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
- -->
 
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.copyfromarray.example.basic">
    <title><methodname>Pdo\Pgsql::copyFromArray</methodname> example</title>
    <simpara>
-    Description.
+    Each element of <parameter>rows</parameter> is one record whose fields are
+    joined by <parameter>separator</parameter> (a tab by default).
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+
+$rows = [
+    "1\tapple\t10",
+    "2\tbanana\t20",
+    "3\tcherry\t30",
+];
+$db->copyFromArray('fruits', $rows);
+
+foreach ($db->query('SELECT * FROM fruits ORDER BY id') as $row) {
+    echo "{$row['id']} {$row['name']} {$row['qty']}\n";
+}
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Code example
+1 apple 10
+2 banana 20
+3 cherry 30
 ]]>
    </screen>
   </example>
  </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
@@ -55,40 +55,47 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
+   If <parameter>filename</parameter> cannot be opened for reading, the failure
+   is reported through the connection's error handling
+   (see <constant>PDO::ATTR_ERRMODE</constant>); with
+   <constant>PDO::ERRMODE_EXCEPTION</constant> a
+   <exceptionname>PDOException</exceptionname> is thrown.
   </simpara>
  </refsect1>
- -->
 
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.copyfromfile.example.basic">
    <title><methodname>Pdo\Pgsql::copyFromFile</methodname> example</title>
    <simpara>
-    Description.
+    The file holds one record per line, with fields joined by
+    <parameter>separator</parameter> (a tab by default).
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+
+file_put_contents('/tmp/fruits.tsv', "1\tapple\t10\n2\tbanana\t20\n");
+$db->copyFromFile('fruits', '/tmp/fruits.tsv');
+
+echo $db->query('SELECT count(*) FROM fruits')->fetchColumn(), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Code example
+2
 ]]>
    </screen>
   </example>
  </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
@@ -49,40 +49,40 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
- <refsect1 role="errors">
-  &reftitle.errors;
-  <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
-  </simpara>
- </refsect1>
- -->
-
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.copytoarray.example.basic">
    <title><methodname>Pdo\Pgsql::copyToArray</methodname> example</title>
    <simpara>
-    Description.
+    Each returned element is one record, with fields joined by
+    <parameter>separator</parameter> and a trailing newline.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+$db->exec("INSERT INTO fruits VALUES (1, 'apple', 10), (2, 'banana', 20)");
+
+$rows = $db->copyToArray('fruits');
+var_export($rows);
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Code example
+array (
+  0 => '1	apple	10
+',
+  1 => '2	banana	20
+',
+)
 ]]>
    </screen>
   </example>
  </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
@@ -46,7 +46,7 @@
     <term><parameter>fields</parameter></term>
     <listitem>
      <simpara>
-      List of fields to insert.
+      List of fields to export.
      </simpara>
     </listitem>
    </varlistentry>
@@ -60,49 +60,47 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
+   If <parameter>filename</parameter> cannot be opened for writing, or cannot be
+   written to, the failure is reported through the connection's error handling
+   (see <constant>PDO::ATTR_ERRMODE</constant>); with
+   <constant>PDO::ERRMODE_EXCEPTION</constant> a
+   <exceptionname>PDOException</exceptionname> is thrown.
   </simpara>
  </refsect1>
- -->
 
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.copytofile.example.basic">
    <title><methodname>Pdo\Pgsql::copyToFile</methodname> example</title>
    <simpara>
-    Description.
+    The table is written to <parameter>filename</parameter>, one record per
+    line, with fields joined by <parameter>separator</parameter>.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+$db->exec("INSERT INTO fruits VALUES (1, 'apple', 10), (2, 'banana', 20)");
+
+$db->copyToFile('fruits', '/tmp/fruits.tsv');
+echo file_get_contents('/tmp/fruits.tsv');
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Code example
+1	apple	10
+2	banana	20
 ]]>
    </screen>
   </example>
  </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <simpara>
-    Any notes that don't fit anywhere else should go here.
-   </simpara>
-  </note>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/getnotify.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/getnotify.xml
@@ -49,9 +49,13 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   If one or more notifications is pending, returns a single row,
-   with fields <literal>message</literal> and <literal>pid</literal>,
-   otherwise returns &false;.
+   If a notification is pending, returns a single row, otherwise returns
+   &false;. The row has a <literal>message</literal> field (the channel name)
+   and a <literal>pid</literal> field (the process ID of the notifying backend).
+   If the notification carries a non-empty payload, the row also has a
+   <literal>payload</literal> field. With <constant>PDO::FETCH_NUM</constant>,
+   these fields are at indexes <literal>0</literal>, <literal>1</literal>, and
+   <literal>2</literal>.
   </simpara>
  </refsect1>
 
@@ -75,30 +79,40 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.getnotify.example.basic">
    <title><methodname>Pdo\Pgsql::getNotify</methodname> example</title>
    <simpara>
-    Description.
+    Subscribe to a channel with <literal>LISTEN</literal>, then read the next
+    pending notification with a one-second timeout.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$db->exec('LISTEN messages');
+$db->exec("NOTIFY messages, 'hello'");
+
+$notification = $db->getNotify(PDO::FETCH_ASSOC, 1000);
+var_export($notification);
 ?>
 ]]>
    </programlisting>
-   &example.outputs;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
-Code example
+array (
+  'message' => 'messages',
+  'pid' => 1928,
+  'payload' => 'hello',
+)
 ]]>
    </screen>
   </example>
  </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/getpid.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/getpid.xml
@@ -29,6 +29,34 @@
    Returns the PID as an <type>int</type>.
   </simpara>
  </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-pgsql.getpid.example.basic">
+   <title><methodname>Pdo\Pgsql::getPid</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+echo $db->getPid();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+12345
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_get_pid</function></member>
+  </simplelist>
+ </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
@@ -39,8 +39,11 @@
     <term><parameter>mode</parameter></term>
     <listitem>
      <simpara>
-      If mode is <literal>r</literal>, open the stream for reading.
-      If mode is <literal>w</literal>, open the stream for writing.
+      The access mode. If <parameter>mode</parameter> contains
+      <literal>w</literal> or <literal>+</literal>, the stream is opened for
+      reading and writing; otherwise it is opened for reading only. A
+      <literal>b</literal> (binary) flag has no effect. The default
+      <literal>"rb"</literal> opens the stream for reading.
      </simpara>
     </listitem>
    </varlistentry>
@@ -70,10 +73,10 @@ $db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->beginTransaction();
 $stmt = $db->prepare("SELECT oid FROM BLOBS WHERE ident = ?");
-$stmt->execute(array($some_id));
+$stmt->execute([$some_id]);
 $stmt->bindColumn('oid', $oid, PDO::PARAM_STR);
 $stmt->fetch(PDO::FETCH_BOUND);
-$stream = $db->pgsqlLOBOpen($oid, 'r');
+$stream = $db->lobOpen($oid, 'r');
 header("Content-type: application/octet-stream");
 fpassthru($stream);
 ?>

--- a/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
@@ -45,20 +45,20 @@
   <example xml:id="pdo-pgsql.lobunlink.example.basic">
    <title><methodname>Pdo\Pgsql::lobUnlink</methodname> example</title>
    <simpara>
-    This example unlinks a large object from the database prior to deleting
-    the row that references it from the blobs table are used in the examples of
+    This example unlinks a large object from the database before deleting the
+    row that references it. It uses the blobs table from the
     <methodname>Pdo\Pgsql::lobCreate</methodname> and
-    <methodname>Pdo\Pgsql::lobOpen</methodname>.
+    <methodname>Pdo\Pgsql::lobOpen</methodname> examples.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-$db = new PDO('pgsql:dbname=test host=localhost', $user, $pass);
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->beginTransaction();
-$db->pgsqlLOBUnlink($oid);
+$db->lobUnlink($oid);
 $stmt = $db->prepare("DELETE FROM BLOBS where ident = ?");
-$stmt->execute(array($some_id));
+$stmt->execute([$some_id]);
 $db->commit();
 ?>
 ]]>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
@@ -7,12 +7,17 @@
    &Alias; <methodname>Pdo\Pgsql::copyFromArray</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyFromArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
-   <methodparam><type>array</type><parameter>rows</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>Traversable</type></type><parameter>rows</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>nullAs</parameter><initializer>"\\\\N"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>fields</parameter><initializer>&null;</initializer></methodparam>
@@ -20,6 +25,30 @@
   <simpara>
    &info.method.alias; <methodname>Pdo\Pgsql::copyFromArray</methodname>.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The <parameter>rows</parameter> parameter now also accepts a
+       <classname>Traversable</classname>; previously only an
+       <type>array</type> was accepted.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyFromFile</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyFromFile</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyToArray</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>PDO::pgsqlCopyToArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyToFile</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyToFile</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::getNotify</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>PDO::pgsqlGetNotify</methodname>
    <methodparam choice="opt"><type>int</type><parameter>fetchMode</parameter><initializer>PDO::FETCH_DEFAULT</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>timeoutMilliseconds</parameter><initializer>0</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetPid.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetPid.xml
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::getPid</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>int</type><methodname>PDO::pgsqlGetPid</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBCreate.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBCreate.xml
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobCreate</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>string</type><methodname>PDO::pgsqlLOBCreate</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBOpen.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBOpen.xml
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobOpen</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>PDO::pgsqlLOBOpen</methodname>
    <methodparam><type>string</type><parameter>oid</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>mode</parameter><initializer>"rb"</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBUnlink.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBUnlink.xml
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobUnlink</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlLOBUnlink</methodname>
    <methodparam><type>string</type><parameter>oid</parameter></methodparam>
   </methodsynopsis>

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -18,10 +18,10 @@
 
    <section xml:id="ref.pdo-pgsql.resources">
     &reftitle.resources;
-    <para>
+    <simpara>
      This extension defines a stream resource returned by
      <methodname>Pdo\Pgsql::lobOpen</methodname>.
-    </para>
+    </simpara>
    </section>
 
    &reference.pdo-pgsql.configure;
@@ -30,11 +30,11 @@
    <section xml:id="ref.pdo-pgsql.general-notes">
     <title>General notes</title>
     <note>
-     <para>
+     <simpara>
       <literal>bytea</literal> columns are returned as stream resources. See
       <link linkend="pdo.lobs">Large Objects (LOBs)</link> for how to read these
       values and how to bind data with <constant>PDO::PARAM_LOB</constant>.
-     </para>
+     </simpara>
     </note>
    </section>
 
@@ -106,7 +106,7 @@
       <varlistentry>
        <term><literal>sslmode</literal></term>
        <listitem>
-        <para>
+        <simpara>
          The SSL mode. Accepted values are <literal>disable</literal>,
          <literal>allow</literal>, <literal>prefer</literal>,
          <literal>require</literal>, <literal>verify-ca</literal>, and
@@ -114,7 +114,7 @@
          <link xlink:href="&url.pgsql.manual;">PostgreSQL Documentation</link>.
          Many hosted PostgreSQL services require an encrypted connection, so
          <literal>require</literal> or stricter is needed to connect to them.
-        </para>
+        </simpara>
        </listitem>
       </varlistentry>
 

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -20,7 +20,7 @@
     &reftitle.resources;
     <para>
      This extension defines a stream resource returned by
-     <function>PDO::pgsqlLOBOpen</function>.
+     <methodname>Pdo\Pgsql::lobOpen</methodname>.
     </para>
    </section>
 
@@ -31,7 +31,9 @@
     <title>General notes</title>
     <note>
      <para>
-      <literal>bytea</literal> fields are returned as streams.
+      <literal>bytea</literal> columns are returned as stream resources. See
+      <link linkend="pdo.lobs">Large Objects (LOBs)</link> for how to read these
+      values and how to bind data with <constant>PDO::PARAM_LOB</constant>.
      </para>
     </note>
    </section>
@@ -105,8 +107,13 @@
        <term><literal>sslmode</literal></term>
        <listitem>
         <para>
-         The SSL mode. Supported values and their meaning are listed in the
+         The SSL mode. Accepted values are <literal>disable</literal>,
+         <literal>allow</literal>, <literal>prefer</literal>,
+         <literal>require</literal>, <literal>verify-ca</literal>, and
+         <literal>verify-full</literal>; their meaning is described in the
          <link xlink:href="&url.pgsql.manual;">PostgreSQL Documentation</link>.
+         Many hosted PostgreSQL services require an encrypted connection, so
+         <literal>require</literal> or stricter is needed to connect to them.
         </para>
        </listitem>
       </varlistentry>


### PR DESCRIPTION
Deprecate legacy methods and constants (8.5), add tested examples, and fill in missing details.