### PR TITLE
Add redirect.xml map for manual pages on php.net

### DIFF
--- a/redirects.xml
+++ b/redirects.xml
@@ -1,0 +1,454 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Redirect map for manual pages on php.net.
+
+  Rendered to redirects.php by phd (Redirects package) and included by
+  web-php/error.php. Only redirects that concern manual pages live here;
+  site-level aliases (downloads, support, git, etc.) and external URLs
+  stay in web-php/error.php.
+
+  Scopes:
+    shortcut   match a bare URI  (php.net/{from})
+                  -> /manual/{lang}/{to}.php
+    in-manual  match a manual URI (php.net/manual/{lang}/{from}.php)
+                  -> /manual/{lang}/{to}.php
+    both       fires at either entry point (bare or in-manual)
+
+  Every redirect here is served with HTTP 301.
+
+  The regex block only carries rewrites that target the manual URL
+  space; non-manual regex rewrites (news-N, release_*, GH-N, .php3)
+  remain in error.php.
+-->
+<redirects xmlns="http://php.net/redirects">
+ 
+ <!-- ==================================================================== -->
+ <!-- scope="in-manual": only fires inside /manual/{lang}/{from}.php        -->
+ <!-- (ported from $manual_redirections in web-php/error.php)               -->
+ <!-- ==================================================================== -->
+ <group scope="in-manual">
+
+  <!-- OCI-Lob class renamed -->
+  <redirect from="class.oci-lob"          to="class.ocilob"/>
+  <redirect from="oci-lob.append"         to="ocilob.append"/>
+  <redirect from="oci-lob.close"          to="ocilob.close"/>
+  <redirect from="oci-lob.eof"            to="ocilob.eof"/>
+  <redirect from="oci-lob.erase"          to="ocilob.erase"/>
+  <redirect from="oci-lob.export"         to="ocilob.export"/>
+  <redirect from="oci-lob.flush"          to="ocilob.flush"/>
+  <redirect from="oci-lob.free"           to="ocilob.free"/>
+  <redirect from="oci-lob.getbuffering"   to="ocilob.getbuffering"/>
+  <redirect from="oci-lob.import"         to="ocilob.import"/>
+  <redirect from="oci-lob.load"           to="ocilob.load"/>
+  <redirect from="oci-lob.read"           to="ocilob.read"/>
+  <redirect from="oci-lob.rewind"         to="ocilob.rewind"/>
+  <redirect from="oci-lob.save"           to="ocilob.save"/>
+  <redirect from="oci-lob.seek"           to="ocilob.seek"/>
+  <redirect from="oci-lob.setbuffering"   to="ocilob.setbuffering"/>
+  <redirect from="oci-lob.size"           to="ocilob.size"/>
+  <redirect from="oci-lob.tell"           to="ocilob.tell"/>
+  <redirect from="oci-lob.truncate"       to="ocilob.truncate"/>
+  <redirect from="oci-lob.write"          to="ocilob.write"/>
+  <redirect from="oci-lob.writetemporary" to="ocilob.writetemporary"/>
+
+  <!-- OCI-Collection class renamed -->
+  <redirect from="class.oci-collection"      to="class.ocicollection"/>
+  <redirect from="oci-collection.append"     to="ocicollection.append"/>
+  <redirect from="oci-collection.assign"     to="ocicollection.assign"/>
+  <redirect from="oci-collection.assignelem" to="ocicollection.assignelem"/>
+  <redirect from="oci-collection.free"       to="ocicollection.free"/>
+  <redirect from="oci-collection.getelem"    to="ocicollection.getelem"/>
+  <redirect from="oci-collection.max"        to="ocicollection.max"/>
+  <redirect from="oci-collection.size"       to="ocicollection.size"/>
+  <redirect from="oci-collection.trim"       to="ocicollection.trim"/>
+
+  <!-- SplStack/SplQueue methods moved to SplDoublyLinkedList -->
+  <redirect from="splstack.setiteratormode" to="spldoublylinkedlist.setiteratormode"/>
+  <redirect from="splqueue.setiteratormode" to="spldoublylinkedlist.setiteratormode"/>
+
+  <!-- Attribute classes renamed to CamelCase -->
+  <redirect from="class.allow-dynamic-properties" to="class.allowdynamicproperties"/>
+  <redirect from="class.return-type-will-change"  to="class.returntypewillchange"/>
+  <redirect from="class.sensitive-parameter"      to="class.sensitiveparameter"/>
+
+  <!-- Function-form page replaced by class page -->
+  <redirect from="function.curl-file-create" to="curlfile.construct"/>
+
+  <!-- SimpleXMLIterator methods moved to SimpleXMLElement -->
+  <redirect from="simplexmliterator.current"     to="simplexmlelement.current"/>
+  <redirect from="simplexmliterator.getchildren" to="simplexmlelement.getchildren"/>
+  <redirect from="simplexmliterator.haschildren" to="simplexmlelement.haschildren"/>
+  <redirect from="simplexmliterator.key"         to="simplexmlelement.key"/>
+  <redirect from="simplexmliterator.next"        to="simplexmlelement.next"/>
+  <redirect from="simplexmliterator.rewind"      to="simplexmlelement.rewind"/>
+  <redirect from="simplexmliterator.valid"       to="simplexmlelement.valid"/>
+ </group>
+
+ <!-- ==================================================================== -->
+ <!-- scope="shortcut": bare URI shortcut into a manual page                -->
+ <!-- (ported from $uri_aliases doc-target subset + $mysqli_redirects)      -->
+ <!-- ==================================================================== -->
+ <group scope="shortcut">
+
+  <!-- Manual shortcuts -->
+  <redirect from="intro"       to="introduction"/>
+  <redirect from="whatis"      to="introduction"/>
+  <redirect from="whatisphp"   to="introduction"/>
+  <redirect from="what_is_php" to="introduction"/>
+  <redirect from="composer"    to="install.composer.intro"/>
+
+  <redirect from="windows" to="install.windows"/>
+  <redirect from="win32"   to="install.windows"/>
+
+  <redirect from="globals"                                to="language.variables.predefined"/>
+  <redirect from="register_globals"                       to="security.globals"/>
+  <redirect from="registerglobals"                        to="security.globals"/>
+  <!-- fix for 4.3.8 configure -->
+  <redirect from="manual/en/security.registerglobals.php" to="security.globals"/>
+  <redirect from="magic_quotes"                           to="security.magicquotes"/>
+  <redirect from="magicquotes"                            to="security.magicquotes"/>
+  <redirect from="gd"                                     to="image"/>
+  <redirect from="bcmath"                                 to="bc"/>
+  <redirect from="streams"                                to="book.stream"/>
+  <redirect from="mongodb"                                to="book.mongodb"/>
+  <!-- Prefer function over PECL ext -->
+  <redirect from="hrtime"                                 to="function.hrtime"/>
+
+  <!-- Types & pseudo-types -->
+  <redirect from="callback" to="language.pseudo-types"/>
+  <redirect from="number"   to="language.pseudo-types"/>
+  <redirect from="mixed"    to="language.pseudo-types"/>
+  <redirect from="bool"     to="language.types.boolean"/>
+  <redirect from="boolean"  to="language.types.boolean"/>
+  <redirect from="int"      to="language.types.integer"/>
+  <redirect from="integer"  to="language.types.integer"/>
+  <redirect from="float"    to="language.types.float"/>
+  <redirect from="string"   to="language.types.string"/>
+  <redirect from="heredoc"  to="language.types.string"/>
+  <redirect from="&lt;&lt;&lt;" to="language.types.string"/>
+  <redirect from="object"   to="language.types.object"/>
+  <redirect from="null"     to="language.types.null"/>
+  <redirect from="callable" to="language.types.callable"/>
+
+  <redirect from="htaccess"  to="configuration.changes"/>
+  <redirect from="php_value" to="configuration.changes"/>
+
+  <!-- Operators -->
+  <redirect from="operator.precedence"  to="language.operators.precedence"/>
+  <redirect from="operator-precedence"  to="language.operators.precedence"/>
+  <redirect from="precedence"           to="language.operators.precedence"/>
+  <redirect from="arithmetic.operators" to="language.operators.arithmetic"/>
+  <redirect from="arithmetic-operators" to="language.operators.arithmetic"/>
+  <redirect from="assignment.operators" to="language.operators.assignment"/>
+  <redirect from="assignment-operators" to="language.operators.assignment"/>
+  <redirect from="bitwise.operators"    to="language.operators.bitwise"/>
+  <redirect from="bitwise-operators"    to="language.operators.bitwise"/>
+  <redirect from="comparison.operators" to="language.operators.comparison"/>
+  <redirect from="comparison-operators" to="language.operators.comparison"/>
+  <redirect from="error.control"        to="language.operators.errorcontrol"/>
+  <redirect from="error-control"        to="language.operators.errorcontrol"/>
+  <redirect from="backtick"             to="language.operators.execution"/>
+  <redirect from="backtick.operator"    to="language.operators.execution"/>
+  <redirect from="backtick-operator"    to="language.operators.execution"/>
+  <redirect from="execution.operator"   to="language.operators.execution"/>
+  <redirect from="increment.operators"  to="language.operators.increment"/>
+  <redirect from="increment-operators"  to="language.operators.increment"/>
+  <redirect from="logical.operators"    to="language.operators.logical"/>
+  <redirect from="logical-operators"    to="language.operators.logical"/>
+  <redirect from="string.operators"     to="language.operators.string"/>
+  <redirect from="string-operators"     to="language.operators.string"/>
+  <redirect from="type.operators"       to="language.operators.type"/>
+  <redirect from="type-operators"       to="language.operators.type"/>
+
+  <redirect from="string.type" to="language.types.string"/>
+  <redirect from="array.type"  to="language.types.array"/>
+  <redirect from="object.type" to="language.types.object"/>
+
+  <redirect from="statements"         to="control-structures.intro"/>
+  <redirect from="control.structures" to="control-structures.intro"/>
+  <redirect from="control-structures" to="control-structures.intro"/>
+
+  <redirect from="ternary"    to="language.operators.comparison"/>
+  <redirect from="instanceof" to="language.operators.type"/>
+  <redirect from="if"         to="language.control-structures"/>
+  <redirect from="static"     to="language.variables.scope"/>
+  <redirect from="global"     to="language.variables.scope"/>
+  <redirect from="@"          to="language.operators.errorcontrol"/>
+  <redirect from="&amp;"      to="language.references"/>
+  <redirect from="**"         to="language.operators.arithmetic"/>
+  <redirect from="..."        to="functions.arguments"/>
+  <redirect from="splat"      to="functions.arguments"/>
+  <redirect from="arrow"      to="functions.arrow"/>
+  <redirect from="fn"         to="functions.arrow"/>
+  <redirect from="pipe"       to="operators.functional"/>
+  <redirect from="|&gt;"      to="operators.functional"/>
+  <!--
+    ?:, ??, ??= shortcuts can't be captured here since they don't
+    actually produce a 404. Handled inline in index.php.
+  -->
+
+  <redirect from="dowhile" to="control-structures.do.while"/>
+
+  <redirect from="tut"     to="tutorial"/>
+  <redirect from="tut.php" to="tutorial"/> <!-- BC -->
+
+  <redirect from="faq.php" to="faq"/> <!-- BC -->
+
+  <redirect from="odbc"   to="uodbc"/> <!-- BC -->
+  <redirect from="oracle" to="oci8"/>
+  <redirect from="cli"    to="features.commandline"/>
+
+  <!-- OOP -->
+  <redirect from="oop"   to="language.oop5"/>
+  <redirect from="enum"  to="language.enumerations"/>
+  <redirect from="enums" to="language.enumerations"/>
+
+  <redirect from="const"      to="language.constants.syntax"/>
+  <redirect from="class"      to="language.oop5.basic"/>
+  <redirect from="new"        to="language.oop5.basic"/>
+  <redirect from="extends"    to="language.oop5.basic"/>
+  <redirect from="clone"      to="language.oop5.cloning"/>
+  <redirect from="construct"  to="language.oop5.decon"/>
+  <redirect from="destruct"   to="language.oop5.decon"/>
+  <redirect from="public"     to="language.oop5.visibility"/>
+  <redirect from="private"    to="language.oop5.visibility"/>
+  <redirect from="protected"  to="language.oop5.visibility"/>
+  <redirect from="var"        to="language.oop5.visibility"/>
+  <redirect from="abstract"   to="language.oop5.abstract"/>
+  <redirect from="interface"  to="language.oop5.interfaces"/>
+  <redirect from="interfaces" to="language.oop5.interfaces"/>
+  <redirect from="autoload"   to="language.oop5.autoload"/>
+  <redirect from="__autoload" to="language.oop5.autoload"/>
+  <!-- BC -->
+  <redirect from="language.oop5.reflection" to="book.reflection"/>
+  <redirect from="::"                       to="language.oop5.paamayim-nekudotayim"/>
+
+  <redirect from="__construct"  to="language.oop5.decon"/>
+  <redirect from="__destruct"   to="language.oop5.decon"/>
+  <redirect from="__call"       to="language.oop5.overloading"/>
+  <redirect from="__callstatic" to="language.oop5.overloading"/>
+  <redirect from="__get"        to="language.oop5.overloading"/>
+  <redirect from="__set"        to="language.oop5.overloading"/>
+  <redirect from="__isset"      to="language.oop5.overloading"/>
+  <redirect from="__unset"      to="language.oop5.overloading"/>
+  <redirect from="__sleep"      to="language.oop5.magic"/>
+  <redirect from="__wakeup"     to="language.oop5.magic"/>
+  <redirect from="__tostring"   to="language.oop5.magic"/>
+  <redirect from="__invoke"     to="language.oop5.magic"/>
+  <redirect from="__set_state"  to="language.oop5.magic"/>
+  <redirect from="__debuginfo"  to="language.oop5.magic"/>
+  <redirect from="__clone"      to="language.oop5.cloning"/>
+
+  <redirect from="throw"     to="language.exceptions"/>
+  <redirect from="try"       to="language.exceptions"/>
+  <redirect from="catch"     to="language.exceptions"/>
+  <redirect from="lsb"       to="language.oop5.late-static-bindings"/>
+  <redirect from="namespace" to="language.namespaces"/>
+  <redirect from="use"       to="language.namespaces.using"/>
+
+  <redirect from="factory"   to="language.oop5.patterns"/>
+  <redirect from="singleton" to="language.oop5.patterns"/>
+
+  <redirect from="trait"  to="language.oop5.traits"/>
+  <redirect from="traits" to="language.oop5.traits"/>
+
+  <!-- BC legacy PHP 5 assets that landed on the OOP chapter -->
+  <redirect from="php5"                         to="language.oop5"/>
+  <redirect from="zend_changes.txt"             to="language.oop5"/>
+  <redirect from="zend2_example.phps"           to="language.oop5"/>
+  <redirect from="zend_changes_php_5_0_0b2.txt" to="language.oop5"/>
+  <redirect from="zend-engine-2"                to="language.oop5"/>
+  <redirect from="zend-engine-2.php"            to="language.oop5"/>
+
+  <!-- Legacy manual page BC -->
+  <redirect from="manual/about-notes.php" to="manual/add-note"/>
+
+  <!-- Migration guides -->
+  <redirect from="migration7"            to="migration70"/>
+  <redirect from="update_5_2.txt"        to="migration52"/> <!-- BC -->
+  <redirect from="readme_upgrade_51.php" to="migration51"/> <!-- BC -->
+
+  <!-- Internals & ini -->
+  <redirect from="internals"                to="internals2"/>   <!-- BC -->
+  <redirect from="configuration.directives" to="ini.core"/>     <!-- BC -->
+
+  <!-- regexp reference BC -->
+  <redirect from="regexp.reference.backslash"      to="regexp.reference.escape"/>
+  <redirect from="regexp.reference.circudollar"    to="regexp.reference.anchors"/>
+  <redirect from="regexp.reference.squarebrackets" to="regexp.reference.character-classes"/>
+  <redirect from="regexp.reference.verticalbar"    to="regexp.reference.alternation"/>
+
+  <!-- Security -->
+  <redirect from="security/crypt" to="security/crypt_blowfish"/>
+
+  <!-- Bugfixes: #64743 -->
+  <redirect from="array_sort" to="sort"/>
+  <redirect from="array-sort" to="sort"/>
+
+  <!--
+    Temporary hack to fix bug #49956 for mysqli.
+    Data taken from mysqli/summary.xml.
+  -->
+  <redirect from="mysqli_affected_rows"        to="mysqli.affected-rows"/>
+  <redirect from="mysqli_get_client_version"   to="mysqli.client-version"/>
+  <redirect from="mysqli_connect_errno"        to="mysqli.connect-errno"/>
+  <redirect from="mysqli_connect_error"        to="mysqli.connect-error"/>
+  <redirect from="mysqli_errno"                to="mysqli.errno"/>
+  <redirect from="mysqli_error"                to="mysqli.error"/>
+  <redirect from="mysqli_field_count"          to="mysqli.field-count"/>
+  <redirect from="mysqli_get_host_info"        to="mysqli.host-info"/>
+  <redirect from="mysqli_get_proto_info"       to="mysqli.protocol-version"/>
+  <redirect from="mysqli_get_server_version"   to="mysqli.server-version"/>
+  <redirect from="mysqli_info"                 to="mysqli.info"/>
+  <redirect from="mysqli_insert_id"            to="mysqli.insert-id"/>
+  <redirect from="mysqli_sqlstate"             to="mysqli.sqlstate"/>
+  <redirect from="mysqli_warning_count"        to="mysqli.warning-count"/>
+  <redirect from="mysqli_autocommit"           to="mysqli.autocommit"/>
+  <redirect from="mysqli_change_user"          to="mysqli.change-user"/>
+  <redirect from="mysqli_character_set_name"   to="mysqli.character-set-name"/>
+  <redirect from="mysqli_close"                to="mysqli.close"/>
+  <redirect from="mysqli_commit"               to="mysqli.commit"/>
+  <redirect from="mysqli_connect"              to="mysqli.construct"/>
+  <redirect from="mysqli_debug"                to="mysqli.debug"/>
+  <redirect from="mysqli_dump_debug_info"      to="mysqli.dump-debug-info"/>
+  <redirect from="mysqli_get_charset"          to="mysqli.get-charset"/>
+  <redirect from="mysqli_get_connection_stats" to="mysqli.get-connection-stats"/>
+  <redirect from="mysqli_get_client_info"      to="mysqli.get-client-info"/>
+  <redirect from="mysqli_get_client_stats"     to="mysqli.get-client-stats"/>
+  <redirect from="mysqli_get_cache_stats"      to="mysqli.get-cache-stats"/>
+  <redirect from="mysqli_get_server_info"      to="mysqli.get-server-info"/>
+  <redirect from="mysqli_get_warnings"         to="mysqli.get-warnings"/>
+  <redirect from="mysqli_init"                 to="mysqli.init"/>
+  <redirect from="mysqli_kill"                 to="mysqli.kill"/>
+  <redirect from="mysqli_more_results"         to="mysqli.more-results"/>
+  <redirect from="mysqli_multi_query"          to="mysqli.multi-query"/>
+  <redirect from="mysqli_next_result"          to="mysqli.next-result"/>
+  <redirect from="mysqli_options"              to="mysqli.options"/>
+  <redirect from="mysqli_ping"                 to="mysqli.ping"/>
+  <redirect from="mysqli_prepare"              to="mysqli.prepare"/>
+  <redirect from="mysqli_query"                to="mysqli.query"/>
+  <redirect from="mysqli_real_connect"         to="mysqli.real-connect"/>
+  <redirect from="mysqli_real_escape_string"   to="mysqli.real-escape-string"/>
+  <redirect from="mysqli_real_query"           to="mysqli.real-query"/>
+  <redirect from="mysqli_refresh"              to="mysqli.refresh"/>
+  <redirect from="mysqli_rollback"             to="mysqli.rollback"/>
+  <redirect from="mysqli_select_db"            to="mysqli.select-db"/>
+  <redirect from="mysqli_set_charset"          to="mysqli.set-charset"/>
+  <redirect from="mysqli_set_local_infile_default" to="mysqli.set-local-infile-default"/>
+  <redirect from="mysqli_set_local_infile_handler" to="mysqli.set-local-infile-handler"/>
+  <redirect from="mysqli_ssl_set"              to="mysqli.ssl-set"/>
+  <redirect from="mysqli_stat"                 to="mysqli.stat"/>
+  <redirect from="mysqli_stmt_init"            to="mysqli.stmt-init"/>
+  <redirect from="mysqli_store_result"         to="mysqli.store-result"/>
+  <redirect from="mysqli_thread_id"            to="mysqli.thread-id"/>
+  <redirect from="mysqli_thread_safe"          to="mysqli.thread-safe"/>
+  <redirect from="mysqli_use_result"           to="mysqli.use-result"/>
+
+  <redirect from="mysqli_stmt_affected_rows"   to="mysqli-stmt.affected-rows"/>
+  <redirect from="mysqli_stmt_errno"           to="mysqli-stmt.errno"/>
+  <redirect from="mysqli_stmt_error"           to="mysqli-stmt.error"/>
+  <redirect from="mysqli_stmt_field_count"     to="mysqli-stmt.field-count"/>
+  <redirect from="mysqli_stmt_insert_id"       to="mysqli-stmt.insert-id"/>
+  <redirect from="mysqli_stmt_param_count"     to="mysqli-stmt.param-count"/>
+  <redirect from="mysqli_stmt_sqlstate"        to="mysqli-stmt.sqlstate"/>
+  <redirect from="mysqli_stmt_attr_get"        to="mysqli-stmt.attr-get"/>
+  <redirect from="mysqli_stmt_attr_set"        to="mysqli-stmt.attr-set"/>
+  <redirect from="mysqli_stmt_bind_param"      to="mysqli-stmt.bind-param"/>
+  <redirect from="mysqli_stmt_bind_result"     to="mysqli-stmt.bind-result"/>
+  <redirect from="mysqli_stmt_close"           to="mysqli-stmt.close"/>
+  <redirect from="mysqli_stmt_data_seek"       to="mysqli-stmt.data-seek"/>
+  <redirect from="mysqli_stmt_execute"         to="mysqli-stmt.execute"/>
+  <redirect from="mysqli_stmt_fetch"           to="mysqli-stmt.fetch"/>
+  <redirect from="mysqli_stmt_free_result"     to="mysqli-stmt.free-result"/>
+  <redirect from="mysqli_stmt_get_result"      to="mysqli-stmt.get-result"/>
+  <redirect from="mysqli_stmt_get_warnings"    to="mysqli-stmt.get-warnings"/>
+  <redirect from="mysqli_stmt_more_results"    to="mysqli-stmt.more-results"/>
+  <redirect from="mysqli_stmt_next_result"     to="mysqli-stmt.next-result"/>
+  <redirect from="mysqli_stmt_num_rows"        to="mysqli-stmt.num-rows"/>
+  <redirect from="mysqli_stmt_prepare"         to="mysqli-stmt.prepare"/>
+  <redirect from="mysqli_stmt_reset"           to="mysqli-stmt.reset"/>
+  <redirect from="mysqli_stmt_result_metadata" to="mysqli-stmt.result-metadata"/>
+  <redirect from="mysqli_stmt_send_long_data"  to="mysqli-stmt.send-long-data"/>
+  <redirect from="mysqli_stmt_store_result"    to="mysqli-stmt.store-result"/>
+
+  <redirect from="mysqli_field_tell"         to="mysqli-result.current-field"/>
+  <redirect from="mysqli_num_fields"         to="mysqli-result.field-count"/>
+  <redirect from="mysqli_fetch_lengths"      to="mysqli-result.lengths"/>
+  <redirect from="mysqli_num_rows"           to="mysqli-result.num-rows"/>
+  <redirect from="mysqli_data_seek"          to="mysqli-result.data-seek"/>
+  <redirect from="mysqli_fetch_all"          to="mysqli-result.fetch-all"/>
+  <redirect from="mysqli_fetch_array"        to="mysqli-result.fetch-array"/>
+  <redirect from="mysqli_fetch_assoc"        to="mysqli-result.fetch-assoc"/>
+  <redirect from="mysqli_fetch_field_direct" to="mysqli-result.fetch-field-direct"/>
+  <redirect from="mysqli_fetch_field"        to="mysqli-result.fetch-field"/>
+  <redirect from="mysqli_fetch_fields"       to="mysqli-result.fetch-fields"/>
+  <redirect from="mysqli_fetch_object"       to="mysqli-result.fetch-object"/>
+  <redirect from="mysqli_fetch_row"          to="mysqli-result.fetch-row"/>
+  <redirect from="mysqli_field_seek"         to="mysqli-result.field-seek"/>
+  <redirect from="mysqli_free_result"        to="mysqli-result.free"/>
+
+  <redirect from="mysqli_embedded_server_end"   to="mysqli-driver.embedded-server-end"/>
+  <redirect from="mysqli_embedded_server_start" to="mysqli-driver.embedded-server-start"/>
+  
+ </group>
+
+ <!-- ==================================================================== -->
+ <!-- scope="both": manual page renamed; both bare and in-manual URLs fire  -->
+ <!-- (ported from $manual_page_moves in web-php/error.php)                 -->
+ <!-- ==================================================================== -->
+ <group scope="both">
+
+  <!-- entry point changed -->
+  <redirect from="installation" to="install"/>
+
+  <!-- XML Id changed (see https://github.com/php/doc-en/commit/0d51ca45814bbc60d7a1e6cf6fc7213f0b49c8d5) -->
+  <redirect from="enum.random.intervalboundary"          to="enum.random-intervalboundary"/>
+  <redirect from="enum.random.intervalboundary.intro"    to="enum.random-intervalboundary.intro"/>
+  <redirect from="enum.random.intervalboundary.synopsis" to="enum.random-intervalboundary.synopsis"/>
+
+  <!-- was split among platforms (don't know where to redirect) -->
+  <redirect from="install.apache"              to="install"/>
+  <redirect from="install.apache2"             to="install"/>
+  <redirect from="install.netscape-enterprise" to="install"/>
+  <redirect from="install.otherhttpd"          to="install"/>
+
+  <!-- moved to platform sections -->
+  <redirect from="install.caudium"               to="install.unix.caudium"/>
+  <redirect from="install.commandline"           to="install.unix.commandline"/>
+  <redirect from="install.fhttpd"                to="install.unix.fhttpd"/>
+  <redirect from="install.hpux"                  to="install.unix.hpux"/>
+  <redirect from="install.iis"                   to="install.windows.iis"/>
+  <redirect from="install.linux"                 to="install.unix"/>
+  <redirect from="install.omnihttpd"             to="install.windows.omnihttpd"/>
+  <redirect from="install.openbsd"               to="install.unix.openbsd"/>
+  <redirect from="install.sambar"                to="install.windows.sambar"/>
+  <redirect from="install.solaris"               to="install.unix.solaris"/>
+  <redirect from="install.xitami"                to="install.windows.xitami"/>
+  <redirect from="install.windows.installer.msi" to="install.windows"/>
+  <redirect from="install.windows.installer"     to="install.windows"/>
+
+  <!-- Internals docs were moved -->
+  <redirect from="zend"          to="internals2.ze1.zendapi"/>
+  <redirect from="zend-api"      to="internals2.ze1.zendapi"/>
+  <redirect from="internals.pdo" to="internals2.pdo"/>
+  <redirect from="phpdevel"      to="internals2.ze1.php3devel"/>
+  <redirect from="tsrm"          to="internals2.ze1.tsrm"/>
+
+  <!-- Replaced extensions -->
+  <redirect from="aspell" to="pspell"/>
+
+  <!-- Refactored -->
+  <redirect from="regexp.reference" to="regexp.introduction"/>
+  <redirect from="security"         to="manual/security"/>
+
+  <!-- MongoDB converted from set to book -->
+  <redirect from="set.mongodb"                         to="book.mongodb"/>
+  <redirect from="mongodb.installation.homebrew"       to="mongodb.installation#mongodb.installation.homebrew"/>
+  <redirect from="mongodb.installation.manual"         to="mongodb.installation#mongodb.installation.manual"/>
+  <redirect from="mongodb.installation.pecl"           to="mongodb.installation#mongodb.installation.pecl"/>
+  <redirect from="mongodb.installation.windows"        to="mongodb.installation#mongodb.installation.windows"/>
+  <redirect from="mongodb.persistence.deserialization" to="mongodb.persistence#mongodb.persistence.deserialization"/>
+  <redirect from="mongodb.persistence.serialization"   to="mongodb.persistence#mongodb.persistence.serialization"/>
+ </group>
+
+</redirects>

--- a/redirects.xml
+++ b/redirects.xml
@@ -101,23 +101,17 @@
   <redirect from="win32"   to="install.windows"/>
 
   <redirect from="globals"                                to="language.variables.predefined"/>
-  <redirect from="register_globals"                       to="security.globals"/>
-  <redirect from="registerglobals"                        to="security.globals"/>
-  <!-- fix for 4.3.8 configure -->
-  <redirect from="manual/en/security.registerglobals.php" to="security.globals"/>
-  <redirect from="magic_quotes"                           to="security.magicquotes"/>
-  <redirect from="magicquotes"                            to="security.magicquotes"/>
-  <redirect from="gd"                                     to="image"/>
-  <redirect from="bcmath"                                 to="bc"/>
+  <redirect from="gd"                                     to="book.image"/>
+  <redirect from="bcmath"                                 to="book.bc"/>
   <redirect from="streams"                                to="book.stream"/>
   <redirect from="mongodb"                                to="book.mongodb"/>
   <!-- Prefer function over PECL ext -->
   <redirect from="hrtime"                                 to="function.hrtime"/>
 
   <!-- Types & pseudo-types -->
-  <redirect from="callback" to="language.pseudo-types"/>
-  <redirect from="number"   to="language.pseudo-types"/>
-  <redirect from="mixed"    to="language.pseudo-types"/>
+  <redirect from="callback" to="language.types.declarations"/>
+  <redirect from="number"   to="language.types.declarations"/>
+  <redirect from="mixed"    to="language.types.declarations"/>
   <redirect from="bool"     to="language.types.boolean"/>
   <redirect from="boolean"  to="language.types.boolean"/>
   <redirect from="int"      to="language.types.integer"/>
@@ -180,8 +174,8 @@
   <redirect from="splat"      to="functions.arguments"/>
   <redirect from="arrow"      to="functions.arrow"/>
   <redirect from="fn"         to="functions.arrow"/>
-  <redirect from="pipe"       to="operators.functional"/>
-  <redirect from="|&gt;"      to="operators.functional"/>
+  <redirect from="pipe"       to="language.operators.functional"/>
+  <redirect from="|&gt;"      to="language.operators.functional"/>
   <!--
     ?:, ??, ??= shortcuts can't be captured here since they don't
     actually produce a 404. Handled inline in index.php.
@@ -194,8 +188,8 @@
 
   <redirect from="faq.php" to="faq"/> <!-- BC -->
 
-  <redirect from="odbc"   to="uodbc"/> <!-- BC -->
-  <redirect from="oracle" to="oci8"/>
+  <redirect from="odbc"   to="book.uodbc"/> <!-- BC -->
+  <redirect from="oracle" to="book.oci8"/>
   <redirect from="cli"    to="features.commandline"/>
 
   <!-- OOP -->
@@ -244,10 +238,7 @@
   <redirect from="catch"     to="language.exceptions"/>
   <redirect from="lsb"       to="language.oop5.late-static-bindings"/>
   <redirect from="namespace" to="language.namespaces"/>
-  <redirect from="use"       to="language.namespaces.using"/>
-
-  <redirect from="factory"   to="language.oop5.patterns"/>
-  <redirect from="singleton" to="language.oop5.patterns"/>
+  <redirect from="use"       to="language.namespaces.importing"/>
 
   <redirect from="trait"  to="language.oop5.traits"/>
   <redirect from="traits" to="language.oop5.traits"/>
@@ -260,17 +251,11 @@
   <redirect from="zend-engine-2"                to="language.oop5"/>
   <redirect from="zend-engine-2.php"            to="language.oop5"/>
 
-  <!-- Legacy manual page BC -->
-  <redirect from="manual/about-notes.php" to="manual/add-note"/>
-
   <!-- Migration guides -->
-  <redirect from="migration7"            to="migration70"/>
-  <redirect from="update_5_2.txt"        to="migration52"/> <!-- BC -->
-  <redirect from="readme_upgrade_51.php" to="migration51"/> <!-- BC -->
+  <redirect from="migration7" to="migration70"/>
 
-  <!-- Internals & ini -->
-  <redirect from="internals"                to="internals2"/>   <!-- BC -->
-  <redirect from="configuration.directives" to="ini.core"/>     <!-- BC -->
+  <!-- ini -->
+  <redirect from="configuration.directives" to="ini.core"/> <!-- BC -->
 
   <!-- regexp reference BC -->
   <redirect from="regexp.reference.backslash"      to="regexp.reference.escape"/>
@@ -278,27 +263,23 @@
   <redirect from="regexp.reference.squarebrackets" to="regexp.reference.character-classes"/>
   <redirect from="regexp.reference.verticalbar"    to="regexp.reference.alternation"/>
 
-  <!-- Security -->
-  <redirect from="security/crypt" to="security/crypt_blowfish"/>
-
   <!-- Bugfixes: #64743 -->
-  <redirect from="array_sort" to="sort"/>
-  <redirect from="array-sort" to="sort"/>
+  <redirect from="array_sort" to="function.sort"/>
+  <redirect from="array-sort" to="function.sort"/>
 
   <!--
     Temporary hack to fix bug #49956 for mysqli.
     Data taken from mysqli/summary.xml.
   -->
   <redirect from="mysqli_affected_rows"        to="mysqli.affected-rows"/>
-  <redirect from="mysqli_get_client_version"   to="mysqli.client-version"/>
+  <redirect from="mysqli_get_client_version"   to="mysqli.get-client-version"/>
   <redirect from="mysqli_connect_errno"        to="mysqli.connect-errno"/>
   <redirect from="mysqli_connect_error"        to="mysqli.connect-error"/>
   <redirect from="mysqli_errno"                to="mysqli.errno"/>
   <redirect from="mysqli_error"                to="mysqli.error"/>
   <redirect from="mysqli_field_count"          to="mysqli.field-count"/>
-  <redirect from="mysqli_get_host_info"        to="mysqli.host-info"/>
-  <redirect from="mysqli_get_proto_info"       to="mysqli.protocol-version"/>
-  <redirect from="mysqli_get_server_version"   to="mysqli.server-version"/>
+  <redirect from="mysqli_get_host_info"        to="mysqli.get-host-info"/>
+  <redirect from="mysqli_get_server_version"   to="mysqli.get-server-version"/>
   <redirect from="mysqli_info"                 to="mysqli.info"/>
   <redirect from="mysqli_insert_id"            to="mysqli.insert-id"/>
   <redirect from="mysqli_sqlstate"             to="mysqli.sqlstate"/>
@@ -314,8 +295,6 @@
   <redirect from="mysqli_get_charset"          to="mysqli.get-charset"/>
   <redirect from="mysqli_get_connection_stats" to="mysqli.get-connection-stats"/>
   <redirect from="mysqli_get_client_info"      to="mysqli.get-client-info"/>
-  <redirect from="mysqli_get_client_stats"     to="mysqli.get-client-stats"/>
-  <redirect from="mysqli_get_cache_stats"      to="mysqli.get-cache-stats"/>
   <redirect from="mysqli_get_server_info"      to="mysqli.get-server-info"/>
   <redirect from="mysqli_get_warnings"         to="mysqli.get-warnings"/>
   <redirect from="mysqli_init"                 to="mysqli.init"/>
@@ -334,8 +313,6 @@
   <redirect from="mysqli_rollback"             to="mysqli.rollback"/>
   <redirect from="mysqli_select_db"            to="mysqli.select-db"/>
   <redirect from="mysqli_set_charset"          to="mysqli.set-charset"/>
-  <redirect from="mysqli_set_local_infile_default" to="mysqli.set-local-infile-default"/>
-  <redirect from="mysqli_set_local_infile_handler" to="mysqli.set-local-infile-handler"/>
   <redirect from="mysqli_ssl_set"              to="mysqli.ssl-set"/>
   <redirect from="mysqli_stat"                 to="mysqli.stat"/>
   <redirect from="mysqli_stmt_init"            to="mysqli.stmt-init"/>
@@ -413,29 +390,16 @@
   <redirect from="install.otherhttpd"          to="install"/>
 
   <!-- moved to platform sections -->
-  <redirect from="install.caudium"               to="install.unix.caudium"/>
   <redirect from="install.commandline"           to="install.unix.commandline"/>
-  <redirect from="install.fhttpd"                to="install.unix.fhttpd"/>
-  <redirect from="install.hpux"                  to="install.unix.hpux"/>
   <redirect from="install.iis"                   to="install.windows.iis"/>
   <redirect from="install.linux"                 to="install.unix"/>
-  <redirect from="install.omnihttpd"             to="install.windows.omnihttpd"/>
   <redirect from="install.openbsd"               to="install.unix.openbsd"/>
-  <redirect from="install.sambar"                to="install.windows.sambar"/>
   <redirect from="install.solaris"               to="install.unix.solaris"/>
-  <redirect from="install.xitami"                to="install.windows.xitami"/>
   <redirect from="install.windows.installer.msi" to="install.windows"/>
   <redirect from="install.windows.installer"     to="install.windows"/>
 
-  <!-- Internals docs were moved -->
-  <redirect from="zend"          to="internals2.ze1.zendapi"/>
-  <redirect from="zend-api"      to="internals2.ze1.zendapi"/>
-  <redirect from="internals.pdo" to="internals2.pdo"/>
-  <redirect from="phpdevel"      to="internals2.ze1.php3devel"/>
-  <redirect from="tsrm"          to="internals2.ze1.tsrm"/>
-
   <!-- Replaced extensions -->
-  <redirect from="aspell" to="pspell"/>
+  <redirect from="aspell" to="book.pspell"/>
 
   <!-- Refactored -->
   <redirect from="regexp.reference" to="regexp.introduction"/>

--- a/redirects.xml
+++ b/redirects.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
 <!--
   Redirect map for manual pages on php.net.
 
-  Rendered to redirects.php by phd and included by web-php/error.php. 
+  Rendered to redirects.php by phd and included by web-php/error.php.
   Only redirects that concern manual pages live here;
 
   Every redirect here is served with HTTP 301.
@@ -15,42 +16,42 @@
     both       fires at either entry point (bare or in-manual)
 -->
 <redirects>
- 
+
  <group scope="in-manual">
 
   <!-- OCI-Lob class renamed -->
-  <redirect from="class.oci-lob"          to="class.ocilob"/>
-  <redirect from="oci-lob.append"         to="ocilob.append"/>
-  <redirect from="oci-lob.close"          to="ocilob.close"/>
-  <redirect from="oci-lob.eof"            to="ocilob.eof"/>
-  <redirect from="oci-lob.erase"          to="ocilob.erase"/>
-  <redirect from="oci-lob.export"         to="ocilob.export"/>
-  <redirect from="oci-lob.flush"          to="ocilob.flush"/>
-  <redirect from="oci-lob.free"           to="ocilob.free"/>
-  <redirect from="oci-lob.getbuffering"   to="ocilob.getbuffering"/>
-  <redirect from="oci-lob.import"         to="ocilob.import"/>
-  <redirect from="oci-lob.load"           to="ocilob.load"/>
-  <redirect from="oci-lob.read"           to="ocilob.read"/>
-  <redirect from="oci-lob.rewind"         to="ocilob.rewind"/>
-  <redirect from="oci-lob.save"           to="ocilob.save"/>
-  <redirect from="oci-lob.seek"           to="ocilob.seek"/>
-  <redirect from="oci-lob.setbuffering"   to="ocilob.setbuffering"/>
-  <redirect from="oci-lob.size"           to="ocilob.size"/>
-  <redirect from="oci-lob.tell"           to="ocilob.tell"/>
-  <redirect from="oci-lob.truncate"       to="ocilob.truncate"/>
-  <redirect from="oci-lob.write"          to="ocilob.write"/>
+  <redirect from="class.oci-lob" to="class.ocilob"/>
+  <redirect from="oci-lob.append" to="ocilob.append"/>
+  <redirect from="oci-lob.close" to="ocilob.close"/>
+  <redirect from="oci-lob.eof" to="ocilob.eof"/>
+  <redirect from="oci-lob.erase" to="ocilob.erase"/>
+  <redirect from="oci-lob.export" to="ocilob.export"/>
+  <redirect from="oci-lob.flush" to="ocilob.flush"/>
+  <redirect from="oci-lob.free" to="ocilob.free"/>
+  <redirect from="oci-lob.getbuffering" to="ocilob.getbuffering"/>
+  <redirect from="oci-lob.import" to="ocilob.import"/>
+  <redirect from="oci-lob.load" to="ocilob.load"/>
+  <redirect from="oci-lob.read" to="ocilob.read"/>
+  <redirect from="oci-lob.rewind" to="ocilob.rewind"/>
+  <redirect from="oci-lob.save" to="ocilob.save"/>
+  <redirect from="oci-lob.seek" to="ocilob.seek"/>
+  <redirect from="oci-lob.setbuffering" to="ocilob.setbuffering"/>
+  <redirect from="oci-lob.size" to="ocilob.size"/>
+  <redirect from="oci-lob.tell" to="ocilob.tell"/>
+  <redirect from="oci-lob.truncate" to="ocilob.truncate"/>
+  <redirect from="oci-lob.write" to="ocilob.write"/>
   <redirect from="oci-lob.writetemporary" to="ocilob.writetemporary"/>
 
   <!-- OCI-Collection class renamed -->
-  <redirect from="class.oci-collection"      to="class.ocicollection"/>
-  <redirect from="oci-collection.append"     to="ocicollection.append"/>
-  <redirect from="oci-collection.assign"     to="ocicollection.assign"/>
+  <redirect from="class.oci-collection" to="class.ocicollection"/>
+  <redirect from="oci-collection.append" to="ocicollection.append"/>
+  <redirect from="oci-collection.assign" to="ocicollection.assign"/>
   <redirect from="oci-collection.assignelem" to="ocicollection.assignelem"/>
-  <redirect from="oci-collection.free"       to="ocicollection.free"/>
-  <redirect from="oci-collection.getelem"    to="ocicollection.getelem"/>
-  <redirect from="oci-collection.max"        to="ocicollection.max"/>
-  <redirect from="oci-collection.size"       to="ocicollection.size"/>
-  <redirect from="oci-collection.trim"       to="ocicollection.trim"/>
+  <redirect from="oci-collection.free" to="ocicollection.free"/>
+  <redirect from="oci-collection.getelem" to="ocicollection.getelem"/>
+  <redirect from="oci-collection.max" to="ocicollection.max"/>
+  <redirect from="oci-collection.size" to="ocicollection.size"/>
+  <redirect from="oci-collection.trim" to="ocicollection.trim"/>
 
   <!-- SplStack/SplQueue methods moved to SplDoublyLinkedList -->
   <redirect from="splstack.setiteratormode" to="spldoublylinkedlist.setiteratormode"/>
@@ -58,110 +59,97 @@
 
   <!-- Attribute classes renamed to CamelCase -->
   <redirect from="class.allow-dynamic-properties" to="class.allowdynamicproperties"/>
-  <redirect from="class.return-type-will-change"  to="class.returntypewillchange"/>
-  <redirect from="class.sensitive-parameter"      to="class.sensitiveparameter"/>
+  <redirect from="class.return-type-will-change" to="class.returntypewillchange"/>
+  <redirect from="class.sensitive-parameter" to="class.sensitiveparameter"/>
 
   <!-- Function-form page replaced by class page -->
   <redirect from="function.curl-file-create" to="curlfile.construct"/>
 
   <!-- SimpleXMLIterator methods moved to SimpleXMLElement -->
-  <redirect from="simplexmliterator.current"     to="simplexmlelement.current"/>
+  <redirect from="simplexmliterator.current" to="simplexmlelement.current"/>
   <redirect from="simplexmliterator.getchildren" to="simplexmlelement.getchildren"/>
   <redirect from="simplexmliterator.haschildren" to="simplexmlelement.haschildren"/>
-  <redirect from="simplexmliterator.key"         to="simplexmlelement.key"/>
-  <redirect from="simplexmliterator.next"        to="simplexmlelement.next"/>
-  <redirect from="simplexmliterator.rewind"      to="simplexmlelement.rewind"/>
-  <redirect from="simplexmliterator.valid"       to="simplexmlelement.valid"/>
+  <redirect from="simplexmliterator.key" to="simplexmlelement.key"/>
+  <redirect from="simplexmliterator.next" to="simplexmlelement.next"/>
+  <redirect from="simplexmliterator.rewind" to="simplexmlelement.rewind"/>
+  <redirect from="simplexmliterator.valid" to="simplexmlelement.valid"/>
  </group>
- 
+
  <group scope="shortcut">
 
   <!-- Manual shortcuts -->
-  <redirect from="intro"       to="introduction"/>
-  <redirect from="whatis"      to="introduction"/>
-  <redirect from="whatisphp"   to="introduction"/>
+  <redirect from="intro" to="introduction"/>
+  <redirect from="whatis" to="introduction"/>
+  <redirect from="whatisphp" to="introduction"/>
   <redirect from="what_is_php" to="introduction"/>
-  <redirect from="composer"    to="install.composer.intro"/>
+  <redirect from="composer" to="install.composer.intro"/>
 
   <redirect from="windows" to="install.windows"/>
-  <redirect from="win32"   to="install.windows"/>
+  <redirect from="win32" to="install.windows"/>
 
-  <redirect from="globals"                                to="language.variables.predefined"/>
-  <redirect from="gd"                                     to="book.image"/>
-  <redirect from="bcmath"                                 to="book.bc"/>
-  <redirect from="streams"                                to="book.stream"/>
-  <redirect from="mongodb"                                to="book.mongodb"/>
+  <redirect from="bcmath" to="book.bc"/>
+  <redirect from="streams" to="book.stream"/>
+  <redirect from="mongodb" to="book.mongodb"/>
   <!-- Prefer function over PECL ext -->
-  <redirect from="hrtime"                                 to="function.hrtime"/>
+  <redirect from="hrtime" to="function.hrtime"/>
 
   <!-- Types & pseudo-types -->
   <redirect from="callback" to="language.types.declarations"/>
-  <redirect from="number"   to="language.types.declarations"/>
-  <redirect from="mixed"    to="language.types.declarations"/>
-  <redirect from="bool"     to="language.types.boolean"/>
-  <redirect from="boolean"  to="language.types.boolean"/>
-  <redirect from="int"      to="language.types.integer"/>
-  <redirect from="integer"  to="language.types.integer"/>
-  <redirect from="float"    to="language.types.float"/>
-  <redirect from="string"   to="language.types.string"/>
-  <redirect from="heredoc"  to="language.types.string"/>
+  <redirect from="number" to="language.types.declarations"/>
+  <redirect from="bool" to="language.types.boolean"/>
+  <redirect from="boolean" to="language.types.boolean"/>
+  <redirect from="integer" to="language.types.integer"/>
+  <redirect from="float" to="language.types.float"/>
   <redirect from="&lt;&lt;&lt;" to="language.types.string"/>
-  <redirect from="object"   to="language.types.object"/>
-  <redirect from="null"     to="language.types.null"/>
   <redirect from="callable" to="language.types.callable"/>
 
-  <redirect from="htaccess"  to="configuration.changes"/>
   <redirect from="php_value" to="configuration.changes"/>
 
   <!-- Operators -->
-  <redirect from="operator.precedence"  to="language.operators.precedence"/>
-  <redirect from="operator-precedence"  to="language.operators.precedence"/>
-  <redirect from="precedence"           to="language.operators.precedence"/>
+  <redirect from="operator.precedence" to="language.operators.precedence"/>
+  <redirect from="operator-precedence" to="language.operators.precedence"/>
+  <redirect from="precedence" to="language.operators.precedence"/>
   <redirect from="arithmetic.operators" to="language.operators.arithmetic"/>
   <redirect from="arithmetic-operators" to="language.operators.arithmetic"/>
   <redirect from="assignment.operators" to="language.operators.assignment"/>
   <redirect from="assignment-operators" to="language.operators.assignment"/>
-  <redirect from="bitwise.operators"    to="language.operators.bitwise"/>
-  <redirect from="bitwise-operators"    to="language.operators.bitwise"/>
+  <redirect from="bitwise.operators" to="language.operators.bitwise"/>
+  <redirect from="bitwise-operators" to="language.operators.bitwise"/>
   <redirect from="comparison.operators" to="language.operators.comparison"/>
   <redirect from="comparison-operators" to="language.operators.comparison"/>
-  <redirect from="error.control"        to="language.operators.errorcontrol"/>
-  <redirect from="error-control"        to="language.operators.errorcontrol"/>
-  <redirect from="backtick"             to="language.operators.execution"/>
-  <redirect from="backtick.operator"    to="language.operators.execution"/>
-  <redirect from="backtick-operator"    to="language.operators.execution"/>
-  <redirect from="execution.operator"   to="language.operators.execution"/>
-  <redirect from="increment.operators"  to="language.operators.increment"/>
-  <redirect from="increment-operators"  to="language.operators.increment"/>
-  <redirect from="logical.operators"    to="language.operators.logical"/>
-  <redirect from="logical-operators"    to="language.operators.logical"/>
-  <redirect from="string.operators"     to="language.operators.string"/>
-  <redirect from="string-operators"     to="language.operators.string"/>
-  <redirect from="type.operators"       to="language.operators.type"/>
-  <redirect from="type-operators"       to="language.operators.type"/>
+  <redirect from="error.control" to="language.operators.errorcontrol"/>
+  <redirect from="error-control" to="language.operators.errorcontrol"/>
+  <redirect from="backtick" to="language.operators.execution"/>
+  <redirect from="backtick.operator" to="language.operators.execution"/>
+  <redirect from="backtick-operator" to="language.operators.execution"/>
+  <redirect from="execution.operator" to="language.operators.execution"/>
+  <redirect from="increment.operators" to="language.operators.increment"/>
+  <redirect from="increment-operators" to="language.operators.increment"/>
+  <redirect from="logical.operators" to="language.operators.logical"/>
+  <redirect from="logical-operators" to="language.operators.logical"/>
+  <redirect from="string.operators" to="language.operators.string"/>
+  <redirect from="string-operators" to="language.operators.string"/>
+  <redirect from="type.operators" to="language.operators.type"/>
+  <redirect from="type-operators" to="language.operators.type"/>
 
   <redirect from="string.type" to="language.types.string"/>
-  <redirect from="array.type"  to="language.types.array"/>
+  <redirect from="array.type" to="language.types.array"/>
   <redirect from="object.type" to="language.types.object"/>
 
-  <redirect from="statements"         to="control-structures.intro"/>
+  <redirect from="statements" to="control-structures.intro"/>
   <redirect from="control.structures" to="control-structures.intro"/>
   <redirect from="control-structures" to="control-structures.intro"/>
 
-  <redirect from="ternary"    to="language.operators.comparison"/>
+  <redirect from="ternary" to="language.operators.comparison"/>
   <redirect from="instanceof" to="language.operators.type"/>
-  <redirect from="if"         to="language.control-structures"/>
-  <redirect from="static"     to="language.variables.scope"/>
-  <redirect from="global"     to="language.variables.scope"/>
-  <redirect from="@"          to="language.operators.errorcontrol"/>
-  <redirect from="&amp;"      to="language.references"/>
-  <redirect from="**"         to="language.operators.arithmetic"/>
-  <redirect from="..."        to="functions.arguments"/>
-  <redirect from="splat"      to="functions.arguments"/>
-  <redirect from="arrow"      to="functions.arrow"/>
-  <redirect from="fn"         to="functions.arrow"/>
-  <redirect from="pipe"       to="language.operators.functional"/>
-  <redirect from="|&gt;"      to="language.operators.functional"/>
+  <redirect from="&amp;" to="language.references"/>
+  <redirect from="**" to="language.operators.arithmetic"/>
+  <redirect from="..." to="functions.arguments"/>
+  <redirect from="splat" to="functions.arguments"/>
+  <redirect from="arrow" to="functions.arrow"/>
+  <redirect from="fn" to="functions.arrow"/>
+  <redirect from="pipe" to="language.operators.functional"/>
+  <redirect from="|&gt;" to="language.operators.functional"/>
   <!--
     ?:, ??, ??= shortcuts can't be captured here since they don't
     actually produce a 404. Handled inline in index.php.
@@ -169,73 +157,67 @@
 
   <redirect from="dowhile" to="control-structures.do.while"/>
 
-  <redirect from="tut"     to="tutorial"/>
+  <redirect from="tut" to="tutorial"/>
   <redirect from="tut.php" to="tutorial"/> <!-- BC -->
 
   <redirect from="faq.php" to="faq"/> <!-- BC -->
 
-  <redirect from="odbc"   to="book.uodbc"/> <!-- BC -->
+  <redirect from="odbc" to="book.uodbc"/> <!-- BC -->
   <redirect from="oracle" to="book.oci8"/>
-  <redirect from="cli"    to="features.commandline"/>
+  <redirect from="cli" to="features.commandline"/>
 
   <!-- OOP -->
-  <redirect from="oop"   to="language.oop5"/>
-  <redirect from="enum"  to="language.enumerations"/>
+  <redirect from="oop" to="language.oop5"/>
+  <redirect from="enum" to="language.enumerations"/>
   <redirect from="enums" to="language.enumerations"/>
 
-  <redirect from="const"      to="language.constants.syntax"/>
-  <redirect from="class"      to="language.oop5.basic"/>
-  <redirect from="new"        to="language.oop5.basic"/>
-  <redirect from="extends"    to="language.oop5.basic"/>
-  <redirect from="clone"      to="language.oop5.cloning"/>
-  <redirect from="construct"  to="language.oop5.decon"/>
-  <redirect from="destruct"   to="language.oop5.decon"/>
-  <redirect from="public"     to="language.oop5.visibility"/>
-  <redirect from="private"    to="language.oop5.visibility"/>
-  <redirect from="protected"  to="language.oop5.visibility"/>
-  <redirect from="var"        to="language.oop5.visibility"/>
-  <redirect from="abstract"   to="language.oop5.abstract"/>
-  <redirect from="interface"  to="language.oop5.interfaces"/>
+  <redirect from="const" to="language.constants.syntax"/>
+  <redirect from="clone" to="language.oop5.cloning"/>
+  <redirect from="construct" to="language.oop5.decon"/>
+  <redirect from="destruct" to="language.oop5.decon"/>
+  <redirect from="public" to="language.oop5.visibility"/>
+  <redirect from="private" to="language.oop5.visibility"/>
+  <redirect from="protected" to="language.oop5.visibility"/>
+  <redirect from="var" to="language.oop5.visibility"/>
+  <redirect from="abstract" to="language.oop5.abstract"/>
+  <redirect from="interface" to="language.oop5.interfaces"/>
   <redirect from="interfaces" to="language.oop5.interfaces"/>
-  <redirect from="autoload"   to="language.oop5.autoload"/>
+  <redirect from="autoload" to="language.oop5.autoload"/>
   <redirect from="__autoload" to="language.oop5.autoload"/>
   <!-- BC -->
   <redirect from="language.oop5.reflection" to="book.reflection"/>
-  <redirect from="::"                       to="language.oop5.paamayim-nekudotayim"/>
+  <redirect from="::" to="language.oop5.paamayim-nekudotayim"/>
 
-  <redirect from="__construct"  to="language.oop5.decon"/>
-  <redirect from="__destruct"   to="language.oop5.decon"/>
-  <redirect from="__call"       to="language.oop5.overloading"/>
+  <redirect from="__construct" to="language.oop5.decon"/>
+  <redirect from="__destruct" to="language.oop5.decon"/>
+  <redirect from="__call" to="language.oop5.overloading"/>
   <redirect from="__callstatic" to="language.oop5.overloading"/>
-  <redirect from="__get"        to="language.oop5.overloading"/>
-  <redirect from="__set"        to="language.oop5.overloading"/>
-  <redirect from="__isset"      to="language.oop5.overloading"/>
-  <redirect from="__unset"      to="language.oop5.overloading"/>
-  <redirect from="__sleep"      to="language.oop5.magic"/>
-  <redirect from="__wakeup"     to="language.oop5.magic"/>
-  <redirect from="__tostring"   to="language.oop5.magic"/>
-  <redirect from="__invoke"     to="language.oop5.magic"/>
-  <redirect from="__set_state"  to="language.oop5.magic"/>
-  <redirect from="__debuginfo"  to="language.oop5.magic"/>
-  <redirect from="__clone"      to="language.oop5.cloning"/>
+  <redirect from="__get" to="language.oop5.overloading"/>
+  <redirect from="__set" to="language.oop5.overloading"/>
+  <redirect from="__isset" to="language.oop5.overloading"/>
+  <redirect from="__unset" to="language.oop5.overloading"/>
+  <redirect from="__sleep" to="language.oop5.magic"/>
+  <redirect from="__wakeup" to="language.oop5.magic"/>
+  <redirect from="__tostring" to="language.oop5.magic"/>
+  <redirect from="__invoke" to="language.oop5.magic"/>
+  <redirect from="__set_state" to="language.oop5.magic"/>
+  <redirect from="__debuginfo" to="language.oop5.magic"/>
+  <redirect from="__clone" to="language.oop5.cloning"/>
 
-  <redirect from="throw"     to="language.exceptions"/>
-  <redirect from="try"       to="language.exceptions"/>
-  <redirect from="catch"     to="language.exceptions"/>
-  <redirect from="lsb"       to="language.oop5.late-static-bindings"/>
+  <redirect from="throw" to="language.exceptions"/>
+  <redirect from="lsb" to="language.oop5.late-static-bindings"/>
   <redirect from="namespace" to="language.namespaces"/>
-  <redirect from="use"       to="language.namespaces.importing"/>
 
-  <redirect from="trait"  to="language.oop5.traits"/>
+  <redirect from="trait" to="language.oop5.traits"/>
   <redirect from="traits" to="language.oop5.traits"/>
 
   <!-- BC legacy PHP 5 assets that landed on the OOP chapter -->
-  <redirect from="php5"                         to="language.oop5"/>
-  <redirect from="zend_changes.txt"             to="language.oop5"/>
-  <redirect from="zend2_example.phps"           to="language.oop5"/>
+  <redirect from="php5" to="language.oop5"/>
+  <redirect from="zend_changes.txt" to="language.oop5"/>
+  <redirect from="zend2_example.phps" to="language.oop5"/>
   <redirect from="zend_changes_php_5_0_0b2.txt" to="language.oop5"/>
-  <redirect from="zend-engine-2"                to="language.oop5"/>
-  <redirect from="zend-engine-2.php"            to="language.oop5"/>
+  <redirect from="zend-engine-2" to="language.oop5"/>
+  <redirect from="zend-engine-2.php" to="language.oop5"/>
 
   <!-- Migration guides -->
   <redirect from="migration7" to="migration70"/>
@@ -244,10 +226,10 @@
   <redirect from="configuration.directives" to="ini.core"/> <!-- BC -->
 
   <!-- regexp reference BC -->
-  <redirect from="regexp.reference.backslash"      to="regexp.reference.escape"/>
-  <redirect from="regexp.reference.circudollar"    to="regexp.reference.anchors"/>
+  <redirect from="regexp.reference.backslash" to="regexp.reference.escape"/>
+  <redirect from="regexp.reference.circudollar" to="regexp.reference.anchors"/>
   <redirect from="regexp.reference.squarebrackets" to="regexp.reference.character-classes"/>
-  <redirect from="regexp.reference.verticalbar"    to="regexp.reference.alternation"/>
+  <redirect from="regexp.reference.verticalbar" to="regexp.reference.alternation"/>
 
   <!-- Bugfixes: #64743 -->
   <redirect from="array_sort" to="function.sort"/>
@@ -257,144 +239,538 @@
     Temporary hack to fix bug #49956 for mysqli.
     Data taken from mysqli/summary.xml.
   -->
-  <redirect from="mysqli_affected_rows"        to="mysqli.affected-rows"/>
-  <redirect from="mysqli_get_client_version"   to="mysqli.get-client-version"/>
-  <redirect from="mysqli_connect_errno"        to="mysqli.connect-errno"/>
-  <redirect from="mysqli_connect_error"        to="mysqli.connect-error"/>
-  <redirect from="mysqli_errno"                to="mysqli.errno"/>
-  <redirect from="mysqli_error"                to="mysqli.error"/>
-  <redirect from="mysqli_field_count"          to="mysqli.field-count"/>
-  <redirect from="mysqli_get_host_info"        to="mysqli.get-host-info"/>
-  <redirect from="mysqli_get_server_version"   to="mysqli.get-server-version"/>
-  <redirect from="mysqli_info"                 to="mysqli.info"/>
-  <redirect from="mysqli_insert_id"            to="mysqli.insert-id"/>
-  <redirect from="mysqli_sqlstate"             to="mysqli.sqlstate"/>
-  <redirect from="mysqli_warning_count"        to="mysqli.warning-count"/>
-  <redirect from="mysqli_autocommit"           to="mysqli.autocommit"/>
-  <redirect from="mysqli_change_user"          to="mysqli.change-user"/>
-  <redirect from="mysqli_character_set_name"   to="mysqli.character-set-name"/>
-  <redirect from="mysqli_close"                to="mysqli.close"/>
-  <redirect from="mysqli_commit"               to="mysqli.commit"/>
-  <redirect from="mysqli_connect"              to="mysqli.construct"/>
-  <redirect from="mysqli_debug"                to="mysqli.debug"/>
-  <redirect from="mysqli_dump_debug_info"      to="mysqli.dump-debug-info"/>
-  <redirect from="mysqli_get_charset"          to="mysqli.get-charset"/>
+  <redirect from="mysqli_affected_rows" to="mysqli.affected-rows"/>
+  <redirect from="mysqli_get_client_version" to="mysqli.get-client-version"/>
+  <redirect from="mysqli_connect_errno" to="mysqli.connect-errno"/>
+  <redirect from="mysqli_connect_error" to="mysqli.connect-error"/>
+  <redirect from="mysqli_errno" to="mysqli.errno"/>
+  <redirect from="mysqli_error" to="mysqli.error"/>
+  <redirect from="mysqli_field_count" to="mysqli.field-count"/>
+  <redirect from="mysqli_get_host_info" to="mysqli.get-host-info"/>
+  <redirect from="mysqli_get_server_version" to="mysqli.get-server-version"/>
+  <redirect from="mysqli_info" to="mysqli.info"/>
+  <redirect from="mysqli_insert_id" to="mysqli.insert-id"/>
+  <redirect from="mysqli_sqlstate" to="mysqli.sqlstate"/>
+  <redirect from="mysqli_warning_count" to="mysqli.warning-count"/>
+  <redirect from="mysqli_autocommit" to="mysqli.autocommit"/>
+  <redirect from="mysqli_change_user" to="mysqli.change-user"/>
+  <redirect from="mysqli_character_set_name" to="mysqli.character-set-name"/>
+  <redirect from="mysqli_close" to="mysqli.close"/>
+  <redirect from="mysqli_commit" to="mysqli.commit"/>
+  <redirect from="mysqli_connect" to="mysqli.construct"/>
+  <redirect from="mysqli_debug" to="mysqli.debug"/>
+  <redirect from="mysqli_dump_debug_info" to="mysqli.dump-debug-info"/>
+  <redirect from="mysqli_get_charset" to="mysqli.get-charset"/>
   <redirect from="mysqli_get_connection_stats" to="mysqli.get-connection-stats"/>
-  <redirect from="mysqli_get_client_info"      to="mysqli.get-client-info"/>
-  <redirect from="mysqli_get_server_info"      to="mysqli.get-server-info"/>
-  <redirect from="mysqli_get_warnings"         to="mysqli.get-warnings"/>
-  <redirect from="mysqli_init"                 to="mysqli.init"/>
-  <redirect from="mysqli_kill"                 to="mysqli.kill"/>
-  <redirect from="mysqli_more_results"         to="mysqli.more-results"/>
-  <redirect from="mysqli_multi_query"          to="mysqli.multi-query"/>
-  <redirect from="mysqli_next_result"          to="mysqli.next-result"/>
-  <redirect from="mysqli_options"              to="mysqli.options"/>
-  <redirect from="mysqli_ping"                 to="mysqli.ping"/>
-  <redirect from="mysqli_prepare"              to="mysqli.prepare"/>
-  <redirect from="mysqli_query"                to="mysqli.query"/>
-  <redirect from="mysqli_real_connect"         to="mysqli.real-connect"/>
-  <redirect from="mysqli_real_escape_string"   to="mysqli.real-escape-string"/>
-  <redirect from="mysqli_real_query"           to="mysqli.real-query"/>
-  <redirect from="mysqli_refresh"              to="mysqli.refresh"/>
-  <redirect from="mysqli_rollback"             to="mysqli.rollback"/>
-  <redirect from="mysqli_select_db"            to="mysqli.select-db"/>
-  <redirect from="mysqli_set_charset"          to="mysqli.set-charset"/>
-  <redirect from="mysqli_ssl_set"              to="mysqli.ssl-set"/>
-  <redirect from="mysqli_stat"                 to="mysqli.stat"/>
-  <redirect from="mysqli_stmt_init"            to="mysqli.stmt-init"/>
-  <redirect from="mysqli_store_result"         to="mysqli.store-result"/>
-  <redirect from="mysqli_thread_id"            to="mysqli.thread-id"/>
-  <redirect from="mysqli_thread_safe"          to="mysqli.thread-safe"/>
-  <redirect from="mysqli_use_result"           to="mysqli.use-result"/>
+  <redirect from="mysqli_get_client_info" to="mysqli.get-client-info"/>
+  <redirect from="mysqli_get_server_info" to="mysqli.get-server-info"/>
+  <redirect from="mysqli_get_warnings" to="mysqli.get-warnings"/>
+  <redirect from="mysqli_init" to="mysqli.init"/>
+  <redirect from="mysqli_kill" to="mysqli.kill"/>
+  <redirect from="mysqli_more_results" to="mysqli.more-results"/>
+  <redirect from="mysqli_multi_query" to="mysqli.multi-query"/>
+  <redirect from="mysqli_next_result" to="mysqli.next-result"/>
+  <redirect from="mysqli_options" to="mysqli.options"/>
+  <redirect from="mysqli_ping" to="mysqli.ping"/>
+  <redirect from="mysqli_prepare" to="mysqli.prepare"/>
+  <redirect from="mysqli_query" to="mysqli.query"/>
+  <redirect from="mysqli_real_connect" to="mysqli.real-connect"/>
+  <redirect from="mysqli_real_escape_string" to="mysqli.real-escape-string"/>
+  <redirect from="mysqli_real_query" to="mysqli.real-query"/>
+  <redirect from="mysqli_refresh" to="mysqli.refresh"/>
+  <redirect from="mysqli_rollback" to="mysqli.rollback"/>
+  <redirect from="mysqli_select_db" to="mysqli.select-db"/>
+  <redirect from="mysqli_set_charset" to="mysqli.set-charset"/>
+  <redirect from="mysqli_ssl_set" to="mysqli.ssl-set"/>
+  <redirect from="mysqli_stat" to="mysqli.stat"/>
+  <redirect from="mysqli_stmt_init" to="mysqli.stmt-init"/>
+  <redirect from="mysqli_store_result" to="mysqli.store-result"/>
+  <redirect from="mysqli_thread_id" to="mysqli.thread-id"/>
+  <redirect from="mysqli_thread_safe" to="mysqli.thread-safe"/>
+  <redirect from="mysqli_use_result" to="mysqli.use-result"/>
 
-  <redirect from="mysqli_stmt_affected_rows"   to="mysqli-stmt.affected-rows"/>
-  <redirect from="mysqli_stmt_errno"           to="mysqli-stmt.errno"/>
-  <redirect from="mysqli_stmt_error"           to="mysqli-stmt.error"/>
-  <redirect from="mysqli_stmt_field_count"     to="mysqli-stmt.field-count"/>
-  <redirect from="mysqli_stmt_insert_id"       to="mysqli-stmt.insert-id"/>
-  <redirect from="mysqli_stmt_param_count"     to="mysqli-stmt.param-count"/>
-  <redirect from="mysqli_stmt_sqlstate"        to="mysqli-stmt.sqlstate"/>
-  <redirect from="mysqli_stmt_attr_get"        to="mysqli-stmt.attr-get"/>
-  <redirect from="mysqli_stmt_attr_set"        to="mysqli-stmt.attr-set"/>
-  <redirect from="mysqli_stmt_bind_param"      to="mysqli-stmt.bind-param"/>
-  <redirect from="mysqli_stmt_bind_result"     to="mysqli-stmt.bind-result"/>
-  <redirect from="mysqli_stmt_close"           to="mysqli-stmt.close"/>
-  <redirect from="mysqli_stmt_data_seek"       to="mysqli-stmt.data-seek"/>
-  <redirect from="mysqli_stmt_execute"         to="mysqli-stmt.execute"/>
-  <redirect from="mysqli_stmt_fetch"           to="mysqli-stmt.fetch"/>
-  <redirect from="mysqli_stmt_free_result"     to="mysqli-stmt.free-result"/>
-  <redirect from="mysqli_stmt_get_result"      to="mysqli-stmt.get-result"/>
-  <redirect from="mysqli_stmt_get_warnings"    to="mysqli-stmt.get-warnings"/>
-  <redirect from="mysqli_stmt_more_results"    to="mysqli-stmt.more-results"/>
-  <redirect from="mysqli_stmt_next_result"     to="mysqli-stmt.next-result"/>
-  <redirect from="mysqli_stmt_num_rows"        to="mysqli-stmt.num-rows"/>
-  <redirect from="mysqli_stmt_prepare"         to="mysqli-stmt.prepare"/>
-  <redirect from="mysqli_stmt_reset"           to="mysqli-stmt.reset"/>
+  <redirect from="mysqli_stmt_affected_rows" to="mysqli-stmt.affected-rows"/>
+  <redirect from="mysqli_stmt_errno" to="mysqli-stmt.errno"/>
+  <redirect from="mysqli_stmt_error" to="mysqli-stmt.error"/>
+  <redirect from="mysqli_stmt_field_count" to="mysqli-stmt.field-count"/>
+  <redirect from="mysqli_stmt_insert_id" to="mysqli-stmt.insert-id"/>
+  <redirect from="mysqli_stmt_param_count" to="mysqli-stmt.param-count"/>
+  <redirect from="mysqli_stmt_sqlstate" to="mysqli-stmt.sqlstate"/>
+  <redirect from="mysqli_stmt_attr_get" to="mysqli-stmt.attr-get"/>
+  <redirect from="mysqli_stmt_attr_set" to="mysqli-stmt.attr-set"/>
+  <redirect from="mysqli_stmt_bind_param" to="mysqli-stmt.bind-param"/>
+  <redirect from="mysqli_stmt_bind_result" to="mysqli-stmt.bind-result"/>
+  <redirect from="mysqli_stmt_close" to="mysqli-stmt.close"/>
+  <redirect from="mysqli_stmt_data_seek" to="mysqli-stmt.data-seek"/>
+  <redirect from="mysqli_stmt_execute" to="mysqli-stmt.execute"/>
+  <redirect from="mysqli_stmt_fetch" to="mysqli-stmt.fetch"/>
+  <redirect from="mysqli_stmt_free_result" to="mysqli-stmt.free-result"/>
+  <redirect from="mysqli_stmt_get_result" to="mysqli-stmt.get-result"/>
+  <redirect from="mysqli_stmt_get_warnings" to="mysqli-stmt.get-warnings"/>
+  <redirect from="mysqli_stmt_more_results" to="mysqli-stmt.more-results"/>
+  <redirect from="mysqli_stmt_next_result" to="mysqli-stmt.next-result"/>
+  <redirect from="mysqli_stmt_num_rows" to="mysqli-stmt.num-rows"/>
+  <redirect from="mysqli_stmt_prepare" to="mysqli-stmt.prepare"/>
+  <redirect from="mysqli_stmt_reset" to="mysqli-stmt.reset"/>
   <redirect from="mysqli_stmt_result_metadata" to="mysqli-stmt.result-metadata"/>
-  <redirect from="mysqli_stmt_send_long_data"  to="mysqli-stmt.send-long-data"/>
-  <redirect from="mysqli_stmt_store_result"    to="mysqli-stmt.store-result"/>
+  <redirect from="mysqli_stmt_send_long_data" to="mysqli-stmt.send-long-data"/>
+  <redirect from="mysqli_stmt_store_result" to="mysqli-stmt.store-result"/>
 
-  <redirect from="mysqli_field_tell"         to="mysqli-result.current-field"/>
-  <redirect from="mysqli_num_fields"         to="mysqli-result.field-count"/>
-  <redirect from="mysqli_fetch_lengths"      to="mysqli-result.lengths"/>
-  <redirect from="mysqli_num_rows"           to="mysqli-result.num-rows"/>
-  <redirect from="mysqli_data_seek"          to="mysqli-result.data-seek"/>
-  <redirect from="mysqli_fetch_all"          to="mysqli-result.fetch-all"/>
-  <redirect from="mysqli_fetch_array"        to="mysqli-result.fetch-array"/>
-  <redirect from="mysqli_fetch_assoc"        to="mysqli-result.fetch-assoc"/>
+  <redirect from="mysqli_field_tell" to="mysqli-result.current-field"/>
+  <redirect from="mysqli_num_fields" to="mysqli-result.field-count"/>
+  <redirect from="mysqli_fetch_lengths" to="mysqli-result.lengths"/>
+  <redirect from="mysqli_num_rows" to="mysqli-result.num-rows"/>
+  <redirect from="mysqli_data_seek" to="mysqli-result.data-seek"/>
+  <redirect from="mysqli_fetch_all" to="mysqli-result.fetch-all"/>
+  <redirect from="mysqli_fetch_array" to="mysqli-result.fetch-array"/>
+  <redirect from="mysqli_fetch_assoc" to="mysqli-result.fetch-assoc"/>
   <redirect from="mysqli_fetch_field_direct" to="mysqli-result.fetch-field-direct"/>
-  <redirect from="mysqli_fetch_field"        to="mysqli-result.fetch-field"/>
-  <redirect from="mysqli_fetch_fields"       to="mysqli-result.fetch-fields"/>
-  <redirect from="mysqli_fetch_object"       to="mysqli-result.fetch-object"/>
-  <redirect from="mysqli_fetch_row"          to="mysqli-result.fetch-row"/>
-  <redirect from="mysqli_field_seek"         to="mysqli-result.field-seek"/>
-  <redirect from="mysqli_free_result"        to="mysqli-result.free"/>
+  <redirect from="mysqli_fetch_field" to="mysqli-result.fetch-field"/>
+  <redirect from="mysqli_fetch_fields" to="mysqli-result.fetch-fields"/>
+  <redirect from="mysqli_fetch_object" to="mysqli-result.fetch-object"/>
+  <redirect from="mysqli_fetch_row" to="mysqli-result.fetch-row"/>
+  <redirect from="mysqli_field_seek" to="mysqli-result.field-seek"/>
+  <redirect from="mysqli_free_result" to="mysqli-result.free"/>
 
-  <redirect from="mysqli_embedded_server_end"   to="mysqli-driver.embedded-server-end"/>
+  <redirect from="mysqli_embedded_server_end" to="mysqli-driver.embedded-server-end"/>
   <redirect from="mysqli_embedded_server_start" to="mysqli-driver.embedded-server-start"/>
-  
+
+  <!-- ============================================================== -->
+  <!-- INI directives (from is_known_ini in web-php/errors.inc) -->
+  <!-- ============================================================== -->
+  <redirect from="engine" to="apache.configuration#ini.engine"/>
+  <redirect from="short-open-tag" to="ini.core#ini.short-open-tag"/>
+  <redirect from="asp-tags" to="ini.core#ini.asp-tags"/>
+  <redirect from="precision" to="ini.core#ini.precision"/>
+  <redirect from="y2k-compliance" to="ini.core#ini.y2k-compliance"/>
+  <redirect from="output-buffering" to="outcontrol.configuration#ini.output-buffering"/>
+  <redirect from="output-handler" to="outcontrol.configuration#ini.output-handler"/>
+  <redirect from="zlib.output-compression" to="zlib.configuration#ini.zlib.output-compression"/>
+  <redirect from="zlib.output-compression-level" to="zlib.configuration#ini.zlib.output-compression-level"/>
+  <redirect from="zlib.output-handler" to="zlib.configuration#ini.zlib.output-handler"/>
+  <redirect from="implicit-flush" to="outcontrol.configuration#ini.implicit-flush"/>
+  <redirect from="allow-call-time-pass-reference" to="ini.core#ini.allow-call-time-pass-reference"/>
+  <redirect from="open-basedir" to="ini.core#ini.open-basedir"/>
+  <redirect from="disable-functions" to="ini.core#ini.disable-functions"/>
+  <redirect from="disable-classes" to="ini.core#ini.disable-classes"/>
+  <redirect from="zend.assertions" to="ini.core#ini.zend.assertions"/>
+  <redirect from="syntax-highlighting" to="misc.configuration#ini.syntax-highlighting"/>
+  <redirect from="ignore-user-abort" to="misc.configuration#ini.ignore-user-abort"/>
+  <redirect from="realpath-cache-size" to="ini.core#ini.realpath-cache-size"/>
+  <redirect from="realpath-cache-ttl" to="ini.core#ini.realpath-cache-ttl"/>
+  <redirect from="expose-php" to="ini.core#ini.expose-php"/>
+  <redirect from="max-execution-time" to="info.configuration#ini.max-execution-time"/>
+  <redirect from="max-input-time" to="info.configuration#ini.max-input-time"/>
+  <redirect from="max-input-vars" to="info.configuration#ini.max-input-vars"/>
+  <redirect from="max-input-nesting-level" to="info.configuration#ini.max-input-nesting-level"/>
+  <redirect from="memory-limit" to="ini.core#ini.memory-limit"/>
+  <redirect from="error-reporting" to="errorfunc.configuration#ini.error-reporting"/>
+  <redirect from="display-errors" to="errorfunc.configuration#ini.display-errors"/>
+  <redirect from="display-startup-errors" to="errorfunc.configuration#ini.display-startup-errors"/>
+  <redirect from="log-errors" to="errorfunc.configuration#ini.log-errors"/>
+  <redirect from="log-errors-max-len" to="errorfunc.configuration#ini.log-errors-max-len"/>
+  <redirect from="ignore-repeated-errors" to="errorfunc.configuration#ini.ignore-repeated-errors"/>
+  <redirect from="ignore-repeated-source" to="errorfunc.configuration#ini.ignore-repeated-source"/>
+  <redirect from="report-memleaks" to="errorfunc.configuration#ini.report-memleaks"/>
+  <redirect from="track-errors" to="errorfunc.configuration#ini.track-errors"/>
+  <redirect from="xmlrpc-errors" to="errorfunc.configuration#ini.xmlrpc-errors"/>
+  <redirect from="html-errors" to="errorfunc.configuration#ini.html-errors"/>
+  <redirect from="docref-root" to="errorfunc.configuration#ini.docref-root"/>
+  <redirect from="docref-ext" to="errorfunc.configuration#ini.docref-ext"/>
+  <redirect from="error-prepend-string" to="errorfunc.configuration#ini.error-prepend-string"/>
+  <redirect from="error-append-string" to="errorfunc.configuration#ini.error-append-string"/>
+  <redirect from="error-log" to="errorfunc.configuration#ini.error-log"/>
+  <redirect from="syslog.facility" to="errorfunc.configuration#ini.syslog.facility"/>
+  <redirect from="syslog.filter" to="errorfunc.configuration#ini.syslog.filter"/>
+  <redirect from="syslog.ident" to="errorfunc.configuration#ini.syslog.ident"/>
+  <redirect from="arg-separator.output" to="ini.core#ini.arg-separator.output"/>
+  <redirect from="arg-separator.input" to="ini.core#ini.arg-separator.input"/>
+  <redirect from="variables-order" to="ini.core#ini.variables-order"/>
+  <redirect from="request-order" to="ini.core#ini.request-order"/>
+  <redirect from="register-globals" to="ini.core#ini.register-globals"/>
+  <redirect from="register-long-arrays" to="ini.core#ini.register-long-arrays"/>
+  <redirect from="register-argc-argv" to="ini.core#ini.register-argc-argv"/>
+  <redirect from="auto-globals-jit" to="ini.core#ini.auto-globals-jit"/>
+  <redirect from="post-max-size" to="ini.core#ini.post-max-size"/>
+  <redirect from="magic-quotes-gpc" to="info.configuration#ini.magic-quotes-gpc"/>
+  <redirect from="magic-quotes-runtime" to="info.configuration#ini.magic-quotes-runtime"/>
+  <redirect from="auto-prepend-file" to="ini.core#ini.auto-prepend-file"/>
+  <redirect from="auto-append-file" to="ini.core#ini.auto-append-file"/>
+  <redirect from="default-mimetype" to="ini.core#ini.default-mimetype"/>
+  <redirect from="default-charset" to="ini.core#ini.default-charset"/>
+  <redirect from="always-populate-raw-post-data" to="ini.core#ini.always-populate-raw-post-data"/>
+  <redirect from="include-path" to="ini.core#ini.include-path"/>
+  <redirect from="doc-root" to="ini.core#ini.doc-root"/>
+  <redirect from="user-dir" to="ini.core#ini.user-dir"/>
+  <redirect from="extension-dir" to="ini.core#ini.extension-dir"/>
+  <redirect from="enable-dl" to="info.configuration#ini.enable-dl"/>
+  <redirect from="cgi.force-redirect" to="ini.core#ini.cgi.force-redirect"/>
+  <redirect from="cgi.redirect-status-env" to="ini.core#ini.cgi.redirect-status-env"/>
+  <redirect from="cgi.fix-pathinfo" to="ini.core#ini.cgi.fix-pathinfo"/>
+  <redirect from="fastcgi.impersonate" to="ini.core#ini.fastcgi.impersonate"/>
+  <redirect from="cgi.rfc2616-headers" to="ini.core#ini.cgi.rfc2616-headers"/>
+  <redirect from="file-uploads" to="ini.core#ini.file-uploads"/>
+  <redirect from="upload-tmp-dir" to="ini.core#ini.upload-tmp-dir"/>
+  <redirect from="upload-max-filesize" to="ini.core#ini.upload-max-filesize"/>
+  <redirect from="allow-url-fopen" to="filesystem.configuration#ini.allow-url-fopen"/>
+  <redirect from="allow-url-include" to="filesystem.configuration#ini.allow-url-include"/>
+  <redirect from="from" to="filesystem.configuration#ini.from"/>
+  <redirect from="user-agent" to="filesystem.configuration#ini.user-agent"/>
+  <redirect from="default-socket-timeout" to="filesystem.configuration#ini.default-socket-timeout"/>
+  <redirect from="auto-detect-line-endings" to="filesystem.configuration#ini.auto-detect-line-endings"/>
+  <redirect from="date.timezone" to="datetime.configuration#ini.date.timezone"/>
+  <redirect from="date.default-latitude" to="datetime.configuration#ini.date.default-latitude"/>
+  <redirect from="date.default-longitude" to="datetime.configuration#ini.date.default-longitude"/>
+  <redirect from="date.sunrise-zenith" to="datetime.configuration#ini.date.sunrise-zenith"/>
+  <redirect from="date.sunset-zenith" to="datetime.configuration#ini.date.sunset-zenith"/>
+  <redirect from="filter.default" to="filter.configuration#ini.filter.default"/>
+  <redirect from="filter.default-flags" to="filter.configuration#ini.filter.default-flags"/>
+  <redirect from="pcre.backtrack-limit" to="pcre.configuration#ini.pcre.backtrack-limit"/>
+  <redirect from="pcre.recursion-limit" to="pcre.configuration#ini.pcre.recursion-limit"/>
+  <redirect from="pdo-odbc.connection-pooling" to="ref.pdo-odbc#ini.pdo-odbc.connection-pooling"/>
+  <redirect from="phar.readonly" to="phar.configuration#ini.phar.readonly"/>
+  <redirect from="phar.require-hash" to="phar.configuration#ini.phar.require-hash"/>
+  <redirect from="smtp" to="mail.configuration#ini.smtp"/>
+  <redirect from="smtp-port" to="mail.configuration#ini.smtp-port"/>
+  <redirect from="sendmail-from" to="mail.configuration#ini.sendmail-from"/>
+  <redirect from="sendmail-path" to="mail.configuration#ini.sendmail-path"/>
+  <redirect from="sql.safe-mode" to="ini.core#ini.sql.safe-mode"/>
+  <redirect from="odbc.default-db" to="odbc.configuration#ini.uodbc.default-db"/>
+  <redirect from="odbc.default-user" to="odbc.configuration#ini.uodbc.default-user"/>
+  <redirect from="odbc.default-pw" to="odbc.configuration#ini.uodbc.default-pw"/>
+  <redirect from="odbc.allow-persistent" to="odbc.configuration#ini.uodbc.allow-persistent"/>
+  <redirect from="odbc.check-persistent" to="odbc.configuration#ini.uodbc.check-persistent"/>
+  <redirect from="odbc.max-persistent" to="odbc.configuration#ini.uodbc.max-persistent"/>
+  <redirect from="odbc.max-links" to="odbc.configuration#ini.uodbc.max-links"/>
+  <redirect from="odbc.defaultlrl" to="odbc.configuration#ini.uodbc.defaultlrl"/>
+  <redirect from="odbc.defaultbinmode" to="odbc.configuration#ini.uodbc.defaultbinmode"/>
+  <redirect from="mysql.allow-local-infile" to="mysql.configuration#ini.mysql.allow-local-infile"/>
+  <redirect from="mysql.allow-persistent" to="mysql.configuration#ini.mysql.allow-persistent"/>
+  <redirect from="mysql.max-persistent" to="mysql.configuration#ini.mysql.max-persistent"/>
+  <redirect from="mysql.max-links" to="mysql.configuration#ini.mysql.max-links"/>
+  <redirect from="mysql.default-port" to="mysql.configuration#ini.mysql.default-port"/>
+  <redirect from="mysql.default-socket" to="mysql.configuration#ini.mysql.default-socket"/>
+  <redirect from="mysql.default-host" to="mysql.configuration#ini.mysql.default-host"/>
+  <redirect from="mysql.default-user" to="mysql.configuration#ini.mysql.default-user"/>
+  <redirect from="mysql.default-password" to="mysql.configuration#ini.mysql.default-password"/>
+  <redirect from="mysql.connect-timeout" to="mysql.configuration#ini.mysql.connect-timeout"/>
+  <redirect from="mysql.trace-mode" to="mysql.configuration#ini.mysql.trace-mode"/>
+  <redirect from="mysqli.allow-local-infile" to="mysqli.configuration#ini.mysqli.allow-local-infile"/>
+  <redirect from="mysqli.max-links" to="mysqli.configuration#ini.mysqli.max-links"/>
+  <redirect from="mysqli.allow-persistent" to="mysqli.configuration#ini.mysqli.allow-persistent"/>
+  <redirect from="mysqli.default-port" to="mysqli.configuration#ini.mysqli.default-port"/>
+  <redirect from="mysqli.default-socket" to="mysqli.configuration#ini.mysqli.default-socket"/>
+  <redirect from="mysqli.default-host" to="mysqli.configuration#ini.mysqli.default-host"/>
+  <redirect from="mysqli.default-user" to="mysqli.configuration#ini.mysqli.default-user"/>
+  <redirect from="mysqli.default-pw" to="mysqli.configuration#ini.mysqli.default-pw"/>
+  <redirect from="oci8.privileged-connect" to="oci8.configuration#ini.oci8.privileged-connect"/>
+  <redirect from="oci8.max-persistent" to="oci8.configuration#ini.oci8.max-persistent"/>
+  <redirect from="oci8.persistent-timeout" to="oci8.configuration#ini.oci8.persistent-timeout"/>
+  <redirect from="oci8.ping-interval" to="oci8.configuration#ini.oci8.ping-interval"/>
+  <redirect from="oci8.statement-cache-size" to="oci8.configuration#ini.oci8.statement-cache-size"/>
+  <redirect from="oci8.default-prefetch" to="oci8.configuration#ini.oci8.default-prefetch"/>
+  <redirect from="oci8.old-oci-close-semantics" to="oci8.configuration#ini.oci8.old-oci-close-semantics"/>
+  <redirect from="opcache.preload" to="opcache.configuration#ini.opcache.preload"/>
+  <redirect from="pgsql.allow-persistent" to="pgsql.configuration#ini.pgsql.allow-persistent"/>
+  <redirect from="pgsql.auto-reset-persistent" to="pgsql.configuration#ini.pgsql.auto-reset-persistent"/>
+  <redirect from="pgsql.max-persistent" to="pgsql.configuration#ini.pgsql.max-persistent"/>
+  <redirect from="pgsql.max-links" to="pgsql.configuration#ini.pgsql.max-links"/>
+  <redirect from="pgsql.ignore-notice" to="pgsql.configuration#ini.pgsql.ignore-notice"/>
+  <redirect from="pgsql.log-notice" to="pgsql.configuration#ini.pgsql.log-notice"/>
+  <redirect from="sqlite3.extension-dir" to="sqlite3.configuration#ini.sqlite3.extension-dir"/>
+  <redirect from="bcmath.scale" to="bc.configuration#ini.bcmath.scale"/>
+  <redirect from="browscap" to="misc.configuration#ini.browscap"/>
+  <redirect from="session.save-handler" to="session.configuration#ini.session.save-handler"/>
+  <redirect from="session.save-path" to="session.configuration#ini.session.save-path"/>
+  <redirect from="session.use-cookies" to="session.configuration#ini.session.use-cookies"/>
+  <redirect from="session.cookie-secure" to="session.configuration#ini.session.cookie-secure"/>
+  <redirect from="session.use-only-cookies" to="session.configuration#ini.session.use-only-cookies"/>
+  <redirect from="session.name" to="session.configuration#ini.session.name"/>
+  <redirect from="session.auto-start" to="session.configuration#ini.session.auto-start"/>
+  <redirect from="session.cookie-lifetime" to="session.configuration#ini.session.cookie-lifetime"/>
+  <redirect from="session.cookie-path" to="session.configuration#ini.session.cookie-path"/>
+  <redirect from="session.cookie-domain" to="session.configuration#ini.session.cookie-domain"/>
+  <redirect from="session.cookie-httponly" to="session.configuration#ini.session.cookie-httponly"/>
+  <redirect from="session.serialize-handler" to="session.configuration#ini.session.serialize-handler"/>
+  <redirect from="session.gc-probability" to="session.configuration#ini.session.gc-probability"/>
+  <redirect from="session.gc-divisor" to="session.configuration#ini.session.gc-divisor"/>
+  <redirect from="session.gc-maxlifetime" to="session.configuration#ini.session.gc-maxlifetime"/>
+  <redirect from="session.bug-compat-42" to="session.configuration#ini.session.bug-compat-42"/>
+  <redirect from="session.bug-compat-warn" to="session.configuration#ini.session.bug-compat-warn"/>
+  <redirect from="session.referer-check" to="session.configuration#ini.session.referer-check"/>
+  <redirect from="session.entropy-length" to="session.configuration#ini.session.entropy-length"/>
+  <redirect from="session.entropy-file" to="session.configuration#ini.session.entropy-file"/>
+  <redirect from="session.cache-limiter" to="session.configuration#ini.session.cache-limiter"/>
+  <redirect from="session.cache-expire" to="session.configuration#ini.session.cache-expire"/>
+  <redirect from="session.sid-length" to="session.configuration#ini.session.sid-length"/>
+  <redirect from="session.use-trans-sid" to="session.configuration#ini.session.use-trans-sid"/>
+  <redirect from="session.hash-function" to="session.configuration#ini.session.hash-function"/>
+  <redirect from="session.hash-bits-per-character" to="session.configuration#ini.session.hash-bits-per-character"/>
+  <redirect from="session.upload-progress.enabled" to="session.configuration#ini.session.upload-progress.enabled"/>
+  <redirect from="session.upload-progress.cleanup" to="session.configuration#ini.session.upload-progress.cleanup"/>
+  <redirect from="session.upload-progress.prefix" to="session.configuration#ini.session.upload-progress.prefix"/>
+  <redirect from="session.upload-progress.name" to="session.configuration#ini.session.upload-progress.name"/>
+  <redirect from="session.upload-progress.freq" to="session.configuration#ini.session.upload-progress.freq"/>
+  <redirect from="session.upload-progress.min-freq" to="session.configuration#ini.session.upload-progress.min-freq"/>
+  <redirect from="url-rewriter.tags" to="session.configuration#ini.url-rewriter.tags"/>
+  <redirect from="assert.active" to="info.configuration#ini.assert.active"/>
+  <redirect from="assert.exception" to="info.configuration#ini.assert.exception"/>
+  <redirect from="assert.warning" to="info.configuration#ini.assert.warning"/>
+  <redirect from="assert.bail" to="info.configuration#ini.assert.bail"/>
+  <redirect from="assert.callback" to="info.configuration#ini.assert.callback"/>
+  <redirect from="assert.quiet-eval" to="info.configuration#ini.assert.quiet-eval"/>
+  <redirect from="zend.enable-gc" to="info.configuration#ini.zend.enable-gc"/>
+  <redirect from="com.typelib-file" to="com.configuration#ini.com.typelib-file"/>
+  <redirect from="com.allow-dcom" to="com.configuration#ini.com.allow-dcom"/>
+  <redirect from="com.autoregister-typelib" to="com.configuration#ini.com.autoregister-typelib"/>
+  <redirect from="com.autoregister-casesensitive" to="com.configuration#ini.com.autoregister-casesensitive"/>
+  <redirect from="com.autoregister-verbose" to="com.configuration#ini.com.autoregister-verbose"/>
+  <redirect from="mbstring.language" to="mbstring.configuration#ini.mbstring.language"/>
+  <redirect from="mbstring.internal-encoding" to="mbstring.configuration#ini.mbstring.internal-encoding"/>
+  <redirect from="mbstring.http-input" to="mbstring.configuration#ini.mbstring.http-input"/>
+  <redirect from="mbstring.http-output" to="mbstring.configuration#ini.mbstring.http-output"/>
+  <redirect from="mbstring.encoding-translation" to="mbstring.configuration#ini.mbstring.encoding-translation"/>
+  <redirect from="mbstring.detect-order" to="mbstring.configuration#ini.mbstring.detect-order"/>
+  <redirect from="mbstring.substitute-character" to="mbstring.configuration#ini.mbstring.substitute-character"/>
+  <redirect from="mbstring.func-overload" to="mbstring.configuration#ini.mbstring.func-overload"/>
+  <redirect from="gd.jpeg-ignore-warning" to="image.configuration#ini.image.jpeg-ignore-warning"/>
+  <redirect from="exif.encode-unicode" to="exif.configuration#ini.exif.encode-unicode"/>
+  <redirect from="exif.decode-unicode-motorola" to="exif.configuration#ini.exif.decode-unicode-motorola"/>
+  <redirect from="exif.decode-unicode-intel" to="exif.configuration#ini.exif.decode-unicode-intel"/>
+  <redirect from="exif.encode-jis" to="exif.configuration#ini.exif.encode-jis"/>
+  <redirect from="exif.decode-jis-motorola" to="exif.configuration#ini.exif.decode-jis-motorola"/>
+  <redirect from="exif.decode-jis-intel" to="exif.configuration#ini.exif.decode-jis-intel"/>
+  <redirect from="tidy.default-config" to="tidy.configuration#ini.tidy.default-config"/>
+  <redirect from="tidy.clean-output" to="tidy.configuration#ini.tidy.clean-output"/>
+  <redirect from="soap.wsdl-cache-enabled" to="soap.configuration#ini.soap.wsdl-cache-enabled"/>
+  <redirect from="soap.wsdl-cache-dir" to="soap.configuration#ini.soap.wsdl-cache-dir"/>
+  <redirect from="soap.wsdl-cache-ttl" to="soap.configuration#ini.soap.wsdl-cache-ttl"/>
+
+  <!-- ============================================================== -->
+  <!-- Reserved variables (from is_known_variable) -->
+  <!-- $-stripped keys; dispatcher does ltrim($term, '$') -->
+  <!-- ============================================================== -->
+  <redirect from="globals" to="reserved.variables.globals"/>
+  <redirect from="-server" to="reserved.variables.server"/>
+  <redirect from="-get" to="reserved.variables.get"/>
+  <redirect from="-post" to="reserved.variables.post"/>
+  <redirect from="-files" to="reserved.variables.files"/>
+  <redirect from="-request" to="reserved.variables.request"/>
+  <redirect from="-session" to="reserved.variables.session"/>
+  <redirect from="-cookie" to="reserved.variables.cookies"/>
+  <redirect from="-env" to="reserved.variables.environment"/>
+  <redirect from="this" to="language.oop5.basic"/>
+  <redirect from="php-errormsg" to="reserved.variables.phperrormsg"/>
+  <redirect from="argv" to="reserved.variables.argv"/>
+  <redirect from="argc" to="reserved.variables.argc"/>
+  <redirect from="http-response-header" to="reserved.variables.httpresponseheader"/>
+  <redirect from="http-server-vars" to="reserved.variables.server"/>
+  <redirect from="http-get-vars" to="reserved.variables.get"/>
+  <redirect from="http-post-vars" to="reserved.variables.post"/>
+  <redirect from="http-session-vars" to="reserved.variables.session"/>
+  <redirect from="http-post-files" to="reserved.variables.files"/>
+  <redirect from="http-cookie-vars" to="reserved.variables.cookies"/>
+
+  <!-- ============================================================== -->
+  <!-- Keywords / terms (from is_known_term) -->
+  <!-- ============================================================== -->
+  <redirect from="&lt;&gt;" to="language.operators.comparison"/>
+  <redirect from="&lt;=&gt;" to="language.operators.comparison"/>
+  <redirect from="spaceship" to="language.operators.comparison"/>
+  <redirect from="==" to="language.operators.comparison"/>
+  <redirect from="===" to="language.operators.comparison"/>
+  <redirect from="@" to="language.operators.errorcontrol"/>
+  <redirect from="--halt-compiler" to="function.halt-compiler"/>
+  <redirect from="--php-incomplete-class" to="function.unserialize"/>
+  <redirect from="and" to="language.operators.logical"/>
+  <redirect from="apache" to="install"/>
+  <redirect from="array" to="language.types.array"/>
+  <redirect from="arrays" to="language.types.array"/>
+  <redirect from="as" to="control-structures.foreach"/>
+  <redirect from="case" to="control-structures.switch"/>
+  <redirect from="catch" to="language.exceptions"/>
+  <redirect from="checkbox" to="faq.html"/>
+  <redirect from="class" to="language.oop5.basic"/>
+  <redirect from="classes" to="language.oop5.basic"/>
+  <redirect from="closures" to="functions.anonymous"/>
+  <redirect from="cookie" to="features.cookies"/>
+  <redirect from="date" to="function.date"/>
+  <redirect from="default" to="control-structures.switch"/>
+  <redirect from="do" to="control-structures.do.while"/>
+  <redirect from="enddeclare" to="control-structures.declare"/>
+  <redirect from="endfor" to="control-structures.alternative-syntax"/>
+  <redirect from="endforeach" to="control-structures.alternative-syntax"/>
+  <redirect from="endif" to="control-structures.alternative-syntax"/>
+  <redirect from="endswitch" to="control-structures.alternative-syntax"/>
+  <redirect from="endwhile" to="control-structures.alternative-syntax"/>
+  <redirect from="exception" to="language.exceptions"/>
+  <redirect from="extends" to="language.oop5.basic#language.oop5.basic.extends"/>
+  <redirect from="false" to="language.types.boolean"/>
+  <redirect from="file" to="function.file"/>
+  <redirect from="final" to="language.oop5.final"/>
+  <redirect from="finally" to="language.exceptions"/>
+  <redirect from="fopen" to="function.fopen"/>
+  <redirect from="for" to="control-structures.for"/>
+  <redirect from="foreach" to="control-structures.foreach"/>
+  <redirect from="form" to="language.variables.external"/>
+  <redirect from="forms" to="language.variables.external"/>
+  <redirect from="function" to="language.functions"/>
+  <redirect from="gd" to="book.image"/>
+  <redirect from="get" to="reserved.variables.get"/>
+  <redirect from="global" to="language.variables.scope"/>
+  <redirect from="header" to="function.header"/>
+  <redirect from="heredoc" to="language.types.string#language.types.string.syntax.heredoc"/>
+  <redirect from="htaccess" to="configuration.file"/>
+  <redirect from="if" to="control-structures.if"/>
+  <redirect from="implements" to="language.oop5.interfaces"/>
+  <redirect from="include" to="function.include"/>
+  <redirect from="insteadof" to="language.oop5.traits#language.oop5.traits.conflict"/>
+  <redirect from="int" to="language.types.integer"/>
+  <redirect from="ip" to="reserved.variables.server"/>
+  <redirect from="iterable" to="language.types.iterable"/>
+  <redirect from="juggling" to="language.types.type-juggling"/>
+  <redirect from="location" to="function.header"/>
+  <redirect from="mail" to="function.mail"/>
+  <redirect from="mixed" to="language.types.mixed"/>
+  <redirect from="modulo" to="language.operators.arithmetic"/>
+  <redirect from="mysql" to="mysql"/>
+  <redirect from="never" to="language.types.never"/>
+  <redirect from="new" to="language.oop5.basic#language.oop5.basic.new"/>
+  <redirect from="nowdoc" to="language.types.string#language.types.string.syntax.nowdoc"/>
+  <redirect from="null" to="language.types.null"/>
+  <redirect from="numeric" to="reserved.other-reserved-words"/>
+  <redirect from="object" to="language.types.object"/>
+  <redirect from="operator" to="language.operators"/>
+  <redirect from="operators" to="language.operators"/>
+  <redirect from="or" to="language.operators.logical"/>
+  <redirect from="parent" to="reserved.classes#reserved.classes.special"/>
+  <redirect from="php.ini" to="configuration.file"/>
+  <redirect from="php-mysql.dll" to="book.mysql"/>
+  <redirect from="php-self" to="reserved.variables.server"/>
+  <redirect from="query-string" to="reserved.variables.server"/>
+  <redirect from="readonly" to="language.oop5.properties#language.oop5.properties.readonly-properties"/>
+  <redirect from="redirect" to="function.header"/>
+  <redirect from="reference" to="index"/>
+  <redirect from="referer" to="reserved.variables.server"/>
+  <redirect from="referrer" to="reserved.variables.server"/>
+  <redirect from="remote-addr" to="reserved.variables.server"/>
+  <redirect from="request" to="reserved.variables.request"/>
+  <redirect from="self" to="reserved.classes#reserved.classes.special"/>
+  <redirect from="session" to="features.sessions"/>
+  <redirect from="ssl" to="book.openssl"/>
+  <redirect from="static" to="language.oop5.static"/>
+  <redirect from="stdin" to="wrappers.php"/>
+  <redirect from="string" to="language.types.string"/>
+  <redirect from="superglobal" to="language.variables.superglobals"/>
+  <redirect from="superglobals" to="language.variables.superglobals"/>
+  <redirect from="switch" to="control-structures.switch"/>
+  <redirect from="timestamp" to="function.time"/>
+  <redirect from="true" to="language.types.boolean"/>
+  <redirect from="try" to="language.exceptions"/>
+  <redirect from="upload" to="features.file-upload"/>
+  <redirect from="use" to="language.namespaces"/>
+  <redirect from="void" to="language.types.void"/>
+  <redirect from="xor" to="language.operators.logical"/>
+  <redirect from="yield from" to="language.generators.syntax#control-structures.yield.from"/>
+  <redirect from="yield" to="language.generators.syntax#control-structures.yield"/>
+  <redirect from="--compiler-halt-offset--" to="function.halt-compiler"/>
+  <redirect from="default-include-path" to="reserved.constants"/>
+  <redirect from="e-all" to="errorfunc.constants"/>
+  <redirect from="e-compile-error" to="errorfunc.constants"/>
+  <redirect from="e-compile-warning" to="errorfunc.constants"/>
+  <redirect from="e-core-error" to="errorfunc.constants"/>
+  <redirect from="e-core-warning" to="errorfunc.constants"/>
+  <redirect from="e-deprecated" to="errorfunc.constants"/>
+  <redirect from="e-error" to="errorfunc.constants"/>
+  <redirect from="e-notice" to="errorfunc.constants"/>
+  <redirect from="e-parse" to="errorfunc.constants"/>
+  <redirect from="e-recoverable-error" to="errorfunc.constants"/>
+  <redirect from="e-strict" to="errorfunc.constants"/>
+  <redirect from="e-user-deprecated" to="errorfunc.constants"/>
+  <redirect from="e-user-error" to="errorfunc.constants"/>
+  <redirect from="e-user-notice" to="errorfunc.constants"/>
+  <redirect from="e-user-warning" to="errorfunc.constants"/>
+  <redirect from="e-warning" to="errorfunc.constants"/>
+  <redirect from="pear-extension-dir" to="reserved.constants"/>
+  <redirect from="pear-install-dir" to="reserved.constants"/>
+  <redirect from="php-binary" to="reserved.constants"/>
+  <redirect from="php-bindir" to="reserved.constants"/>
+  <redirect from="php-config-file-path" to="reserved.constants"/>
+  <redirect from="php-config-file-scan-dir" to="reserved.constants"/>
+  <redirect from="php-datadir" to="reserved.constants"/>
+  <redirect from="php-debug" to="reserved.constants"/>
+  <redirect from="php-eol" to="reserved.constants"/>
+  <redirect from="php-extension-dir" to="reserved.constants"/>
+  <redirect from="php-extra-version" to="reserved.constants"/>
+  <redirect from="php-fd-setsize" to="reserved.constants"/>
+  <redirect from="php-float-dig" to="reserved.constants"/>
+  <redirect from="php-float-epsilon" to="reserved.constants"/>
+  <redirect from="php-float-max" to="reserved.constants"/>
+  <redirect from="php-float-min" to="reserved.constants"/>
+  <redirect from="php-int-max" to="reserved.constants"/>
+  <redirect from="php-int-min" to="reserved.constants"/>
+  <redirect from="php-int-size" to="reserved.constants"/>
+  <redirect from="php-libdir" to="reserved.constants"/>
+  <redirect from="php-localstatedir" to="reserved.constants"/>
+  <redirect from="php-major-version" to="reserved.constants"/>
+  <redirect from="php-mandir" to="reserved.constants"/>
+  <redirect from="php-maxpathlen" to="reserved.constants"/>
+  <redirect from="php-minor-version" to="reserved.constants"/>
+  <redirect from="php-os-family" to="reserved.constants"/>
+  <redirect from="php-os" to="reserved.constants"/>
+  <redirect from="php-prefix" to="reserved.constants"/>
+  <redirect from="php-release-version" to="reserved.constants"/>
+  <redirect from="php-sapi" to="reserved.constants"/>
+  <redirect from="php-shlib-suffix" to="reserved.constants"/>
+  <redirect from="php-sysconfdir" to="reserved.constants"/>
+  <redirect from="php-version-id" to="reserved.constants"/>
+  <redirect from="php-version" to="reserved.constants"/>
+  <redirect from="php-windows-event-ctrl-break" to="reserved.constants"/>
+  <redirect from="php-windows-event-ctrl-c" to="reserved.constants"/>
+  <redirect from="php-zts" to="reserved.constants"/>
  </group>
- 
+
  <group scope="both">
 
   <!-- entry point changed -->
   <redirect from="installation" to="install"/>
 
   <!-- XML Id changed (see https://github.com/php/doc-en/commit/0d51ca45814bbc60d7a1e6cf6fc7213f0b49c8d5) -->
-  <redirect from="enum.random.intervalboundary"          to="enum.random-intervalboundary"/>
-  <redirect from="enum.random.intervalboundary.intro"    to="enum.random-intervalboundary.intro"/>
+  <redirect from="enum.random.intervalboundary" to="enum.random-intervalboundary"/>
+  <redirect from="enum.random.intervalboundary.intro" to="enum.random-intervalboundary.intro"/>
   <redirect from="enum.random.intervalboundary.synopsis" to="enum.random-intervalboundary.synopsis"/>
 
   <!-- was split among platforms (don't know where to redirect) -->
-  <redirect from="install.apache"              to="install"/>
-  <redirect from="install.apache2"             to="install"/>
+  <redirect from="install.apache" to="install"/>
+  <redirect from="install.apache2" to="install"/>
   <redirect from="install.netscape-enterprise" to="install"/>
-  <redirect from="install.otherhttpd"          to="install"/>
+  <redirect from="install.otherhttpd" to="install"/>
 
   <!-- moved to platform sections -->
-  <redirect from="install.commandline"           to="install.unix.commandline"/>
-  <redirect from="install.iis"                   to="install.windows.iis"/>
-  <redirect from="install.linux"                 to="install.unix"/>
-  <redirect from="install.openbsd"               to="install.unix.openbsd"/>
-  <redirect from="install.solaris"               to="install.unix.solaris"/>
+  <redirect from="install.commandline" to="install.unix.commandline"/>
+  <redirect from="install.iis" to="install.windows.iis"/>
+  <redirect from="install.linux" to="install.unix"/>
+  <redirect from="install.openbsd" to="install.unix.openbsd"/>
+  <redirect from="install.solaris" to="install.unix.solaris"/>
   <redirect from="install.windows.installer.msi" to="install.windows"/>
-  <redirect from="install.windows.installer"     to="install.windows"/>
+  <redirect from="install.windows.installer" to="install.windows"/>
+  <redirect from="install.windows.tools" to="install.windows"/>
 
   <!-- Replaced extensions -->
   <redirect from="aspell" to="book.pspell"/>
 
   <!-- Refactored -->
   <redirect from="regexp.reference" to="regexp.introduction"/>
-  <redirect from="security"         to="security"/>
+  <redirect from="security" to="security"/>
 
   <!-- MongoDB converted from set to book -->
-  <redirect from="set.mongodb"                         to="book.mongodb"/>
-  <redirect from="mongodb.installation.homebrew"       to="mongodb.installation#mongodb.installation.homebrew"/>
-  <redirect from="mongodb.installation.manual"         to="mongodb.installation#mongodb.installation.manual"/>
-  <redirect from="mongodb.installation.pecl"           to="mongodb.installation#mongodb.installation.pecl"/>
-  <redirect from="mongodb.installation.windows"        to="mongodb.installation#mongodb.installation.windows"/>
+  <redirect from="set.mongodb" to="book.mongodb"/>
+  <redirect from="mongodb.installation.homebrew" to="mongodb.installation#mongodb.installation.homebrew"/>
+  <redirect from="mongodb.installation.manual" to="mongodb.installation#mongodb.installation.manual"/>
+  <redirect from="mongodb.installation.pecl" to="mongodb.installation#mongodb.installation.pecl"/>
+  <redirect from="mongodb.installation.windows" to="mongodb.installation#mongodb.installation.windows"/>
   <redirect from="mongodb.persistence.deserialization" to="mongodb.persistence#mongodb.persistence.deserialization"/>
-  <redirect from="mongodb.persistence.serialization"   to="mongodb.persistence#mongodb.persistence.serialization"/>
+  <redirect from="mongodb.persistence.serialization" to="mongodb.persistence#mongodb.persistence.serialization"/>
  </group>
 
 </redirects>

--- a/redirects.xml
+++ b/redirects.xml
@@ -2,10 +2,10 @@
 <!--
   Redirect map for manual pages on php.net.
 
-  Rendered to redirects.php by phd (Redirects package) and included by
-  web-php/error.php. Only redirects that concern manual pages live here;
-  site-level aliases (downloads, support, git, etc.) and external URLs
-  stay in web-php/error.php.
+  Rendered to redirects.php by phd and included by web-php/error.php. 
+  Only redirects that concern manual pages live here;
+
+  Every redirect here is served with HTTP 301.
 
   Scopes:
     shortcut   match a bare URI  (php.net/{from})
@@ -13,19 +13,9 @@
     in-manual  match a manual URI (php.net/manual/{lang}/{from}.php)
                   -> /manual/{lang}/{to}.php
     both       fires at either entry point (bare or in-manual)
-
-  Every redirect here is served with HTTP 301.
-
-  The regex block only carries rewrites that target the manual URL
-  space; non-manual regex rewrites (news-N, release_*, GH-N, .php3)
-  remain in error.php.
 -->
 <redirects>
  
- <!-- ==================================================================== -->
- <!-- scope="in-manual": only fires inside /manual/{lang}/{from}.php        -->
- <!-- (ported from $manual_redirections in web-php/error.php)               -->
- <!-- ==================================================================== -->
  <group scope="in-manual">
 
   <!-- OCI-Lob class renamed -->
@@ -83,11 +73,7 @@
   <redirect from="simplexmliterator.rewind"      to="simplexmlelement.rewind"/>
   <redirect from="simplexmliterator.valid"       to="simplexmlelement.valid"/>
  </group>
-
- <!-- ==================================================================== -->
- <!-- scope="shortcut": bare URI shortcut into a manual page                -->
- <!-- (ported from $uri_aliases doc-target subset + $mysqli_redirects)      -->
- <!-- ==================================================================== -->
+ 
  <group scope="shortcut">
 
   <!-- Manual shortcuts -->
@@ -368,11 +354,7 @@
   <redirect from="mysqli_embedded_server_start" to="mysqli-driver.embedded-server-start"/>
   
  </group>
-
- <!-- ==================================================================== -->
- <!-- scope="both": manual page renamed; both bare and in-manual URLs fire  -->
- <!-- (ported from $manual_page_moves in web-php/error.php)                 -->
- <!-- ==================================================================== -->
+ 
  <group scope="both">
 
   <!-- entry point changed -->
@@ -403,7 +385,7 @@
 
   <!-- Refactored -->
   <redirect from="regexp.reference" to="regexp.introduction"/>
-  <redirect from="security"         to="manual/security"/>
+  <redirect from="security"         to="security"/>
 
   <!-- MongoDB converted from set to book -->
   <redirect from="set.mongodb"                         to="book.mongodb"/>

--- a/redirects.xml
+++ b/redirects.xml
@@ -20,7 +20,7 @@
   space; non-manual regex rewrites (news-N, release_*, GH-N, .php3)
   remain in error.php.
 -->
-<redirects xmlns="http://php.net/redirects">
+<redirects>
  
  <!-- ==================================================================== -->
  <!-- scope="in-manual": only fires inside /manual/{lang}/{from}.php        -->
@@ -403,7 +403,7 @@
 
   <!-- Refactored -->
   <redirect from="regexp.reference" to="regexp.introduction"/>
-  <redirect from="security"         to="manual/security"/>
+  <redirect from="security"         to="book.security"/>
 
   <!-- MongoDB converted from set to book -->
   <redirect from="set.mongodb"                         to="book.mongodb"/>

--- a/redirects.xml
+++ b/redirects.xml
@@ -403,7 +403,7 @@
 
   <!-- Refactored -->
   <redirect from="regexp.reference" to="regexp.introduction"/>
-  <redirect from="security"         to="book.security"/>
+  <redirect from="security"         to="manual/security"/>
 
   <!-- MongoDB converted from set to book -->
   <redirect from="set.mongodb"                         to="book.mongodb"/>


### PR DESCRIPTION
The goal for this PR is to migrate all doc related redirects out of web-php.
Instead we generate a `redirects.json` from `redirects.xml` which is then loaded in-place.

Redirects not related to docs are NOT migrated. However shortcuts are.

Depends on:

https://github.com/php/phd/pull/260