### PR TITLE
Fix codespell typos in actively maintained PECL extensions

### DIFF
--- a/reference/gearman/gearmantask/create.xml
+++ b/reference/gearman/gearmantask/create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmantask.create">
+<refentry xml:id="gearmantask.create" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>GearmanTask::create</refname>
   <refpurpose>Create a task (deprecated)</refpurpose>

--- a/reference/gearman/gearmantask/create.xml
+++ b/reference/gearman/gearmantask/create.xml
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   A <classname>GearmanTask</classname> oject&return.falseforfailure;.
+   A <classname>GearmanTask</classname> object&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-escape-string.xml
+++ b/reference/ibm_db2/functions/db2-escape-string.xml
@@ -61,7 +61,7 @@ if ($conn) {
     $str[0] = "All characters: \x00 , \n , \r , \ , ' , \" , \x1a .";
     $str[1] = "Backslash (\). Single quote ('). Double quote (\")";
     $str[2] = "The NULL character \0 must be quoted as well";
-    $str[3] = "Intersting characters: \x1a , \x00 .";
+    $str[3] = "Interesting characters: \x1a , \x00 .";
     $str[4] = "Nothing to quote";
     $str[5] = 200676;
     $str[6] = "";
@@ -79,7 +79,7 @@ if ($conn) {
 db2_escape_string: All characters: \0 , \n , \r , \\ , \' , \" , \Z .
 db2_escape_string: Backslash (\\). Single quote (\'). Double quote (\")
 db2_escape_string: The NULL character \0 must be quoted as well
-db2_escape_string: Intersting characters: \Z , \0 .
+db2_escape_string: Interesting characters: \Z , \0 .
 db2_escape_string: Nothing to quote
 db2_escape_string: 200676
 db2_escape_string:

--- a/reference/ibm_db2/functions/db2-escape-string.xml
+++ b/reference/ibm_db2/functions/db2-escape-string.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-escape-string">
+<refentry xml:id="function.db2-escape-string" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>db2_escape_string</refname>
   <refpurpose>

--- a/reference/imagick/examples.xml
+++ b/reference/imagick/examples.xml
@@ -60,7 +60,7 @@ $images->writeImages();
   <para>
    This is an example of creating a reflection of an image.
    The reflection is created by flipping the image and overlaying a gradient on it.
-   Then both, the original image and the reflection is overlayed on a canvas.
+   Then both, the original image and the reflection is overlaid on a canvas.
    <example>
     <title>Creating a reflection of an image</title>
     <programlisting role="php">
@@ -79,7 +79,7 @@ $im->borderImage(new ImagickPixel("white"), 5, 5);
 $reflection = $im->clone();
 $reflection->flipImage();
 
-/* Create gradient. It will be overlayed on the reflection */
+/* Create gradient. It will be overlaid on the reflection */
 $gradient = new Imagick();
 
 /* Gradient needs to be large enough for the image and the borders */

--- a/reference/imagick/imagick/brightnesscontrastimage.xml
+++ b/reference/imagick/imagick/brightnesscontrastimage.xml
@@ -15,9 +15,9 @@
    <methodparam><type>float</type><parameter>contrast</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Change the brightness and/or contrast of an image. It converts the brightness and contrast parameters into slope and intercept and calls a polynomical function to apply to the image.
-  </para>
+  <simpara>
+   Change the brightness and/or contrast of an image. It converts the brightness and contrast parameters into slope and intercept and calls a polynomial function to apply to the image.
+  </simpara>
 
  </refsect1>
 

--- a/reference/imagick/imagick/distortimage.xml
+++ b/reference/imagick/imagick/distortimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.distortimage">
+<refentry xml:id="imagick.distortimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::distortImage</refname>
   <refpurpose>Distorts an image using various distortion methods</refpurpose>

--- a/reference/imagick/imagick/distortimage.xml
+++ b/reference/imagick/imagick/distortimage.xml
@@ -120,7 +120,7 @@ $controlPoints = array( 10, 10,
 /* Perform the distortion */                       
 $im->distortImage(Imagick::DISTORTION_PERSPECTIVE, $controlPoints, true);
 
-/* Ouput the image */
+/* Output the image */
 header("Content-Type: image/png");
 echo $im;
 ?>

--- a/reference/imagick/imagick/evaluateimage.xml
+++ b/reference/imagick/imagick/evaluateimage.xml
@@ -14,11 +14,11 @@
    <methodparam><type>float</type><parameter>constant</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Applys an arithmetic, relational, or logical expression to an image.  Use
+  <simpara>
+   Applies an arithmetic, relational, or logical expression to an image.  Use
    these operators to lighten or darken an image, to increase or decrease
    contrast in an image, or to produce the "negative" of an image.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/imagick/imagick/evaluateimage.xml
+++ b/reference/imagick/imagick/evaluateimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.evaluateimage">
+<refentry xml:id="imagick.evaluateimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::evaluateImage</refname>
   <refpurpose>Applies an expression to an image</refpurpose>

--- a/reference/imagick/imagick/extentimage.xml
+++ b/reference/imagick/imagick/extentimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.extentimage">
+<refentry xml:id="imagick.extentimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::extentImage</refname>
   <refpurpose>Set image size</refpurpose>

--- a/reference/imagick/imagick/extentimage.xml
+++ b/reference/imagick/imagick/extentimage.xml
@@ -23,14 +23,14 @@
   </para>
 
   <caution>
-   <para>
+   <simpara>
   Prior to ImageMagick 6.5.7-8 (1623), $x was positive when shifting to the left and negative when shifting to the right, and $y was positive when shifting an image up and negative when shifting an image down.
 
-  Somewhere betwen ImageMagick 6.3.7 (1591) and ImageMagick 6.5.7-8 (1623), the axes of $x and $y were flipped, so that $x was negative when shifting to the left and positive when shifting to the right, and $y was negative when shifting an image up and positive when shifting an image down.
+  Somewhere between ImageMagick 6.3.7 (1591) and ImageMagick 6.5.7-8 (1623), the axes of $x and $y were flipped, so that $x was negative when shifting to the left and positive when shifting to the right, and $y was negative when shifting an image up and positive when shifting an image down.
 
   Somewhere between ImageMagick 6.5.7-8 (1623) and ImageMagick 6.6.9-7 (1641), the axes of $x and $y were flipped back to pre-ImageMagick 6.5.7-8 (1623) functionality.
 
-   </para>
+   </simpara>
   </caution>
  </refsect1>
 

--- a/reference/imagick/imagick/getimageproperties.xml
+++ b/reference/imagick/imagick/getimageproperties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.getimageproperties">
+<refentry xml:id="imagick.getimageproperties" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::getImageProperties</refname>
   <refpurpose>Returns the image properties</refpurpose>

--- a/reference/imagick/imagick/getimageproperties.xml
+++ b/reference/imagick/imagick/getimageproperties.xml
@@ -69,7 +69,7 @@ $im = new imagick("/path/to/example.jpg");
 /* Get the EXIF information */
 $exifArray = $im->getImageProperties("exif:*");
 
-/* Loop trough the EXIF properties */
+/* Loop through the EXIF properties */
 foreach ($exifArray as $name => $property)
 {
     echo "{$name} => {$property}<br />\n"; 

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.sigmoidalcontrastimage" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="imagick.sigmoidalcontrastimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::sigmoidalContrastImage</refname>
   <refpurpose>Adjusts the contrast of an image</refpurpose>

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -53,9 +53,9 @@
     <varlistentry>
      <term><parameter>beta</parameter></term>
      <listitem>
-      <para>
-       Where the midpoint of the gradient will be. This value should be in the range 0 to 1 - mutliplied by the quantum value for ImageMagick.
-      </para>
+      <simpara>
+       Where the midpoint of the gradient will be. This value should be in the range 0 to 1 - multiplied by the quantum value for ImageMagick.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/imagick/imagick/trimimage.xml
+++ b/reference/imagick/imagick/trimimage.xml
@@ -70,7 +70,7 @@ $im = new Imagick("image.jpg");
 /* Trim the image. */
 $im->trimImage(0);
 
-/* Ouput the image */
+/* Output the image */
 header("Content-Type: image/" . $im->getImageFormat());
 echo $im;
 ?>

--- a/reference/imagick/imagick/trimimage.xml
+++ b/reference/imagick/imagick/trimimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.trimimage">
+<refentry xml:id="imagick.trimimage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Imagick::trimImage</refname>
   <refpurpose>Remove edges from the image</refpurpose>

--- a/reference/imagick/imagickdraw/affine.xml
+++ b/reference/imagick/imagickdraw/affine.xml
@@ -79,7 +79,7 @@ function affine($strokeColor, $fillColor, $backgroundColor) {
     //Translate (offset) the drawing
     $affineTranslate = array("sx" => 1, "sy" => 1, "rx" => 0, "ry" => 0, "tx" => 30, "ty" => 30);
 
-    //The identiy affine matrix
+    //The identity affine matrix
     $affineIdentity = array("sx" => 1, "sy" => 1, "rx" => 0, "ry" => 0, "tx" => 0, "ty" => 0);
 
     $examples = [$affineScale, $affineShear, $affineRotate, $affineTranslate, $affineIdentity,];

--- a/reference/imagick/imagickdraw/affine.xml
+++ b/reference/imagick/imagickdraw/affine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickdraw.affine">
+<refentry xml:id="imagickdraw.affine" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ImagickDraw::affine</refname>
   <refpurpose>Adjusts the current affine transformation matrix</refpurpose>

--- a/reference/imagick/imagickpixeliterator/resetiterator.xml
+++ b/reference/imagick/imagickpixeliterator/resetiterator.xml
@@ -43,7 +43,7 @@ function resetIterator($imagePath) {
 
     $imageIterator = $imagick->getPixelIterator();
 
-    /* Loop trough pixel rows */
+    /* Loop through pixel rows */
     foreach ($imageIterator as $pixels) {
         /* Loop through the pixels in the row (columns) */
         foreach ($pixels as $column => $pixel) {
@@ -60,7 +60,7 @@ function resetIterator($imagePath) {
 
     $imageIterator->resetiterator();
 
-    /* Loop trough pixel rows */
+    /* Loop through pixel rows */
     foreach ($imageIterator as $pixels) {
         /* Loop through the pixels in the row (columns) */
         foreach ($pixels as $column => $pixel) {

--- a/reference/imagick/imagickpixeliterator/resetiterator.xml
+++ b/reference/imagick/imagickpixeliterator/resetiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickpixeliterator.resetiterator">
+<refentry xml:id="imagickpixeliterator.resetiterator" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ImagickPixelIterator::resetIterator</refname>
   <refpurpose>Resets the pixel iterator</refpurpose>

--- a/reference/memcached/memcached/ispersistent.xml
+++ b/reference/memcached/memcached/ispersistent.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="memcached.ispersistent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Memcached::isPersistent</refname>
-  <refpurpose>Check if a persitent connection to memcache is being used</refpurpose>
+  <refpurpose>Check if a persistent connection to memcache is being used</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mongodb/bson/document/tophp.xml
+++ b/reference/mongodb/bson/document/tophp.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <simpara>
    Unserializes the BSON document to its PHP representation. The
-   <parameter>typeMap</parameter> paramater may be used to control the PHP types
+   <parameter>typeMap</parameter> parameter may be used to control the PHP types
    used for converting BSON arrays and documents (both root and embedded).
   </simpara>
   &mongodb.warning.duplicate-keys;

--- a/reference/mongodb/bson/objectid/tostring.xml
+++ b/reference/mongodb/bson/objectid/tostring.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="mongodb-bson-objectid.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\ObjectId::__toString</refname>
-  <refpurpose>Returns the hexidecimal representation of this ObjectId</refpurpose>
+  <refpurpose>Returns the hexadecimal representation of this ObjectId</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -23,7 +23,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the hexidecimal representation of this ObjectId.
+   Returns the hexadecimal representation of this ObjectId.
   </simpara>
  </refsect1>
 

--- a/reference/mongodb/bson/objectidinterface/tostring.xml
+++ b/reference/mongodb/bson/objectidinterface/tostring.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="mongodb-bson-objectidinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\ObjectIdInterface::__toString</refname>
-  <refpurpose>Returns the hexidecimal representation of this ObjectIdInterface</refpurpose>
+  <refpurpose>Returns the hexadecimal representation of this ObjectIdInterface</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -23,7 +23,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the hexidecimal representation of this ObjectIdInterface.
+   Returns the hexadecimal representation of this ObjectIdInterface.
   </simpara>
  </refsect1>
 

--- a/reference/mongodb/bson/timestamp/getincrement.xml
+++ b/reference/mongodb/bson/timestamp/getincrement.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <simpara>
    The increment component of a Timestamp is its least significant 32 bits,
-   whichs denotes the incrementing ordinal for operations within a given second.
+   which denotes the incrementing ordinal for operations within a given second.
    This value is read as an unsigned 32-bit integer with big-endian byte order.
   </simpara>
   &mongodb.note.uint32;

--- a/reference/mongodb/functions/bson/tophp.xml
+++ b/reference/mongodb/functions/bson/tophp.xml
@@ -26,7 +26,7 @@
   </methodsynopsis>
   <simpara>
    Unserializes a BSON document (i.e. binary string) to its PHP representation.
-   The <parameter>typeMap</parameter> paramater may be used to control the PHP
+   The <parameter>typeMap</parameter> parameter may be used to control the PHP
    types used for converting BSON arrays and documents (both root and embedded).
   </simpara>
   &mongodb.warning.duplicate-keys;

--- a/reference/mongodb/mongodb/driver/bulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite.xml
@@ -149,7 +149,7 @@ Updated  2 document(s)
 ]]>
    </screen>
    <simpara>
-    If the write concern could not be fullfilled, the example above would output
+    If the write concern could not be fulfilled, the example above would output
     something like:
    </simpara>
    <screen>

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -117,7 +117,7 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        The third parameter is now an <parameter>options</parameter> array.
-       For backwards compatibility, this paramater will still accept a
+       For backwards compatibility, this parameter will still accept a
        <classname>MongoDB\Driver\WriteConcern</classname> object.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -121,7 +121,7 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        The third parameter is now an <parameter>options</parameter> array.
-       For backwards compatibility, this paramater will still accept a
+       For backwards compatibility, this parameter will still accept a
        <classname>MongoDB\Driver\ReadPreference</classname> object.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -100,7 +100,7 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        The third parameter is now an <parameter>options</parameter> array.
-       For backwards compatibility, this paramater will still accept a
+       For backwards compatibility, this parameter will still accept a
        <classname>MongoDB\Driver\ReadPreference</classname> object.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -117,7 +117,7 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        The third parameter is now an <parameter>options</parameter> array.
-       For backwards compatibility, this paramater will still accept a
+       For backwards compatibility, this parameter will still accept a
        <classname>MongoDB\Driver\WriteConcern</classname> object.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -121,7 +121,7 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        The third parameter is now an <parameter>options</parameter> array.
-       For backwards compatibility, this paramater will still accept a
+       For backwards compatibility, this parameter will still accept a
        <classname>MongoDB\Driver\ReadPreference</classname> object.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -100,7 +100,7 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        The third parameter is now an <parameter>options</parameter> array.
-       For backwards compatibility, this paramater will still accept a
+       For backwards compatibility, this parameter will still accept a
        <classname>MongoDB\Driver\ReadPreference</classname> object.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/session/committransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/committransaction.xml
@@ -50,7 +50,7 @@
    should be used to test for this situation instead.</member>
    <member>Throws
    <classname>MongoDB\Driver\Exception\RuntimeException</classname> if the
-   transaction could not be commited (e.g. a transaction was not
+   transaction could not be committed (e.g. a transaction was not
    started).</member>
   </simplelist>
  </refsect1>

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -50,7 +50,7 @@
   <title>Script Injection Attacks</title>
   <simpara>
    If you are using JavaScript, make sure that any variables that cross the PHP-
-   to-JavaScript boundry are passed in the <literal>scope</literal> field of
+   to-JavaScript boundary are passed in the <literal>scope</literal> field of
    <classname>MongoDB\BSON\Javascript</classname>, not interpolated into the
    JavaScript string. This can come up when using <literal>$where</literal>
    clauses in queries, mapReduce and group commands, and any other time you may

--- a/reference/oci8/functions/oci-get-implicit-resultset.xml
+++ b/reference/oci8/functions/oci-get-implicit-resultset.xml
@@ -13,14 +13,14 @@
    <type class="union"><type>resource</type><type>false</type></type><methodname>oci_get_implicit_resultset</methodname>
    <methodparam><type>resource</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Used to fetch consectutive sets of query results after the
+  <simpara>
+   Used to fetch consecutive sets of query results after the
    execution of a stored or anonymous Oracle PL/SQL block where that
    block returns query results with the
    Oracle Database 12 (or later) <emphasis>DBMS_SQL.RETURN_RESULT</emphasis> PL/SQL
    function.  This allows PL/SQL blocks to easily return query
    results.
-  </para>
+  </simpara>
   <para>
     The child statement can be used with any of the OCI8 fetching
     functions: <function>oci_fetch</function>, <function>oci_fetch_all</function>,

--- a/reference/oci8/ini.xml
+++ b/reference/oci8/ini.xml
@@ -317,7 +317,7 @@
         </para>
         <note>
          <simpara>
-          Seting this <literal>On</literal> can allow scripts on web
+          Setting this <literal>On</literal> can allow scripts on web
           servers running with the appropriate OS user privileges to
           connect as privileged database users without requiring a
           database password.  This can be a security risk.

--- a/reference/sqlsrv/constants.xml
+++ b/reference/sqlsrv/constants.xml
@@ -47,7 +47,7 @@
    </term>
    <listitem>
     <simpara>
-    Forces <function>sqlsrv_errors</function> to return both errors and warings
+    Forces <function>sqlsrv_errors</function> to return both errors and warnings
     when passed as a parameter (the default behavior).
     </simpara>
    </listitem>

--- a/reference/sqlsrv/constants.xml
+++ b/reference/sqlsrv/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sqlsrv.constants">
+<appendix xml:id="sqlsrv.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
  <variablelist>

--- a/reference/sqlsrv/functions/sqlsrv-close.xml
+++ b/reference/sqlsrv/functions/sqlsrv-close.xml
@@ -3,7 +3,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sqlsrv-close">
  <refnamediv>
   <refname>sqlsrv_close</refname>
-  <refpurpose>Closes an open connection and releases resourses associated with the connection</refpurpose>
+  <refpurpose>Closes an open connection and releases resources associated with the connection</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -12,7 +12,7 @@
    <methodparam><type>resource</type><parameter>conn</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Closes an open connection and releases resourses associated with the connection.
+   Closes an open connection and releases resources associated with the connection.
   </simpara>
  </refsect1>
 

--- a/reference/sqlsrv/functions/sqlsrv-close.xml
+++ b/reference/sqlsrv/functions/sqlsrv-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sqlsrv-close">
+<refentry xml:id="function.sqlsrv-close" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>sqlsrv_close</refname>
   <refpurpose>Closes an open connection and releases resources associated with the connection</refpurpose>

--- a/reference/sqlsrv/functions/sqlsrv-num-rows.xml
+++ b/reference/sqlsrv/functions/sqlsrv-num-rows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sqlsrv-num-rows">
+<refentry xml:id="function.sqlsrv-num-rows" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>sqlsrv_num_rows</refname>
   <refpurpose>Retrieves the number of rows in a result set</refpurpose>

--- a/reference/sqlsrv/functions/sqlsrv-num-rows.xml
+++ b/reference/sqlsrv/functions/sqlsrv-num-rows.xml
@@ -65,7 +65,7 @@ $stmt = sqlsrv_query( $conn, $sql , $params, $options );
 $row_count = sqlsrv_num_rows( $stmt );
 
 if ($row_count === false)
-   echo "Error in retrieveing row count.";
+   echo "Error in retrieving row count.";
 else
    echo $row_count;
 ?>

--- a/reference/swoole/constants.xml
+++ b/reference/swoole/constants.xml
@@ -1025,7 +1025,7 @@
     </term>
     <listitem>
      <simpara>
-      SSL cannot use senfile
+      SSL cannot use sendfile
      </simpara>
     </listitem>
    </varlistentry>
@@ -1300,7 +1300,7 @@
     </term>
     <listitem>
      <simpara>
-      Socks5 unsupport version.
+      Socks5 unsupported version.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1311,7 +1311,7 @@
     </term>
     <listitem>
      <simpara>
-      Socks5 unsupport method.
+      Socks5 unsupported method.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/swoole/functions/swoole-async-read.xml
+++ b/reference/swoole/functions/swoole-async-read.xml
@@ -53,9 +53,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
-          The content readed from the file stream.
-         </para>
+         <simpara>
+          The content read from the file stream.
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>

--- a/reference/swoole/functions/swoole-last-error.xml
+++ b/reference/swoole/functions/swoole-last-error.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.swoole-last-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>swoole_last_error</refname>
-  <refpurpose>Get the lastest error message</refpurpose>
+  <refpurpose>Get the latest error message</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/swoole/swoole/async/read.xml
+++ b/reference/swoole/swoole/async/read.xml
@@ -53,9 +53,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
-          The content readed from the file stream.
-         </para>
+         <simpara>
+          The content read from the file stream.
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>

--- a/reference/swoole/swoole/async/readfile.xml
+++ b/reference/swoole/swoole/async/readfile.xml
@@ -51,9 +51,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
-          The content readed from the file.
-         </para>
+         <simpara>
+          The content read from the file.
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>


### PR DESCRIPTION
Runs codespell across the docs for non-core extensions still actively maintained on PECL (mongodb, imagick, swoole, oci8, sqlsrv, memcached, gearman, ibm_db2) and applies the suggestions. Scoped to one PR per maintainer surface so each can be reviewed independently. 37 files, pure typos.