### PR TITLE
Remove $ sigil from <parameter> names

### DIFF
--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -38,10 +38,10 @@
  <sect2 xml:id="migration83.deprecated.core.dba">
   <title>DBA</title>
 
-  <para>
+  <simpara>
    Calling <function>dba_fetch</function> with <parameter>dba</parameter> as
    the 3rd argument is now deprecated.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.ffi">
@@ -70,21 +70,21 @@
  <sect2 xml:id="migration83.deprecated.ldap">
   <title>LDAP</title>
 
-  <para>
+  <simpara>
    Calling <function>ldap_connect</function> with separate
    <parameter>hostname</parameter> and <parameter>port</parameter> is
    deprecated.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.mbstring">
   <title>MBString</title>
 
-  <para>
+  <simpara>
    Passing a negative <parameter>width</parameter> to
    <function>mb_strimwidth</function> is now deprecated.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.phar">

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -39,7 +39,7 @@
   <title>DBA</title>
 
   <para>
-   Calling <function>dba_fetch</function> with <parameter>$dba</parameter> as
+   Calling <function>dba_fetch</function> with <parameter>dba</parameter> as
    the 3rd argument is now deprecated.
   </para>
  </sect2>
@@ -72,7 +72,7 @@
 
   <para>
    Calling <function>ldap_connect</function> with separate
-   <parameter>$hostname</parameter> and <parameter>$port</parameter> is
+   <parameter>hostname</parameter> and <parameter>port</parameter> is
    deprecated.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
   </para>
@@ -82,7 +82,7 @@
   <title>MBString</title>
 
   <para>
-   Passing a negative <parameter>$width</parameter> to
+   Passing a negative <parameter>width</parameter> to
    <function>mb_strimwidth</function> is now deprecated.
   </para>
  </sect2>
@@ -92,7 +92,7 @@
 
   <para>
    Calling <methodname>Phar::setStub</methodname> with a
-   <type>resource</type> and a <parameter>$length</parameter>
+   <type>resource</type> and a <parameter>length</parameter>
    is now deprecated. Such calls should be replaced by:
    <code>$phar->setStub(stream_get_contents($resource));</code>
   </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -172,15 +172,15 @@
   <para>
    The <function>range</function> function has had various changes:
    <simplelist>
-    <member>A <classname>TypeError</classname> is now thrown when passing <type>object</type>s,
+    <member>A <exceptionname>TypeError</exceptionname> is now thrown when passing <type>object</type>s,
     <type>resource</type>s, or <type>array</type>s as the boundary inputs.</member>
-    <member>A more descriptive <classname>ValueError</classname> is thrown when
+    <member>A more descriptive <exceptionname>ValueError</exceptionname> is thrown when
     passing <literal>0</literal> for <parameter>step</parameter>.</member>
-    <member>A <classname>ValueError</classname> is now thrown when using a
+    <member>A <exceptionname>ValueError</exceptionname> is now thrown when using a
     negative <parameter>step</parameter> for increasing ranges.</member>
     <member>If <parameter>step</parameter> is a float that can be interpreted
     as an int, it is now done so.</member>
-    <member>A <classname>ValueError</classname> is now thrown if any argument
+    <member>A <exceptionname>ValueError</exceptionname> is now thrown if any argument
     is infinity or NAN.</member>
     <member>An <constant>E_WARNING</constant> is now emitted if
     <parameter>start</parameter> or <parameter>end</parameter> is the empty

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -175,25 +175,25 @@
     <member>A <classname>TypeError</classname> is now thrown when passing <type>object</type>s,
     <type>resource</type>s, or <type>array</type>s as the boundary inputs.</member>
     <member>A more descriptive <classname>ValueError</classname> is thrown when
-    passing <literal>0</literal> for <parameter>$step</parameter>.</member>
+    passing <literal>0</literal> for <parameter>step</parameter>.</member>
     <member>A <classname>ValueError</classname> is now thrown when using a
-    negative <parameter>$step</parameter> for increasing ranges.</member>
-    <member>If <parameter>$step</parameter> is a float that can be interpreted
+    negative <parameter>step</parameter> for increasing ranges.</member>
+    <member>If <parameter>step</parameter> is a float that can be interpreted
     as an int, it is now done so.</member>
     <member>A <classname>ValueError</classname> is now thrown if any argument
     is infinity or NAN.</member>
     <member>An <constant>E_WARNING</constant> is now emitted if
