### PR TITLE
sqlite3: document lastExtendedErrorCode/enableExtendedResultCodes, fix lastInsertRowID casing, describe OK/DENY/IGNORE

### DIFF
--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -267,21 +267,29 @@
     <varlistentry xml:id="sqlite3.constants.ok">
      <term><constant>SQLite3::OK</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Returned from an authorizer callback to allow the action.
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="sqlite3.constants.deny">
      <term><constant>SQLite3::DENY</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Returned from an authorizer callback to abort the SQL statement with an
+       error.
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="sqlite3.constants.ignore">
      <term><constant>SQLite3::IGNORE</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Returned from an authorizer callback to disallow the specific action,
+       treating it as a no-op rather than an error.
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -263,21 +263,31 @@
     <varlistentry xml:id="sqlite3.constants.ok">
      <term><constant>SQLite3::OK</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Returned from an authorizer callback to allow the action.
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="sqlite3.constants.deny">
      <term><constant>SQLite3::DENY</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Returned from an authorizer callback to reject the entire SQL statement
+       with an error.
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="sqlite3.constants.ignore">
      <term><constant>SQLite3::IGNORE</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Returned from an authorizer callback to disallow the specific action
+       while still allowing the SQL statement to be compiled. See
+       <methodname>SQLite3::setAuthorizer</methodname> for the effect on each
+       action.
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/sqlite3/sqlite3/enableextendedresultcodes.xml
+++ b/reference/sqlite3/sqlite3/enableextendedresultcodes.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <refentry xml:id="sqlite3.enableextendedresultcodes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SQLite3::enableExtendedResultCodes</refname>

--- a/reference/sqlite3/sqlite3/enableextendedresultcodes.xml
+++ b/reference/sqlite3/sqlite3/enableextendedresultcodes.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="sqlite3.enableextendedresultcodes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3::enableExtendedResultCodes</refname>
+  <refpurpose>
+   Enables or disables the use of extended result codes
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3">
+   <modifier>public</modifier> <type>bool</type><methodname>SQLite3::enableExtendedResultCodes</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>enable</parameter><initializer>&true;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Enables or disables the use of extended result codes, which are then
+   reported by <methodname>SQLite3::lastExtendedErrorCode</methodname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>enable</parameter></term>
+    <listitem>
+     <simpara>
+      Whether to enable (&true;) or disable (&false;) the use of extended
+      result codes.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns &true; on success or &false; on failure.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::lastExtendedErrorCode</methodname></member>
+   <member><methodname>SQLite3::lastErrorCode</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/sqlite3/enableextendedresultcodes.xml
+++ b/reference/sqlite3/sqlite3/enableextendedresultcodes.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="sqlite3.enableextendedresultcodes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3::enableExtendedResultCodes</refname>
+  <refpurpose>
+   Enables or disables the use of extended result codes
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3">
+   <modifier>public</modifier> <type>bool</type><methodname>SQLite3::enableExtendedResultCodes</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>enable</parameter><initializer>&true;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Enables or disables the use of extended result codes, which are then
+   reported by <methodname>SQLite3::lastErrorCode</methodname>.
+   <methodname>SQLite3::lastExtendedErrorCode</methodname> is not affected by
+   this setting, and always returns the extended result code.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>enable</parameter></term>
+    <listitem>
+     <simpara>
+      Whether to enable (&true;) or disable (&false;) the use of extended
+      result codes.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>SQLite3::enableExtendedResultCodes</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new SQLite3(':memory:');
+$db->enableExceptions(true);
+$db->exec('CREATE TABLE t (a INTEGER UNIQUE)');
+$db->exec('INSERT INTO t VALUES (1)');
+
+try {
+    $db->exec('INSERT INTO t VALUES (1)');
+} catch (Exception $e) {
+}
+
+// The primary result code (SQLITE_CONSTRAINT), then the extended result
+// code (SQLITE_CONSTRAINT_UNIQUE).
+var_dump($db->lastErrorCode(), $db->lastExtendedErrorCode());
+
+// Once enabled, SQLite3::lastErrorCode() reports the extended result code
+// as well.
+$db->enableExtendedResultCodes();
+var_dump($db->lastErrorCode());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(19)
+int(2067)
+int(2067)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::lastExtendedErrorCode</methodname></member>
+   <member><methodname>SQLite3::lastErrorCode</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/sqlite3/lastextendederrorcode.xml
+++ b/reference/sqlite3/sqlite3/lastextendederrorcode.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="sqlite3.lastextendederrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3::lastExtendedErrorCode</refname>
+  <refpurpose>
+   Returns the numeric extended result code of the most recent failed SQLite request
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3">
+   <modifier>public</modifier> <type>int</type><methodname>SQLite3::lastExtendedErrorCode</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Returns the numeric extended result code of the most recent failed SQLite
+   request. Extended result codes must first be enabled with
+   <methodname>SQLite3::enableExtendedResultCodes</methodname>; otherwise the
+   primary result code is returned.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns an integer value representing the numeric extended result code of
+   the most recent failed SQLite request.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::enableExtendedResultCodes</methodname></member>
+   <member><methodname>SQLite3::lastErrorCode</methodname></member>
+   <member><methodname>SQLite3::lastErrorMsg</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/sqlite3/lastextendederrorcode.xml
+++ b/reference/sqlite3/sqlite3/lastextendederrorcode.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <refentry xml:id="sqlite3.lastextendederrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SQLite3::lastExtendedErrorCode</refname>

