### PR TITLE
doc: clarify unary-vs-instanceof precedence and assignment binding inside prefix operators

### DIFF
--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -300,6 +300,18 @@
    </tgroup>
   </table>
  </para>
+ <note>
+  <simpara>
+   The unary operators sharing the row with the cast operators
+   (<literal>~</literal>, <literal>@</literal>, and unary
+   <literal>+</literal>/<literal>-</literal>) bind more tightly than
+   <literal>instanceof</literal>, whereas <literal>!</literal> binds less
+   tightly. Consequently <literal>(int) $x instanceof Foo</literal> is grouped
+   as <literal>((int) $x) instanceof Foo</literal>, while
+   <literal>!$x instanceof Foo</literal> is grouped as
+   <literal>!($x instanceof Foo)</literal>.
+  </simpara>
+ </note>
  <para>
   <example>
    <title>Associativity</title>
@@ -420,6 +432,15 @@ x minus one equals 3, or so I hope
    in which case the return value of <literal>foo()</literal> is
    put into <varname>$a</varname>.
   </para>
+  <simpara>
+   This is possible because the left-hand side of an assignment must be a
+   variable, so the assignment is grouped with that variable rather than with
+   the surrounding higher-precedence prefix operator. The same applies to the
+   other prefix operators that take an expression operand, such as
+   <literal>clone</literal>, the cast operators, <literal>@</literal> and
+   <literal>~</literal>: for instance <literal>clone $a = $b</literal> is grouped
+   as <literal>clone ($a = $b)</literal>, not <literal>(clone $a) = $b</literal>.
+  </simpara>
  </note>
  <sect2 role="changelog">
   &reftitle.changelog;


### PR DESCRIPTION
This keeps coming back to bite me ever now and then :)

Ref: https://github.com/carthage-software/mago/commit/4d01d2d2f5f09e0c0a30364d43f50dc3e565d346