-    <parameter>$start</parameter> or <parameter>$end</parameter> is the empty
+    <parameter>start</parameter> or <parameter>end</parameter> is the empty
     string. The value continues to be cast to the value <literal>0</literal>.</member>
     <member>An <constant>E_WARNING</constant> is now emitted if
-    <parameter>$start</parameter> or <parameter>$end</parameter> has more than
+    <parameter>start</parameter> or <parameter>end</parameter> has more than
     one byte, only if it is a non-numeric string.</member>
     <member>An <constant>E_WARNING</constant> is now emitted if
-    <parameter>$start</parameter> or <parameter>$end</parameter> is cast to an
+    <parameter>start</parameter> or <parameter>end</parameter> is cast to an
     integer because the other boundary input is a number.
     (e.g. <code>range(5, 'z');</code>).</member>
     <member>An <constant>E_WARNING</constant> is now emitted if
-    <parameter>$step</parameter> is a float when trying to generate a range of
+    <parameter>step</parameter> is a float when trying to generate a range of
     characters, except if both boundary inputs are numeric strings (e.g.
     <code>range('5', '9', 0.5);</code> does not produce a warning).</member>
     <member><function>range</function> now produce a list of characters if one
@@ -215,9 +215,9 @@ range('9', 'A');  // [9, 8, 7, 6, 5, 4, 3, 2, 1, 0], prior to PHP 8.3.0
 
   <para>
    <function>number_format</function> now handles negative
-   <parameter>$decimals</parameter> values by rounding
-   <parameter>$num</parameter> to <code>abs($decimals)</code> digits before the
-   decimal point. Previously, negative <parameter>$decimals</parameter> values
+   <parameter>decimals</parameter> values by rounding
+   <parameter>num</parameter> to <code>abs($decimals)</code> digits before the
+   decimal point. Previously, negative <parameter>decimals</parameter> values
    were ignored.
   </para>
 

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -153,10 +153,10 @@ echo $user_ini['listen']; // localhost:9000
  <sect2 xml:id="migration83.new-features.posix">
   <title>POSIX</title>
 
-  <para>
+  <simpara>
    <function>posix_getrlimit</function> now takes an optional
    <parameter>resource</parameter> parameter to allow fetching a single resource limit.
-  </para>
+  </simpara>
 
   <para>
    <function>posix_isatty</function> now raises type warnings for integers

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -155,7 +155,7 @@ echo $user_ini['listen']; // localhost:9000
 
   <para>
    <function>posix_getrlimit</function> now takes an optional
-   <parameter>$resource</parameter> parameter to allow fetching a single resource limit.
+   <parameter>resource</parameter> parameter to allow fetching a single resource limit.
   </para>
 
   <para>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -178,7 +178,7 @@
 
    <para>
     The signature of <function>imagerotate</function> has changed.
-    The <parameter>$ignore_transparent</parameter> parameter has been removed,
+    The <parameter>ignore_transparent</parameter> parameter has been removed,
     as it was ignored since PHP 5.5.0.
    </para>
   </sect3>
@@ -265,14 +265,14 @@
    <para>
     <function>mysqli_fetch_object</function> now raises a
     <classname>ValueError</classname> instead of an <classname>Exception</classname>
-    when the <parameter>$constructor_args</parameter> argument is non empty with
+    when the <parameter>constructor_args</parameter> argument is non empty with
     the class not having constructor.
    </para>
 
    <para>
     <function>mysqli_poll</function> now raises a <classname>ValueError</classname>
-    when neither the <parameter>$read</parameter>
-    nor the <parameter>$error</parameter> arguments are passed.
+    when neither the <parameter>read</parameter>
+    nor the <parameter>error</parameter> arguments are passed.
    </para>
 
    <para>
@@ -287,7 +287,7 @@
 
    <para>
     <function>odbc_autocommit</function> now accepts &null; for the
-    <parameter>$enable</parameter> parameter.
+    <parameter>enable</parameter> parameter.
     Passing &null; has the same behaviour as passing only 1 parameter,
     namely indicating if the autocommit feature is enabled or not.
    </para>
@@ -299,7 +299,7 @@
    <para>
     <function>pg_fetch_object</function> now raises a
     <classname>ValueError</classname> instead of an <classname>Exception</classname>
-    when the <parameter>$constructor_args</parameter> argument is non empty with
+    when the <parameter>constructor_args</parameter> argument is non empty with
     the class not having constructor.
    </para>
 
@@ -316,7 +316,7 @@
    </para>
 
    <para>
