### PR TITLE
Fix ssh2_sftp_* return types to include false (realpath, readlink, stat, lstat)

### DIFF
--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-lstat">
+<refentry xml:id="function.ssh2-sftp-lstat" xmlns="http://docbook.org/ns/docbook" >
  <refnamediv>
   <refname>ssh2_sftp_lstat</refname>
   <refpurpose>Stat a symbolic link</refpurpose>

--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -50,7 +50,7 @@
   &reftitle.returnvalues;
   <simpara>
    Returns an array of statistics for the given symbolic link on success&return.falseforfailure;.
-   See the documentation for <function>stat</function> for details on the 
+   See the documentation for <function>stat</function> for details on the
    values which may be returned.
   </simpara>
  </refsect1>

--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -50,8 +50,8 @@
   &reftitle.returnvalues;
   <simpara>
    Returns an array of statistics for the given symbolic link on success&return.falseforfailure;.
-   See the documentation for <function>stat</function>
-   for details on the values which may be returned.
+   See the documentation for <function>stat</function> for details on the 
+   values which may be returned.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -49,8 +49,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns an array of statistics about the given symbolic link on success,
-   or &false; on failure. See the documentation for <function>stat</function>
+   Returns an array of statistics for the given symbolic link on success&return.falseforfailure;.
+   See the documentation for <function>stat</function>
    for details on the values which may be returned.
   </simpara>
  </refsect1>

--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>ssh2_sftp_lstat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>ssh2_sftp_lstat</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
@@ -49,8 +49,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   See the documentation for <function>stat</function> for details on the
-   values which may be returned.
+   Returns an array of statistics about the given symbolic link on success,
+   or &false; on failure. See the documentation for <function>stat</function>
+   for details on the values which may be returned.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-readlink.xml
+++ b/reference/ssh2/functions/ssh2-sftp-readlink.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-readlink">
+<refentry xml:id="function.ssh2-sftp-readlink" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_readlink</refname>
   <refpurpose>Return the target of a symbolic link</refpurpose>

--- a/reference/ssh2/functions/ssh2-sftp-readlink.xml
+++ b/reference/ssh2/functions/ssh2-sftp-readlink.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>ssh2_sftp_readlink</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>ssh2_sftp_readlink</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>link</parameter></methodparam>
   </methodsynopsis>
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the target of the symbolic <parameter>link</parameter>.
+   Returns the target of the symbolic <parameter>link</parameter>, or &false; on failure.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-readlink.xml
+++ b/reference/ssh2/functions/ssh2-sftp-readlink.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the target of the symbolic <parameter>link</parameter>, or &false; on failure.
+   Returns the target of the symbolic <parameter>link</parameter>&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-realpath.xml
+++ b/reference/ssh2/functions/ssh2-sftp-realpath.xml
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the real path as a string, or &false; on failure.
+   Returns the real path as a string&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-realpath.xml
+++ b/reference/ssh2/functions/ssh2-sftp-realpath.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>ssh2_sftp_realpath</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>ssh2_sftp_realpath</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the real path as a string.
+   Returns the real path as a string, or &false; on failure.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-realpath.xml
+++ b/reference/ssh2/functions/ssh2-sftp-realpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-realpath">
+<refentry xml:id="function.ssh2-sftp-realpath" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_realpath</refname>
   <refpurpose>Resolve the realpath of a provided path string</refpurpose>

--- a/reference/ssh2/functions/ssh2-sftp-stat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-stat.xml
@@ -47,8 +47,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns an array of statistics about the given file on success, or
-   &false; on failure. See the documentation for <function>stat</function>
+   Returns an array of statistics for the given file on success&return.falseforfailure;.
+   See the documentation for <function>stat</function>
    for details on the values which may be returned.
   </simpara>
  </refsect1>

--- a/reference/ssh2/functions/ssh2-sftp-stat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-stat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-stat">
+<refentry xml:id="function.ssh2-sftp-stat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_stat</refname>
   <refpurpose>Stat a file on a remote filesystem</refpurpose>

--- a/reference/ssh2/functions/ssh2-sftp-stat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-stat.xml
@@ -48,7 +48,7 @@
   &reftitle.returnvalues;
   <simpara>
    Returns an array of statistics for the given file on success&return.falseforfailure;.
-   See the documentation for <function>stat</function> for details on the 
+   See the documentation for <function>stat</function> for details on the
    values which may be returned.
   </simpara>
  </refsect1>

--- a/reference/ssh2/functions/ssh2-sftp-stat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-stat.xml
@@ -48,8 +48,8 @@
   &reftitle.returnvalues;
   <simpara>
    Returns an array of statistics for the given file on success&return.falseforfailure;.
-   See the documentation for <function>stat</function>
-   for details on the values which may be returned.
+   See the documentation for <function>stat</function> for details on the 
+   values which may be returned.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-stat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-stat.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>ssh2_sftp_stat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>ssh2_sftp_stat</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
@@ -47,8 +47,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   See the documentation for <function>stat</function> for details on the
-   values which may be returned.
+   Returns an array of statistics about the given file on success, or
+   &false; on failure. See the documentation for <function>stat</function>
+   for details on the values which may be returned.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
## What

Several `ssh2_sftp_*` functions were documented as returning only `string`/`array`, but they return `false` on failure. This updates the method synopsis and **Return Values** for:

- `ssh2_sftp_realpath`: `string` → `string|false`
- `ssh2_sftp_readlink`: `string` → `string|false`
- `ssh2_sftp_stat`: `array` → `array|false`
- `ssh2_sftp_lstat`: `array` → `array|false`

## Why

The [extension source](https://github.com/php/pecl-networking-ssh2/blob/master/ssh2_sftp.c) confirms that each of these calls `RETURN_FALSE` on failure, an invalid SFTP resource, a disconnected session (`data->session_rsrc->ptr == NULL`), or a failed underlying `libssh2` call — and only returns its string/array value on success.

The remaining `ssh2_sftp_*` functions are unaffected: `chmod`, `mkdir`, `rmdir`, `rename`, `symlink` and `unlink` are already documented as `bool`, and `ssh2_sftp` already documents `resource|false`.