### PR TITLE
pdo_pgsql: document ATTR_PREFETCH lazy fetch, fix copyFromArray sig

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -251,6 +251,13 @@
       setting of the prefetch size.  A larger prefetch size results in
       increased performance at the cost of higher memory usage.
      </simpara>
+     <simpara>
+      The PDO_PGSQL driver instead treats this attribute as a toggle: as of
+      PHP 8.5.0, a value of <literal>0</literal> enables lazy (single-row)
+      fetching. See
+      <link linkend="pdo-pgsql.constants.attr-prefetch"><constant>PDO::ATTR_PREFETCH</constant></link>
+      in the PDO_PGSQL driver.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="pdo.constants.attr-timeout">

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -254,9 +254,9 @@
      <simpara>
       The PDO_PGSQL driver instead treats this attribute as a toggle: as of
       PHP 8.5.0, a value of <literal>0</literal> enables lazy (single-row)
-      fetching. See
-      <link linkend="pdo-pgsql.constants.attr-prefetch"><constant>PDO::ATTR_PREFETCH</constant></link>
-      in the PDO_PGSQL driver.
+      fetching; see the
+      <link linkend="pdo-pgsql.constants.attr-prefetch">PDO_PGSQL driver docs</link>
+      for details.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -155,6 +155,32 @@
       </simpara>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="pdo-pgsql.constants.attr-prefetch">
+     <term><constant>PDO::ATTR_PREFETCH</constant></term>
+     <listitem>
+      <simpara>
+       As of PHP 8.5.0, setting this attribute to <literal>0</literal> enables
+       lazy (single-row) fetching: rows are retrieved from the server one at a
+       time as they are fetched, instead of buffering the whole result set in
+       memory before the first <methodname>PDOStatement::fetch</methodname>
+       call. This reduces memory usage for large result sets. Any other value
+       keeps the default buffered behavior.
+      </simpara>
+      <simpara>
+       It can be set per connection with
+       <methodname>PDO::setAttribute</methodname>, or per statement via
+       the <methodname>PDO::prepare</methodname> or
+       <methodname>PDO::query</methodname> driver options.
+      </simpara>
+      <caution>
+       <simpara>
+        In lazy mode, a connection can have only one active statement at a
+        time. Running another statement silently discards any unread rows of
+        the previous one; no error is raised.
+       </simpara>
+      </caution>
+     </listitem>
+    </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-idle">
      <term><constant>Pdo\Pgsql::TRANSACTION_IDLE</constant></term>
      <listitem>

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
@@ -38,7 +38,9 @@
     <listitem>
      <simpara>
       An indexed <type>array</type> of <type>string</type>s with fields
-      separated by <parameter>separator</parameter>.
+An indexed <type>array</type> (or <type>Traversable</type>) of
+<type>string</type>s with fields separated by
+<parameter>separator</parameter>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
@@ -10,7 +10,7 @@
   <methodsynopsis role="Pdo\\Pgsql">
    <modifier>public</modifier> <type>bool</type><methodname>Pdo\Pgsql::copyFromArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
-   <methodparam><type>array</type><parameter>rows</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>Traversable</type></type><parameter>rows</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>nullAs</parameter><initializer>"\\\\N"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>fields</parameter><initializer>&null;</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
@@ -37,10 +37,9 @@
     <term><parameter>rows</parameter></term>
     <listitem>
      <simpara>
-      An indexed <type>array</type> of <type>string</type>s with fields
-An indexed <type>array</type> (or <type>Traversable</type>) of
-<type>string</type>s with fields separated by
-<parameter>separator</parameter>.
+      An indexed <type>array</type> (or <type>Traversable</type>) of
+      <type>string</type>s with fields separated by
+      <parameter>separator</parameter>.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Document the PHP 8.5 lazy (single-row) fetch mode: add a `PDO::ATTR_PREFETCH` entry to the PDO_PGSQL constants describing the =0 toggle, its connection vs per-statement scope, and the single-active-statement caveat. Note the driver-specific behavior on the generic PDO::ATTR_PREFETCH entry.

Update `Pdo\Pgsql::copyFromArray`'s rows parameter to `array|Traversable` in the synopsis, matching the changelog entry already added in #5626 and closes tasks noted in the https://github.com/orgs/php/projects/13/views

Behavior verified against PostgreSQL on PHP 8.5.7.