-    The <parameter>$row</parameter> parameter of
+    The <parameter>row</parameter> parameter of
     <function>pg_fetch_result</function>,
     <function>pg_field_prtlen</function>, and
     <function>pg_field_is_null</function> is now nullable.
@@ -374,19 +374,19 @@
    <para>
     <function>password_hash</function> will now chain the underlying
     <classname>Random\RandomException</classname>
-    as the <classname>ValueError</classname>'s <parameter>$previous</parameter>
+    as the <classname>ValueError</classname>'s <parameter>previous</parameter>
     <classname>Exception</classname> when salt generation fails.
    </para>
 
    <para>
-    If using an array as the <parameter>$command</parameter>
+    If using an array as the <parameter>command</parameter>
     for <function>proc_open</function>, it must now have at least one
     non empty element. Otherwise a <classname>ValueError</classname>
     is thrown.
    </para>
 
    <para>
-    <function>proc_open</function> returns &false; if <parameter>$command</parameter>
+    <function>proc_open</function> returns &false; if <parameter>command</parameter>
     array is invalid command instead of resource object that produces warning later.
     This was already the case for Windows but it is now also the case if a posix_spawn
     implementation is in use (most Linux, BSD and MacOS platforms). There are still
@@ -404,17 +404,17 @@
    </para>
 
    <para>
-    The <parameter>$decimals</parameter> of <function>number_format</function>
+    The <parameter>decimals</parameter> of <function>number_format</function>
     now properly handles negative integers.
-    Rounding with a negative value for <parameter>$decimals</parameter> means
-    that <parameter>$num</parameter> is rounded to <parameter>$decimals</parameter>
+    Rounding with a negative value for <parameter>decimals</parameter> means
+    that <parameter>num</parameter> is rounded to <parameter>decimals</parameter>
     significant digits before the decimal point.
-    Previously negative <parameter>$decimals</parameter> were silently
+    Previously negative <parameter>decimals</parameter> were silently
     ignored and the number got rounded to zero decimal places.
    </para>
 
    <para>
-    A new <parameter>$before_needle</parameter> argument has been added to
+    A new <parameter>before_needle</parameter> argument has been added to
     <function>strrchr</function>. It behaves like its counterpart in the
     <function>strstr</function> or <function>stristr</function> functions.
    </para>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -176,11 +176,11 @@
   <sect3 xml:id="migration83.other-changes.functions.gd">
    <title>Gd</title>
 
-   <para>
+   <simpara>
     The signature of <function>imagerotate</function> has changed.
     The <parameter>ignore_transparent</parameter> parameter has been removed,
     as it was ignored since PHP 5.5.0.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.intl">
@@ -262,18 +262,18 @@
   <sect3 xml:id="migration83.other-changes.functions.mysqli">
    <title>mysqli</title>
 
-   <para>
+   <simpara>
     <function>mysqli_fetch_object</function> now raises a
     <classname>ValueError</classname> instead of an <classname>Exception</classname>
     when the <parameter>constructor_args</parameter> argument is non empty with
     the class not having constructor.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     <function>mysqli_poll</function> now raises a <classname>ValueError</classname>
     when neither the <parameter>read</parameter>
     nor the <parameter>error</parameter> arguments are passed.
-   </para>
+   </simpara>
 
    <para>
     <function>mysqli_field_seek</function> and
@@ -285,23 +285,23 @@
   <sect3 xml:id="migration83.other-changes.functions.odbc">
    <title>ODBC</title>
 
-   <para>
+   <simpara>
     <function>odbc_autocommit</function> now accepts &null; for the
     <parameter>enable</parameter> parameter.
     Passing &null; has the same behaviour as passing only 1 parameter,
     namely indicating if the autocommit feature is enabled or not.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.pgsql">
    <title>PGSQL</title>
 
-   <para>
+   <simpara>
     <function>pg_fetch_object</function> now raises a
     <classname>ValueError</classname> instead of an <classname>Exception</classname>
     when the <parameter>constructor_args</parameter> argument is non empty with
     the class not having constructor.
-   </para>
+   </simpara>
 
    <para>
     <function>pg_insert</function> now raises a <classname>ValueError</classname>
@@ -315,12 +315,12 @@
     does not match properly with a PostgreSQL's type.
    </para>
 
-   <para>
+   <simpara>
     The <parameter>row</parameter> parameter of
     <function>pg_fetch_result</function>,
     <function>pg_field_prtlen</function>, and
     <function>pg_field_is_null</function> is now nullable.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.random">
