### PR TITLE
Mark do-not-translate files

### DIFF
--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
-
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
 <!-- DO NOT TRANSLATE THIS FILE. -->
-
 <appendix xmlns="http://docbook.org/ns/docbook" xml:id="extensions">
  &extcat.intro;
 

--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?do-not-translate?>
-<!-- DO NOT TRANSLATE THIS FILE. -->
+
 <appendix xmlns="http://docbook.org/ns/docbook" xml:id="extensions">
  &extcat.intro;
 

--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -1,9 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  DO NOT TRANSLATE THIS FILE! All the content that is displayed
-  on the extension categorization page in your translated manual
-  can be translated in extensions.ent
--->
+<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
+
+<!-- DO NOT TRANSLATE THIS FILE. -->
+
 <appendix xmlns="http://docbook.org/ns/docbook" xml:id="extensions">
  &extcat.intro;
 

--- a/appendices/extensions.xml
+++ b/appendices/extensions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?do-not-translate?>
-
 <appendix xmlns="http://docbook.org/ns/docbook" xml:id="extensions">
  &extcat.intro;
 

--- a/appendices/license.xml
+++ b/appendices/license.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
+<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
 
-<!-- DO NOT TRANSLATE THIS FILE -->
+<!-- DO NOT TRANSLATE THIS FILE. -->
 
 <appendix xml:id="cc.license" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Creative Commons Attribution 3.0</title>
@@ -390,4 +389,3 @@
   </listitem>
  </orderedlist>
 </appendix>
-

--- a/appendices/license.xml
+++ b/appendices/license.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
-
-<!-- DO NOT TRANSLATE THIS FILE. -->
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
 
 <appendix xml:id="cc.license" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Creative Commons Attribution 3.0</title>

--- a/appendices/reserved.constants.xml
+++ b/appendices/reserved.constants.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
-
-<!-- DO NOT TRANSLATE THIS FILE. -->
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
 
 <sect1 xml:id="reserved.constants" xmlns="http://docbook.org/ns/docbook">
  <title>&ReservedConstants;</title>

--- a/appendices/reserved.constants.xml
+++ b/appendices/reserved.constants.xml
@@ -1,17 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
+<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
 
- <!--
-   This file should only be present in the English doc tree. If you
-   copy it over to your translation tree you will be hunted down
-   relentlessly! You have been warned! :)
- -->
+<!-- DO NOT TRANSLATE THIS FILE. -->
 
- <sect1 xml:id="reserved.constants" xmlns="http://docbook.org/ns/docbook">
-  <title>&ReservedConstants;</title>
-  &appendices.reserved.constants.core;
-  &appendices.reserved.constants.standard;
- </sect1>
+<sect1 xml:id="reserved.constants" xmlns="http://docbook.org/ns/docbook">
+ <title>&ReservedConstants;</title>
+ &appendices.reserved.constants.core;
+ &appendices.reserved.constants.standard;
+</sect1>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/contributors.xml
+++ b/contributors.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
-
-<!-- DO NOT TRANSLATE THIS FILE. -->
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
 
 <section xmlns="http://docbook.org/ns/docbook" annotations="chunk:false" xml:id="contributors">
  <info><title>&Credit.Authors.and.Contributors;</title></info>

--- a/contributors.xml
+++ b/contributors.xml
@@ -1,11 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
+<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
 
- <!--
-   This file should only be present in the English doc tree. If you
-   copy it over to your translation tree you will be hunted down
-   relentlessly! You have been warned! :)
- -->
+<!-- DO NOT TRANSLATE THIS FILE. -->
+
 <section xmlns="http://docbook.org/ns/docbook" annotations="chunk:false" xml:id="contributors">
  <info><title>&Credit.Authors.and.Contributors;</title></info>
 

--- a/language/control-structures/versions.xml
+++ b/language/control-structures/versions.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
-
-<!-- DO NOT TRANSLATE THIS FILE. -->
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
 
 <versions>
  <function name='include' from='PHP 4, PHP 5, PHP 7, PHP 8'/>

--- a/language/control-structures/versions.xml
+++ b/language/control-structures/versions.xml
@@ -1,8 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?xml version="1.0" encoding="utf-8"?><?do-not-translate?>
+
+<!-- DO NOT TRANSLATE THIS FILE. -->
 
 <versions>
  <function name='include' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
@@ -51,4 +49,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/datetime/timezones.xml
+++ b/reference/datetime/timezones.xml
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- AUTO GENERATED, DO NOT TRANSLATE OR MODIFY BY HAND -->
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
 
+<!-- AUTO GENERATED, DO NOT TRANSLATE OR MODIFY BY HAND -->
 <!-- The script to generate this file is scripts/gen-phpdoc-tz-list.php -->
 <!-- in the doc-base repo. However, it should only need to be run when  -->
 <!-- the tzdb file is updated by the maintainer of DateTime/timelib.    -->
@@ -1078,4 +1079,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=php
 vi: ts=4 sw=1
 -->
-


### PR DESCRIPTION
Apply the new `<?do-not-translate?>` in `doc-en` files that are auto-generated, expected not translated, ot that not contains any translatable text.

In special, I would like to confirm/know:

* `docbookcs.xml` should not be copied on translatoins?
* en/appendices/license.xml is expected never translated.
* where is the code that generates en/reference/datetime/timezones.xml, this the generator outputs the `<?do-not-translate?>` mark.

Things I considered:

1. To remove the vi/vim comments and eof very small files, and from all version.xml files;

2. To remove the top comment, and leave only at start:
```xml
<?xml version="1.0" encoding="utf-8"?>
<?do-not-translate?>

```

There still about 200 `/*/versions.xml` files, that I will change, directly, if and after this PR is merged. Plan to merge it in one week, if there is no hard oppositions.