### PR TITLE
sodium: fix return-value prose for 4 functions that throw SodiumException instead of returning false

### DIFF
--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-encrypt.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the ciphertext and tag on success, &return.falseforfailure;.
+   Returns the ciphertext and authentication tag as a string of raw binary bytes.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
@@ -66,7 +66,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the ciphertext and tag on success, &return.falseforfailure;.
+   Returns the ciphertext and authentication tag as a string of raw binary bytes.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
@@ -67,7 +67,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the ciphertext and tag on success, &return.falseforfailure;.
+   Returns the ciphertext and authentication tag as a string of raw binary bytes.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
@@ -71,7 +71,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Encrypted message, &return.falseforfailure;.
+   Encrypted message.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
The *return values* section of these four functions states they return `false` on failure. In php-src they never return `false`: every error path throws a `SodiumException` (`zend_throw_exception` / `zend_argument_error` followed by `RETURN_THROWS()`), and on success the function returns the raw binary string.

Proof in `ext/sodium/libsodium.c` (pinned at `1a7f3c0`), none of the four bodies contains a `RETURN_FALSE`:

- `sodium_crypto_aead_chacha20poly1305_encrypt`: [L2123-L2177](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/ext/sodium/libsodium.c#L2123-L2177), throws at [L2143](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/ext/sodium/libsodium.c#L2143)
- `sodium_crypto_aead_chacha20poly1305_ietf_encrypt`: [L2236-L2294](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/ext/sodium/libsodium.c#L2236-L2294), throws at [L2256](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/ext/sodium/libsodium.c#L2256)
- `sodium_crypto_aead_xchacha20poly1305_ietf_encrypt`: [L2359-L2413](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/ext/sodium/libsodium.c#L2359-L2413), throws at [L2379](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/ext/sodium/libsodium.c#L2379)
- `sodium_crypto_stream_xchacha20_xor_ic`: [L1364-L1405](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/ext/sodium/libsodium.c#L1364-L1405), throws at [L1383](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/ext/sodium/libsodium.c#L1383)