@@ -371,28 +371,28 @@
     case token is not provided when starting tokenization.
    </para>
 
-   <para>
+   <simpara>
     <function>password_hash</function> will now chain the underlying
-    <classname>Random\RandomException</classname>
-    as the <classname>ValueError</classname>'s <parameter>previous</parameter>
-    <classname>Exception</classname> when salt generation fails.
-   </para>
+    <exceptionname>Random\RandomException</exceptionname>
+    as the <exceptionname>ValueError</exceptionname>'s <parameter>previous</parameter>
+    <exceptionname>Exception</exceptionname> when salt generation fails.
+   </simpara>
 
-   <para>
+   <simpara>
     If using an array as the <parameter>command</parameter>
     for <function>proc_open</function>, it must now have at least one
     non empty element. Otherwise a <classname>ValueError</classname>
     is thrown.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     <function>proc_open</function> returns &false; if <parameter>command</parameter>
     array is invalid command instead of resource object that produces warning later.
     This was already the case for Windows but it is now also the case if a posix_spawn
     implementation is in use (most Linux, BSD and MacOS platforms). There are still
     some old platforms where this behavior is not changed as posix_spawn is not
     supported there.
-   </para>
+   </simpara>
 
    <para>
     <function>array_sum</function> and <function>array_product</function> now
@@ -403,7 +403,7 @@
     <!-- RFC: https://wiki.php.net/rfc/saner-array-sum-product -->
    </para>
 
-   <para>
+   <simpara>
     The <parameter>decimals</parameter> of <function>number_format</function>
     now properly handles negative integers.
     Rounding with a negative value for <parameter>decimals</parameter> means
@@ -411,13 +411,13 @@
     significant digits before the decimal point.
     Previously negative <parameter>decimals</parameter> were silently
     ignored and the number got rounded to zero decimal places.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     A new <parameter>before_needle</parameter> argument has been added to
     <function>strrchr</function>. It behaves like its counterpart in the
     <function>strstr</function> or <function>stristr</function> functions.
-   </para>
+   </simpara>
 
    <para>
     <function>str_getcsv</function> and <function>fgetcsv</function> now return

--- a/appendices/migration85/deprecated.xml
+++ b/appendices/migration85/deprecated.xml
@@ -204,7 +204,7 @@
   </simpara>
 
   <simpara>
-   The <parameter>$context</parameter> parameter of the
+   The <parameter>context</parameter> parameter of the
    <function>finfo_buffer</function> function has been deprecated
    as it is ignored.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_context_parameter_for_finfo_buffer -->
@@ -285,7 +285,7 @@
   <title>OpenSSL</title>
 
   <simpara>
-   The <parameter>$key_length</parameter> parameter for
+   The <parameter>key_length</parameter> parameter for
    <function>openssl_pkey_derive</function> has been deprecated.
    This is because it is either ignored, or truncates the key, which can be
    a security vulnerability.

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -155,12 +155,12 @@
 
   <simpara>
    <function>bzcompress</function> now throws a <classname>ValueError</classname>
-   when <parameter>$block_size</parameter> is not between 1 and 9.
+   when <parameter>block_size</parameter> is not between 1 and 9.
   </simpara>
 
   <simpara>
    <function>bzcompress</function> now throws a <classname>ValueError</classname>
-   when <parameter>$work_factor</parameter> is not between 0 and 250.
+   when <parameter>work_factor</parameter> is not between 0 and 250.
   </simpara>
 
  </sect2>
@@ -184,7 +184,7 @@
   <simpara>
    <function>finfo_file</function> and <methodname>finfo::file</methodname>
    now throws a <exceptionname>ValueError</exceptionname> instead of a
-   <exceptionname>TypeError</exceptionname> when <parameter>$filename</parameter>
+   <exceptionname>TypeError</exceptionname> when <parameter>filename</parameter>
    contains nul bytes.
    This aligns the type of Error thrown to be consistent with the rest of
    the language.
@@ -293,12 +293,12 @@
 
   <simpara>
    <function>pcntl_exec</function> now throws <exceptionname>ValueError</exceptionname>
-   when entries of the <parameter>$args</parameter> parameter contain null bytes.
+   when entries of the <parameter>args</parameter> parameter contain null bytes.
   </simpara>
 
   <simpara>
    <function>pcntl_exec</function> now throws <exceptionname>ValueError</exceptionname>
-   when entries or keys of the <parameter>$env_vars</parameter> parameter
+   when entries or keys of the <parameter>env_vars</parameter> parameter
    contain null bytes.
   </simpara>
 
