### PR TITLE
ext/libxml: Clarify that `LIBXML_PARSEHUGE` raises limits rather than removing them

### DIFF
--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -273,14 +273,14 @@
    </term>
    <listitem>
     <simpara>
-     Sets XML_PARSE_HUGE flag, which relaxes any hardcoded limit from the parser. This affects
+     Sets XML_PARSE_HUGE flag, which increases some hardcoded limits from the parser. This affects
      limits like maximum depth of a document or the entity recursion, as well as limits of the
      size of text nodes.
     </simpara>
     <caution>
      <simpara>
-      Because this relaxes the hardcoded limits, it should only be used with trusted data.
-      Removing the depth limit on untrusted input can lead to excessive resource consumption,
+      Because this increases the hardcoded limits, it should only be used with trusted data.
+      Raising the depth limit on untrusted input can lead to excessive resource consumption,
       such as a stack overflow while processing a deeply nested document.
      </simpara>
     </caution>


### PR DESCRIPTION
Follow up of https://github.com/php/doc-en/pull/5647 and its comments