### PR TITLE
Update preg-match.xml to clarify language around when using offset making \A and ^ inoperable

### DIFF
--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -232,7 +232,7 @@ Array
          <para>
           Alternatively, to avoid using <function>substr</function>, use the
           <literal>\G</literal> assertion rather than the <literal>^</literal> anchor, or
-          the <literal>A</literal> modifier instead, both of which work with
+          the <literal>A</literal> modifier - both of which do not work with
           the <parameter>offset</parameter> parameter.
          </para>
         </informalexample>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -229,12 +229,12 @@ Array
 )
 ]]>
          </screen>
-         <para>
+         <simpara>
           Alternatively, to avoid using <function>substr</function>, use the
           <literal>\G</literal> assertion rather than the <literal>^</literal> anchor, or
-          the <literal>A</literal> modifier - both of which do not work with
+          the <literal>A</literal> modifier; both of which do not work with
           the <parameter>offset</parameter> parameter.
-         </para>
+         </simpara>
         </informalexample>
        </para>
       </note>


### PR DESCRIPTION
Try to clarify the language around using \G instead of substr. It read as if ^ and \A both worked with offset and to use use \A instead of ^.