@@ -485,7 +485,7 @@
 
   <simpara>
    <methodname>SoapClient::__doRequest</methodname> now accepts a new,
-   optional <parameter>$uriParserClass</parameter> parameter accepting
+   optional <parameter>uriParserClass</parameter> parameter accepting
    string or &null; arguments.
    &null; represents the original (<function>parse_url</function>) based
    method, while the new backends will be used when passing either
@@ -538,7 +538,7 @@
 
   <simpara>
    <methodname>SplFileObject::fwrite</methodname>'s parameter
-   <parameter>$length</parameter> is now nullable.
+   <parameter>length</parameter> is now nullable.
    The default value changed from <literal>0</literal> to &null;.
   </simpara>
 

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -394,7 +394,7 @@ print T1 . PHP_EOL;   // Prints "0"
   <simpara>
    The signature of <methodname>SoapFault::__construct</methodname> and
    <methodname>SoapServer::fault</methodname> therefore
-   now have an optional <parameter>$lang</parameter> parameter.
+   now have an optional <parameter>lang</parameter> parameter.
    This support solves compatibility with .NET SOAP clients.
   </simpara>
 
@@ -453,11 +453,11 @@ print T1 . PHP_EOL;   // Prints "0"
   <title>XSL</title>
 
   <simpara>
-   The <parameter>$namespace</parameter> argument of <methodname>XSLTProcessor::getParameter</methodname>,
+   The <parameter>namespace</parameter> argument of <methodname>XSLTProcessor::getParameter</methodname>,
    <methodname>XSLTProcessor::setParameter</methodname> and
    <methodname>XSLTProcessor::removeParameter</methodname> now actually works
    instead of being treated as empty.
-   This only works if the <parameter>$name</parameter> argument does not use Clark notation and is not a
+   This only works if the <parameter>name</parameter> argument does not use Clark notation and is not a
    QName because in those cases the namespace is taken from the namespace href or
    prefix respectively.
   </simpara>

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -88,7 +88,7 @@
 
    <simpara>
     <function>grapheme_extract</function> properly assigns
-    <parameter>$next</parameter> value when skipping over invalid starting bytes.
+    <parameter>next</parameter> value when skipping over invalid starting bytes.
     Previously there were cases where it would point to the start of the
     grapheme boundary instead of the end.
    </simpara>
@@ -103,7 +103,7 @@
    </simpara>
 
    <simpara>
-    The following functions now support a <parameter>$locale</parameter> argument:
+    The following functions now support a <parameter>locale</parameter> argument:
     <function>grapheme_strpos</function>,
     <function>grapheme_stripos</function>,
     <function>grapheme_strrpos</function>,
@@ -143,18 +143,18 @@
    <simpara>
     <function>openssl_public_encrypt</function> and
     <function>openssl_private_decrypt</function> have a new parameter
-    <parameter>$digest_algo</parameter> that allows specifying the hash
+    <parameter>digest_algo</parameter> that allows specifying the hash
     digest algorithm for OAEP padding.
    </simpara>
 
    <simpara>
     <function>openssl_sign</function> and <function>openssl_verify</function>
-    have a new parameter <parameter>$padding</parameter> to allow using more
+    have a new parameter <parameter>padding</parameter> to allow using more
     secure RSA PSS padding.
    </simpara>
 
    <simpara>
-    <function>openssl_cms_encrypt</function> <parameter>$cipher_algo</parameter>
+    <function>openssl_cms_encrypt</function> <parameter>cipher_algo</parameter>
     parameter can be a string with the cipher name.
     That allows to use more algorithms including AES GCM cipher algorithms for
     auth enveloped data.
@@ -270,7 +270,7 @@
    <title>Zlib</title>
 
    <simpara>
-    The <parameter>$use_include_path</parameter> argument for the
+    The <parameter>use_include_path</parameter> argument for the
     <function>gzfile</function>, <function>gzopen</function> and
     <function>readgzfile</function> functions has been changed
     from <type>int</type> to <type>bool</type>.

--- a/appendices/migration85/windows-support.xml
+++ b/appendices/migration85/windows-support.xml
@@ -58,9 +58,9 @@
   <title>Streams</title>
 
   <simpara>