--- a/reference/sqlite3/sqlite3/lastextendederrorcode.xml
+++ b/reference/sqlite3/sqlite3/lastextendederrorcode.xml
@@ -1,22 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<refentry xml:id="sqlite3.lasterrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="sqlite3.lastextendederrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>SQLite3::lastErrorCode</refname>
+  <refname>SQLite3::lastExtendedErrorCode</refname>
   <refpurpose>
-   Returns the numeric result code of the most recent failed SQLite request
+   Returns the numeric extended result code of the most recent failed
+   SQLite request
   </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="SQLite3">
-   <modifier>public</modifier> <type>int</type><methodname>SQLite3::lastErrorCode</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>SQLite3::lastExtendedErrorCode</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Returns the numeric result code of the most recent failed SQLite request.
-  </para>
+  <simpara>
+   Returns the numeric extended result code of the most recent failed SQLite
+   request. Unlike <methodname>SQLite3::lastErrorCode</methodname>, this method
+   always returns the extended result code, whether or not extended result
+   codes have been enabled with
+   <methodname>SQLite3::enableExtendedResultCodes</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,17 +31,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns an integer value representing the numeric result code of the most
-   recent failed SQLite request.
-  </para>
+  <simpara>
+   Returns an integer value representing the numeric extended result code of
+   the most recent failed SQLite request.
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>SQLite3::lastExtendedErrorCode</methodname></member>
    <member><methodname>SQLite3::enableExtendedResultCodes</methodname></member>
+   <member><methodname>SQLite3::lastErrorCode</methodname></member>
    <member><methodname>SQLite3::lastErrorMsg</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/sqlite3/versions.xml
+++ b/reference/sqlite3/versions.xml
@@ -15,11 +15,13 @@
  <function name="SQLite3::createCollation" from="PHP 5 &gt;= 5.3.11, PHP 7, PHP 8"/>
  <function name="SQLite3::createFunction" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::enableExceptions" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="SQLite3::enableExtendedResultCodes" from="PHP 8"/>
  <function name="SQLite3::escapeString" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::exec" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::lastErrorCode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::lastErrorMsg" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
- <function name="SQLite3::lastInsertRowId" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="SQLite3::lastExtendedErrorCode" from="PHP 8"/>
+ <function name="SQLite3::lastInsertRowID" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::loadExtension" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::open" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::openBlob" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>

--- a/reference/sqlite3/versions.xml
+++ b/reference/sqlite3/versions.xml
@@ -13,11 +13,13 @@
  <function name="SQLite3::createCollation" from="PHP 5 &gt;= 5.3.11, PHP 7, PHP 8"/>
  <function name="SQLite3::createFunction" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::enableExceptions" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="SQLite3::enableExtendedResultCodes" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
  <function name="SQLite3::escapeString" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::exec" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::lastErrorCode" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::lastErrorMsg" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
- <function name="SQLite3::lastInsertRowId" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="SQLite3::lastExtendedErrorCode" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
+ <function name="SQLite3::lastInsertRowID" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::loadExtension" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::open" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3::openBlob" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>


### PR DESCRIPTION
Document two public SQLite3 methods that have existed since PHP 7.4.0 but had no manual page: `SQLite3::lastExtendedErrorCode(): int` and `SQLite3::enableExtendedResultCodes(bool $enable = true): bool` (both added to versions.xml). Align the casing of `SQLite3::lastInsertRowID` in versions.xml with the stub and the refname, and fill the empty `SQLite3::OK`/`DENY`/`IGNORE` authorizer constant descriptions.

`SQLite3::lastExtendedErrorCode()` always returns the extended result code; what `SQLite3::enableExtendedResultCodes()` changes is the value reported by `SQLite3::lastErrorCode()`. Both pages document it that way, an example on `SQLite3::enableExtendedResultCodes()` shows the difference, and a see also section is added to `SQLite3::lastErrorCode()`, which had none.

The remaining empty descriptions in the authorizer *action* constant list are left for a follow-up; this PR only covers the three *return* constants.

Signatures checked against the php-src 8.4 stubs and arginfo; behaviour verified against ext/sqlite3/sqlite3.c and run on php:7.4 and php:8.4.

Sources:
- Both methods added in PHP 7.4.0: php-src b546ae986a ("Implement SQLite extended result code functionality", 2019-07-02), first release tag php-7.4.0; php-7.4.0 UPGRADING: "Added SQLite3::enableExtendedResultCodes($enable = true), which will make SQLite3::lastErrorCode() return extended result codes."
- Semantics: ext/sqlite3/sqlite3.c: lastExtendedErrorCode() calls sqlite3_extended_errcode(), lastErrorCode() calls sqlite3_errcode(), enableExtendedResultCodes() calls sqlite3_extended_result_codes()
- Authorizer return codes: https://sqlite.org/c3ref/set_authorizer.html