### PR TITLE
predefined/error: getPrevious example uses nonexistent InvalidArgumentError

### DIFF
--- a/language/predefined/error/getprevious.xml
+++ b/language/predefined/error/getprevious.xml
@@ -45,7 +45,7 @@ class MyCustomError extends Error {}
 
 function doStuff() {
     try {
-        throw new InvalidArgumentError("You are doing it wrong!", 112);
+        throw new TypeError("You are doing it wrong!", 112);
     } catch(Error $e) {
         throw new MyCustomError("Something happened", 911, $e);
     }
@@ -66,7 +66,7 @@ try {
     <screen>
 <![CDATA[
 /home/bjori/ex.php:8 Something happened (911) [MyCustomError]
-/home/bjori/ex.php:6 You are doing it wrong! (112) [InvalidArgumentError]
+/home/bjori/ex.php:6 You are doing it wrong! (112) [TypeError]
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
The example for `Error::getPrevious` throws `new InvalidArgumentError(...)`. That class does not exist in PHP: it appears **0 times** in php-src ([code search](https://github.com/search?q=repo%3Aphp%2Fphp-src+InvalidArgumentError&type=code)).

The block catches `catch (Error $e)`, so the thrown class must be a subclass of `Error`. `TypeError` is the correct choice: it extends `Error` ([Zend/zend_exceptions.c#L842](https://github.com/php/php-src/blob/1a7f3c00978a563f20882b44487658a80878d868/Zend/zend_exceptions.c#L842), `register_class_TypeError(zend_ce_error)`), so it is caught. `InvalidArgumentException` would not work here: it extends `Exception`, not `Error`, so it would slip past the `catch (Error $e)`.

Verified by running the example under `php:8.4-cli`:

Before, the documented output was never reachable. `new InvalidArgumentError` raises an `Error` ("Class not found"), so the actual output was:
```
:8 Something happened (911) [MyCustomError]
:6 Class "InvalidArgumentError" not found (0) [Error]
```
The page instead claimed `[InvalidArgumentError]` with message `You are doing it wrong!` and code `112`, none of which could occur.

After, the example runs and produces exactly the documented `<screen>` (illustrative path aside, covered by `&example.outputs.similar;`):
```
:8 Something happened (911) [MyCustomError]
:6 You are doing it wrong! (112) [TypeError]
```
Lines 6 and 8, the messages, the codes (911 and 112) and the class names all match.