-   If only pipe streams are contained in the <parameter>$read</parameter>
-   array, and the <parameter>$write</parameter> and
-   <parameter>$except</parameter> arrays are empty,
+   If only pipe streams are contained in the <parameter>read</parameter>
+   array, and the <parameter>write</parameter> and
+   <parameter>except</parameter> arrays are empty,
    <function>stream_select</function> now behaves similar to POSIX systems,
    i.e. the function only returns if at least one pipe is ready to be read,
    or after the timeout expires.

--- a/reference/com/functions/variant-cat.xml
+++ b/reference/com/functions/variant-cat.xml
@@ -16,10 +16,10 @@
    Concatenates <parameter>left</parameter> with
    <parameter>right</parameter> and returns the result.
   </para>
-  <para>
+  <simpara>
    This function is notionally equivalent to
    <parameter>left</parameter> <literal>.</literal> <parameter>right</parameter>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/com/functions/variant-cat.xml
+++ b/reference/com/functions/variant-cat.xml
@@ -18,7 +18,7 @@
   </para>
   <para>
    This function is notionally equivalent to
-   <parameter>$left</parameter> <literal>.</literal> <parameter>$right</parameter>.
+   <parameter>left</parameter> <literal>.</literal> <parameter>right</parameter>.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -32,7 +32,7 @@
      <para>&date.formats.parameter;</para>
      <para>
       Enter <literal>"now"</literal> here to obtain the current time when using
-      the <parameter>$timezone</parameter> parameter.
+      the <parameter>timezone</parameter> parameter.
      </para>
     </listitem>
    </varlistentry>
@@ -41,17 +41,17 @@
     <listitem>
      <para>
       A <classname>DateTimeZone</classname> object representing the
-      timezone of <parameter>$datetime</parameter>.
+      timezone of <parameter>datetime</parameter>.
      </para>
      <para>
-      If <parameter>$timezone</parameter> is omitted or &null;,
+      If <parameter>timezone</parameter> is omitted or &null;,
       the current timezone will be used.
      </para>
      <note>
       <para>
-       The <parameter>$timezone</parameter> parameter
+       The <parameter>timezone</parameter> parameter
        and the current timezone are ignored when the
-       <parameter>$datetime</parameter> parameter either
+       <parameter>datetime</parameter> parameter either
        is a UNIX timestamp (e.g. <literal>@946684800</literal>)
        or specifies a timezone
        (e.g. <literal>2010-01-28T15:00:00+02:00</literal>).

--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -30,32 +30,32 @@
     <term><parameter>datetime</parameter></term>
     <listitem>
      <para>&date.formats.parameter;</para>
-     <para>
+     <simpara>
       Enter <literal>"now"</literal> here to obtain the current time when using
       the <parameter>timezone</parameter> parameter.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timezone</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A <classname>DateTimeZone</classname> object representing the
       timezone of <parameter>datetime</parameter>.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       If <parameter>timezone</parameter> is omitted or &null;,
       the current timezone will be used.
-     </para>
+     </simpara>
      <note>
-      <para>
+      <simpara>
        The <parameter>timezone</parameter> parameter
        and the current timezone are ignored when the
        <parameter>datetime</parameter> parameter either
        is a UNIX timestamp (e.g. <literal>@946684800</literal>)
        or specifies a timezone
        (e.g. <literal>2010-01-28T15:00:00+02:00</literal>).
-      </para>
+      </simpara>
      </note>
     </listitem>
    </varlistentry>

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -33,25 +33,25 @@
     <term><parameter>datetime</parameter></term>
     <listitem>
      <para>&date.formats.parameter;</para>
-     <para>
+     <simpara>
       Enter <literal>"now"</literal> here to obtain the current time when using
       the <parameter>timezone</parameter> parameter.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timezone</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A <classname>DateTimeZone</classname> object representing the
       timezone of <parameter>datetime</parameter>.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       If <parameter>timezone</parameter> is omitted or &null;,
       the current timezone will be used.
-     </para>
+     </simpara>
      <note>
-      <para>
+      <simpara>
        The <parameter>timezone</parameter> parameter
        and the current timezone are ignored when the
        <parameter>datetime</parameter> parameter either
@@ -59,7 +59,7 @@
        or specifies a timezone
        (e.g. <literal>2010-01-28T15:00:00+02:00</literal>, or
        <literal>2010-07-05T06:00:00Z</literal>).
-      </para>
+      </simpara>
      </note>
     </listitem>
    </varlistentry>

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -35,7 +35,7 @@
      <para>&date.formats.parameter;</para>
      <para>
       Enter <literal>"now"</literal> here to obtain the current time when using
