### PR TITLE
Remove return.falseproblem banner for pcntl_setcpuaffinity

### DIFF
--- a/reference/pcntl/functions/pcntl-setcpuaffinity.xml
+++ b/reference/pcntl/functions/pcntl-setcpuaffinity.xml
@@ -46,7 +46,6 @@
   <simpara>
    &return.success;
   </simpara>
-  &return.falseproblem;
  </refsect1>
 
  <refsect1 role="errors">


### PR DESCRIPTION
The function can only return a boolean value, so the banner does not apply.