### PR TITLE
Document deprecations in PDO constants and methods in PHP 8.5

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -736,6 +736,12 @@
      (<type>int</type>)
     </term>
     <listitem>
+     <warning>
+      <simpara>
+       This constant has been <emphasis>DEPRECATED</emphasis> as of PHP 8.5.0.
+       Use <constant>Pdo\Sqlite::DETERMINISTIC</constant> instead.
+      </simpara>
+     </warning>
      <simpara>
        Specifies that a function created with <methodname>PDO::sqliteCreateFunction</methodname>
        is deterministic, i.e. it always returns the same result given the same inputs within

--- a/reference/pdo_firebird/constants.xml
+++ b/reference/pdo_firebird/constants.xml
@@ -3,6 +3,13 @@
 <section xml:id="ref.pdo-firebird.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
+ <warning>
+  <simpara>
+   The constants listed below have been <emphasis>DEPRECATED</emphasis>
+   as of PHP 8.5.0. Use the corresponding <classname>Pdo\Firebird</classname>
+   constants instead.
+  </simpara>
+ </warning>
  <variablelist>
   <varlistentry xml:id="pdo.constants.fb-attr-date-format">
    <term>
@@ -10,9 +17,9 @@
      (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_DATE_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="pdo.constants.fb-attr-time-format">
@@ -21,9 +28,9 @@
      (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_TIME_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="pdo.constants.fb-attr-timestamp-format">
@@ -32,9 +39,9 @@
      (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_TIMESTAMP_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
  </variablelist>

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -3,6 +3,13 @@
 <section xml:id="ref.pdo-mysql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
+ <warning>
+  <simpara>
+   The constants listed below have been <emphasis>DEPRECATED</emphasis>
+   as of PHP 8.5.0. Use the corresponding <classname>Pdo\Mysql</classname>
+   constants instead.
+  </simpara>
+ </warning>
  <variablelist>
   <varlistentry xml:id="pdo.constants.mysql-attr-use-buffered-query">
    <term>

--- a/reference/pdo_odbc/constants.xml
+++ b/reference/pdo_odbc/constants.xml
@@ -11,11 +11,22 @@
     (<type>string</type>)
    </term>
    <listitem>
-    <para>
-
-    </para>
+    <simpara>
+     Describes the ODBC library linked against the PDO_ODBC extension.
+     Possible values include <literal>unixODBC</literal>,
+     <literal>iODBC</literal>, or <literal>generic</literal>.
+    </simpara>
    </listitem>
   </varlistentry>
+ </variablelist>
+ <warning>
+  <simpara>
+   The constants listed below have been <emphasis>DEPRECATED</emphasis>
+   as of PHP 8.5.0. Use the corresponding <classname>Pdo\Odbc</classname>
+   constants instead.
+  </simpara>
+ </warning>
+ <variablelist>
   <varlistentry xml:id="pdo.constants.odbc-attr-use-cursor-library">
    <term>
     <constant>PDO::ODBC_ATTR_USE_CURSOR_LIBRARY</constant>

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateAggregate.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateAggregate.xml
@@ -8,6 +8,10 @@
   </refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateCollation.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateCollation.xml
@@ -8,6 +8,10 @@
   </refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateFunction.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateFunction.xml
@@ -8,6 +8,10 @@
   </refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>


### PR DESCRIPTION
According to the migration guide:

List of affected constants and their replacement:

```
PDO::DBLIB_ATTR_CONNECTION_TIMEOUT => Pdo\Dblib::ATTR_CONNECTION_TIMEOUT
PDO::DBLIB_ATTR_QUERY_TIMEOUT => Pdo\Dblib::ATTR_QUERY_TIMEOUT
PDO::DBLIB_ATTR_STRINGIFY_UNIQUEIDENTIFIER => Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER
PDO::DBLIB_ATTR_VERSION => Pdo\Dblib::ATTR_VERSION
PDO::DBLIB_ATTR_TDS_VERSION => Pdo\Dblib::ATTR_TDS_VERSION
PDO::DBLIB_ATTR_SKIP_EMPTY_ROWSETS => Pdo\Dblib::ATTR_SKIP_EMPTY_ROWSETS
PDO::DBLIB_ATTR_DATETIME_CONVERT => Pdo\Dblib::ATTR_DATETIME_CONVERT
PDO::FB_ATTR_DATE_FORMAT => Pdo\Firebird::ATTR_DATE_FORMAT
PDO::FB_ATTR_TIME_FORMAT => Pdo\Firebird::ATTR_TIME_FORMAT
PDO::FB_ATTR_TIMESTAMP_FORMAT => Pdo\Firebird::ATTR_TIMESTAMP_FORMAT
PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
PDO::MYSQL_ATTR_LOCAL_INFILE => Pdo\Mysql::ATTR_LOCAL_INFILE
PDO::MYSQL_ATTR_LOCAL_INFILE_DIRECTORY => Pdo\Mysql::ATTR_LOCAL_INFILE_DIRECTORY
PDO::MYSQL_ATTR_INIT_COMMAND => Pdo\Mysql::ATTR_INIT_COMMAND
PDO::MYSQL_ATTR_MAX_BUFFER_SIZE => Pdo\Mysql::ATTR_MAX_BUFFER_SIZE
PDO::MYSQL_ATTR_READ_DEFAULT_FILE => Pdo\Mysql::ATTR_READ_DEFAULT_FILE
PDO::MYSQL_ATTR_READ_DEFAULT_GROUP => Pdo\Mysql::ATTR_READ_DEFAULT_GROUP
PDO::MYSQL_ATTR_COMPRESS => Pdo\Mysql::ATTR_COMPRESS
PDO::MYSQL_ATTR_DIRECT_QUERY => Pdo\Mysql::ATTR_DIRECT_QUERY
PDO::MYSQL_ATTR_FOUND_ROWS => Pdo\Mysql::ATTR_FOUND_ROWS
PDO::MYSQL_ATTR_IGNORE_SPACE => Pdo\Mysql::ATTR_IGNORE_SPACE
PDO::MYSQL_ATTR_SSL_KEY => Pdo\Mysql::ATTR_SSL_KEY
PDO::MYSQL_ATTR_SSL_CERT => Pdo\Mysql::ATTR_SSL_CERT
PDO::MYSQL_ATTR_SSL_CA => Pdo\Mysql::ATTR_SSL_CA
PDO::MYSQL_ATTR_SSL_CAPATH => Pdo\Mysql::ATTR_SSL_CAPATH
PDO::MYSQL_ATTR_SSL_CIPHER => Pdo\Mysql::ATTR_SSL_CIPHER
PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT
PDO::MYSQL_ATTR_SERVER_PUBLIC_KEY => Pdo\Mysql::ATTR_SERVER_PUBLIC_KEY
PDO::MYSQL_ATTR_MULTI_STATEMENTS => Pdo\Mysql::ATTR_MULTI_STATEMENTS
PDO::ODBC_ATTR_USE_CURSOR_LIBRARY => Pdo\Odbc::ATTR_USE_CURSOR_LIBRARY
PDO::ODBC_ATTR_ASSUME_UTF8 => Pdo\Odbc::ATTR_ASSUME_UTF8
PDO::ODBC_SQL_USE_IF_NEEDED => Pdo\Odbc::SQL_USE_IF_NEEDED
PDO::ODBC_SQL_USE_DRIVER => Pdo\Odbc::SQL_USE_DRIVER
PDO::ODBC_SQL_USE_ODBC => Pdo\Odbc::SQL_USE_ODBC
PDO::PGSQL_ATTR_DISABLE_PREPARES => Pdo\Pgsql::ATTR_DISABLE_PREPARES
PDO::SQLITE_ATTR_EXTENDED_RESULT_CODES => Pdo\Sqlite::ATTR_EXTENDED_RESULT_CODES
PDO::SQLITE_ATTR_OPEN_FLAGS => Pdo\Sqlite::OPEN_FLAGS
PDO::SQLITE_ATTR_READONLY_STATEMENT => Pdo\Sqlite::ATTR_READONLY_STATEMENT
PDO::SQLITE_DETERMINISTIC => Pdo\Sqlite::DETERMINISTIC
PDO::SQLITE_OPEN_READONLY => Pdo\Sqlite::OPEN_READONLY
PDO::SQLITE_OPEN_READWRITE => Pdo\Sqlite::OPEN_READWRITE
PDO::SQLITE_OPEN_CREATE => Pdo\Sqlite::OPEN_CREATE
```

List of affected methods and their replacement:

```
PDO::pgsqlCopyFromArray() => Pdo\Pgsql::copyFromArray()
PDO::pgsqlCopyFromFile() => Pdo\Pgsql::copyFromFile()
PDO::pgsqlCopyToArray() => Pdo\Pgsql::copyToArray()
PDO::pgsqlCopyToFile() => Pdo\Pgsql::copyToFile()
PDO::pgsqlGetNotify() => Pdo\Pgsql::getNotify()
PDO::pgsqlGetPid() => Pdo\Pgsql::getPid()
PDO::pgsqlLOBCreate() => Pdo\Pgsql::lobCreate()
PDO::pgsqlLOBOpen() => Pdo\Pgsql::lobOpen()
PDO::pgsqlLOBUnlink() => Pdo\Pgsql::lobUnlink()
PDO::sqliteCreateAggregate() => Pdo\Sqlite::createAggregate()
PDO::sqliteCreateCollation() => Pdo\Sqlite::createCollation()
PDO::sqliteCreateFunction() => Pdo\Sqlite::createFunction()
```