-      the <parameter>$timezone</parameter> parameter.
+      the <parameter>timezone</parameter> parameter.
      </para>
     </listitem>
    </varlistentry>
@@ -44,17 +44,17 @@
     <listitem>
      <para>
       A <classname>DateTimeZone</classname> object representing the
-      timezone of <parameter>$datetime</parameter>.
+      timezone of <parameter>datetime</parameter>.
      </para>
      <para>
-      If <parameter>$timezone</parameter> is omitted or &null;,
+      If <parameter>timezone</parameter> is omitted or &null;,
       the current timezone will be used.
      </para>
      <note>
       <para>
-       The <parameter>$timezone</parameter> parameter
+       The <parameter>timezone</parameter> parameter
        and the current timezone are ignored when the
-       <parameter>$datetime</parameter> parameter either
+       <parameter>datetime</parameter> parameter either
        is a UNIX timestamp (e.g. <literal>@946684800</literal>)
        or specifies a timezone
        (e.g. <literal>2010-01-28T15:00:00+02:00</literal>, or

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -18,7 +18,7 @@
   <literal>commandSucceeded</literal>, and <literal>commandFailed</literal>.
   Each of these three methods accept a single <parameter>event</parameter>
   argument of a specific class for the respective event. For example, the
-  <literal>commandSucceeded</literal>'s <parameter>$event</parameter> argument
+  <literal>commandSucceeded</literal>'s <parameter>event</parameter> argument
   is a <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>
   object.
  </simpara>

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -305,7 +305,7 @@ Array
        <entry>7.2.0</entry>
        <entry>
         The <constant>PREG_UNMATCHED_AS_NULL</constant> is now supported for the
-        <parameter>$flags</parameter> parameter.
+        <parameter>flags</parameter> parameter.
        </entry>
       </row>
      </tbody>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -274,7 +274,7 @@ Array
        <entry>7.2.0</entry>
        <entry>
         The <constant>PREG_UNMATCHED_AS_NULL</constant> is now supported for the
-        <parameter>$flags</parameter> parameter.
+        <parameter>flags</parameter> parameter.
        </entry>
       </row>
      </tbody>

--- a/reference/session/examples.xml
+++ b/reference/session/examples.xml
@@ -233,12 +233,12 @@ here</a>.
    When a session is specifically destroyed, PHP will call the <parameter>destroy</parameter> handler with
    the session ID.
   </para>
- <para>
+ <simpara>
    PHP will call the <parameter>gc</parameter> callback from time to time to
    expire any session records according to the set max lifetime of a session.
    This routine should delete all records from persistent storage which were
    last accessed longer than the <parameter>lifetime</parameter>.
- </para>
+ </simpara>
  </section>
 </appendix>
 

--- a/reference/session/examples.xml
+++ b/reference/session/examples.xml
@@ -237,7 +237,7 @@ here</a>.
    PHP will call the <parameter>gc</parameter> callback from time to time to
    expire any session records according to the set max lifetime of a session.
    This routine should delete all records from persistent storage which were
-   last accessed longer than the <parameter>$lifetime</parameter>.
+   last accessed longer than the <parameter>lifetime</parameter>.
  </para>
  </section>
 </appendix>

--- a/reference/session/functions/session-decode.xml
+++ b/reference/session/functions/session-decode.xml
@@ -12,11 +12,11 @@
    <type>bool</type><methodname>session_decode</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>session_decode</function> decodes the serialized session data provided in
    <parameter>data</parameter>, and populates the $_SESSION superglobal
    with the result.
-  </para>
+  </simpara>
   <para>
    By default, the unserialization method used is internal to PHP, and is not the same as <function>unserialize</function>.
    The serialization method can be set using <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.

--- a/reference/session/functions/session-decode.xml
+++ b/reference/session/functions/session-decode.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   <para>
    <function>session_decode</function> decodes the serialized session data provided in
-   <parameter>$data</parameter>, and populates the $_SESSION superglobal
+   <parameter>data</parameter>, and populates the $_SESSION superglobal
    with the result.
   </para>
   <para>

--- a/reference/session/sessionhandler/destroy.xml
+++ b/reference/session/sessionhandler/destroy.xml
@@ -12,11 +12,11 @@
    <modifier>public</modifier> <type>bool</type><methodname>SessionHandler::destroy</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Destroys a session. Called internally by PHP with <function>session_regenerate_id</function> (assuming
    the <parameter>destroy</parameter> is set to &true;, by <function>session_destroy</function> or when
    <function>session_decode</function> fails.
-  </para>
+  </simpara>
   <para>
    This method wraps the internal PHP save handler defined in the
    <link linkend="ini.session.save-handler">session.save_handler</link> ini setting that was set

--- a/reference/session/sessionhandler/destroy.xml
+++ b/reference/session/sessionhandler/destroy.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   <para>
    Destroys a session. Called internally by PHP with <function>session_regenerate_id</function> (assuming
-   the <parameter>$destroy</parameter> is set to &true;, by <function>session_destroy</function> or when
+   the <parameter>destroy</parameter> is set to &true;, by <function>session_destroy</function> or when
    <function>session_decode</function> fails.
   </para>
   <para>

--- a/reference/session/sessionhandler/read.xml
+++ b/reference/session/sessionhandler/read.xml
@@ -23,12 +23,12 @@
    <link linkend="ini.session.save-handler">session.save_handler</link> ini setting that was set
    before this handler was set by <function>session_set_save_handler</function>.
   </para>
-  <para>
+  <simpara>
    If this class is extended by inheritance, calling the parent <parameter>read</parameter> method will invoke the
    wrapper for this method and therefore invoke the associated internal callback.  This allows the method to be
    overridden and or intercepted and filtered (for example, decrypting the <parameter>data</parameter> value
    returned by the parent <parameter>read</parameter> method).
-  </para>
+  </simpara>
   <para>
    For more information on what this method is expected to do, please refer to the documentation at
    <function>SessionHandlerInterface::read</function>.

--- a/reference/session/sessionhandler/read.xml
+++ b/reference/session/sessionhandler/read.xml
@@ -26,7 +26,7 @@
   <para>
    If this class is extended by inheritance, calling the parent <parameter>read</parameter> method will invoke the
    wrapper for this method and therefore invoke the associated internal callback.  This allows the method to be
-   overridden and or intercepted and filtered (for example, decrypting the <parameter>$data</parameter> value
+   overridden and or intercepted and filtered (for example, decrypting the <parameter>data</parameter> value
    returned by the parent <parameter>read</parameter> method).
   </para>
   <para>

--- a/reference/session/sessionhandler/write.xml
+++ b/reference/session/sessionhandler/write.xml
@@ -26,7 +26,7 @@
   <para>
    If this class is extended by inheritance, calling the parent <parameter>write</parameter> method will invoke the
    wrapper for this method and therefore invoke the associated internal callback.  This allows this method to be
-   overridden and or intercepted and filtered (for example, encrypting the <parameter>$data</parameter> value
+   overridden and or intercepted and filtered (for example, encrypting the <parameter>data</parameter> value
    before sending it to the parent <parameter>write</parameter> method).
   </para>
   <para>

--- a/reference/session/sessionhandler/write.xml
+++ b/reference/session/sessionhandler/write.xml
@@ -23,12 +23,12 @@
    <link linkend="ini.session.save-handler">session.save_handler</link> ini setting that was set
    before this handler was set by <function>session_set_save_handler</function>.
   </para>
-  <para>
+  <simpara>
    If this class is extended by inheritance, calling the parent <parameter>write</parameter> method will invoke the
    wrapper for this method and therefore invoke the associated internal callback.  This allows this method to be
    overridden and or intercepted and filtered (for example, encrypting the <parameter>data</parameter> value
    before sending it to the parent <parameter>write</parameter> method).
-  </para>
+  </simpara>
   <para>
    For more information on what this method is expected to do, please refer to the documentation
    at <function>SessionHandlerInterface::write</function>.

--- a/reference/stream/constants.xml
+++ b/reference/stream/constants.xml
@@ -1203,7 +1203,7 @@
     <listitem>
      <simpara>
       Return value indicating that the userspace filter
-      returned buckets in <parameter>$out</parameter>.
+      returned buckets in <parameter>out</parameter>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -1215,7 +1215,7 @@
     <listitem>
      <simpara>
       Return value indicating that the userspace filter
-      did not return buckets in <parameter>$out</parameter>.
+      did not return buckets in <parameter>out</parameter>.
       (i.e. No data available.)
      </simpara>
     </listitem>

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::dump</methodname>
-   <methodparam><type>int</type><parameter>$num</parameter></methodparam>
+   <methodparam><type>int</type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
    Dump values stored in cache


### PR DESCRIPTION
A `<parameter>` should hold the parameter name without the `$` sigil (79 occurrences, 22 files).

`$this`, superglobals (`$_GET`/`$_POST`) and in-text example variables were reviewed and intentionally left untouched.