### PR TITLE
Mark version.xml files as do-not-translate

### DIFF
--- a/language/control-structures/versions.xml
+++ b/language/control-structures/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='include' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
@@ -51,4 +48,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/language/predefined/versions.xml
+++ b/language/predefined/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="__autoload" from="PHP 5, PHP 7" deprecated="PHP 7.2.0" removed="PHP 8"/>
 

--- a/reference/apache/versions.xml
+++ b/reference/apache/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="apache_child_terminate" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
  <function name="apache_get_modules" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
  <function name="apache_get_version" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>

--- a/reference/apcu/versions.xml
+++ b/reference/apcu/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='apcu_add' from='PECL apcu &gt;= 4.0.0'/>
  <function name='apcu_cache_info' from='PECL apcu &gt;= 4.0.0'/>

--- a/reference/array/versions.xml
+++ b/reference/array/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='array' from='PHP 4, PHP 5, PHP 7, PHP 8'/>
  <function name='array_all' from='PHP 8 &gt;= 8.4.0'/>

--- a/reference/bc/versions.xml
+++ b/reference/bc/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="bcadd" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="bcceil" from="PHP 8 &gt;= 8.4.0"/>
  <function name="bccomp" from="PHP 4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/bzip2/versions.xml
+++ b/reference/bzip2/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="bzwrite" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
  <function name="bzflush" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
  <function name="bzclose" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/calendar/versions.xml
+++ b/reference/calendar/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="cal_days_in_month" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>

--- a/reference/classobj/versions.xml
+++ b/reference/classobj/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="__autoload" from="PHP 5, PHP 7" deprecated="PHP 7.2.0" removed="PHP 8"/>

--- a/reference/cmark/versions.xml
+++ b/reference/cmark/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/com/versions.xml
+++ b/reference/com/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="com" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="com::__construct" from="PHP 4 &gt; 4.1.0, PHP 5, PHP 7, PHP 8"/>

--- a/reference/componere/versions.xml
+++ b/reference/componere/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/ctype/versions.xml
+++ b/reference/ctype/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="ctype_alnum" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
  <function name="ctype_alpha" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
  <function name="ctype_cntrl" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/cubrid/versions.xml
+++ b/reference/cubrid/versions.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <!--
  NOTE: Version info for the cubrid PECL Extension (1.0) is
        considered irrelevant so is not listed here.
 -->
+
 <versions>
  <function name='cubrid' from='PECL CUBRID &gt;= 8.3.0'/>
  <function name='cubrid_affected_rows' from='PECL CUBRID &gt;= 8.3.0'/>

--- a/reference/curl/versions.xml
+++ b/reference/curl/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="curl_close" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.5.0"/>
  <function name="curl_copy_handle" from="PHP 5, PHP 7, PHP 8"/>

--- a/reference/datetime/versions.xml
+++ b/reference/datetime/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <!-- Methods -->
  <function name="datetime" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
@@ -160,6 +158,7 @@
  <function name="timezone_transitions_get" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="timezone_version_get" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/dba/versions.xml
+++ b/reference/dba/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <!-- Classes -->
  <function name="dba\connection" from="PHP 8 &gt;= 8.4.0"/>
@@ -24,6 +22,7 @@
  <function name="dba_replace" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="dba_sync" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/dbase/versions.xml
+++ b/reference/dbase/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name='dbase_add_record' from='PHP 5 &lt; 5.3.0, dbase 5, dbase 7'/>
  <function name='dbase_close' from='PHP 5 &lt; 5.3.0, dbase 5, dbase 7'/>
  <function name='dbase_create' from='PHP 5 &lt; 5.3.0, dbase 5, dbase 7'/>

--- a/reference/dio/versions.xml
+++ b/reference/dio/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name='dio_close' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.1.0'/>
  <function name='dio_fcntl' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.1.0'/>
  <function name='dio_open' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.1.0'/>
@@ -14,6 +12,7 @@
  <function name='dio_truncate' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.1.0'/>
  <function name='dio_write' from='PHP 4 &gt;= 4.2.0, PHP 5 &lt; 5.1.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/dir/versions.xml
+++ b/reference/dir/versions.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="Directory" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="Directory::close" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="Directory::read" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="Directory::rewind" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
- 
+
  <function name="chdir" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="chroot" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
  <function name="closedir" from="PHP 4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/dom/versions.xml
+++ b/reference/dom/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="domattr" from="PHP 5, PHP 7, PHP 8"/>
  <function name="domattr::__construct" from="PHP 5, PHP 7, PHP 8"/>
@@ -264,6 +262,7 @@
  <function name="dom\tokenlist::supports" from="PHP 8 &gt;= 8.4.0"/>
  <function name="dom\tokenlist::toggle" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ds/versions.xml
+++ b/reference/ds/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/eio/versions.xml
+++ b/reference/eio/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/enchant/versions.xml
+++ b/reference/enchant/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="enchant_broker_describe" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0"/>
  <function name="enchant_broker_dict_exists" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
  <function name="enchant_broker_free" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 " deprecated="PHP 8.0.0"/>
@@ -31,6 +29,7 @@
  <function name="enchantbroker" from="PHP 8"/>
  <function name="enchantdictionary" from="PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/errorfunc/versions.xml
+++ b/reference/errorfunc/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="debug_backtrace" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>

--- a/reference/ev/versions.xml
+++ b/reference/ev/versions.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
-<!-- Methods -->
+ <!-- Methods -->
 
  <function name='ev' from='PECL ev &gt;= 0.2.0'/>
  <function name='ev::supportedbackends' from='PECL ev &gt;= 0.2.0'/>
@@ -207,6 +205,7 @@
  <function name='evfork::keepalive' from='PECL ev &gt;= 0.2.0'/>
  <function name='evfork::setcallback' from='PECL ev &gt;= 0.2.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/event/versions.xml
+++ b/reference/event/versions.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
-<!-- Methods -->
+ <!-- Methods -->
  <function name='event' from='PECL event &gt;= 1.2.6-beta'/>
  <function name="event::__construct" from="PECL event &gt;= 1.2.6-beta"/>
  <function name="event::free" from="PECL event &gt;= 1.2.6-beta"/>
@@ -172,6 +170,7 @@
  <function name='eventsslcontext' from='PECL event &gt;= 1.2.6-beta'/>
  <function name="eventsslcontext::__construct" from="PECL event &gt;= 1.2.6-beta"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/exec/versions.xml
+++ b/reference/exec/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="escapeshellarg" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>

--- a/reference/exif/versions.xml
+++ b/reference/exif/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="exif_imagetype" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="exif_read_data" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="exif_tagname" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>

--- a/reference/expect/versions.xml
+++ b/reference/expect/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='expect_expectl' from='PECL expect &gt;= 0.1.0'/>

--- a/reference/fann/versions.xml
+++ b/reference/fann/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/fdf/versions.xml
+++ b/reference/fdf/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name='fdf_add_doc_javascript' from='PHP 4 &gt;= 4.3.0, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
  <function name='fdf_add_template' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>
  <function name='fdf_close' from='PHP 4, PHP 5 &lt; 5.3.0, PECL fdf SVN'/>

--- a/reference/ffi/versions.xml
+++ b/reference/ffi/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/fileinfo/versions.xml
+++ b/reference/fileinfo/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="finfo_buffer" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
  <function name="finfo_close" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0" deprecated="PHP 8.5.0"/>
  <function name="finfo_file" from="PHP &gt;= 5.3.0, PHP 7, PHP 8, PECL fileinfo &gt;= 0.1.0"/>
@@ -18,6 +16,7 @@
 
  <function name="mime_content_type" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/filesystem/versions.xml
+++ b/reference/filesystem/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="basename" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="chgrp" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="chmod" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -109,4 +107,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/filter/versions.xml
+++ b/reference/filter/versions.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <!-- Version information for the PECL version (clutter) is intentionally missing -->
-<versions> 
+
+<versions>
  <function name="filter_has_var" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="filter_id" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="filter_input" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>

--- a/reference/fpm/versions.xml
+++ b/reference/fpm/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="fastcgi_finish_request" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>

--- a/reference/ftp/versions.xml
+++ b/reference/ftp/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="ftp_alloc" from="PHP 5, PHP 7, PHP 8"/>
  <function name="ftp_append" from="PHP 7 &gt;= 7.2.0, PHP 8"/>

--- a/reference/funchand/versions.xml
+++ b/reference/funchand/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="call_user_func_array" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/gearman/versions.xml
+++ b/reference/gearman/versions.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<!--
-Example entries:
- <function name='classname::methodname' from='PECL extname &gt;= 1.1'/>
- <function name='functionname' from='PHP &gt;= 5.3.0'/>
- <function name='functionname' from='PHP 5'/>
--->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name='gearman_version' from='PECL gearman &gt;= 0.5.0'/>

--- a/reference/gender/versions.xml
+++ b/reference/gender/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Methods -->

--- a/reference/geoip/versions.xml
+++ b/reference/geoip/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name='geoip_asnum_by_name' from='PECL geoip &gt;= 1.1.0'/>
  <function name='geoip_continent_code_by_name' from='PECL geoip &gt;= 1.0.3'/>
  <function name='geoip_country_code3_by_name' from='PECL geoip &gt;= 0.2.0'/>

--- a/reference/gettext/versions.xml
+++ b/reference/gettext/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="_" from="PHP 4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/gmagick/versions.xml
+++ b/reference/gmagick/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
   <!-- Methods -->
 

--- a/reference/gmp/versions.xml
+++ b/reference/gmp/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="gmp" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
  <function name="gmp_abs" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
  <function name="gmp_add" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/gnupg/versions.xml
+++ b/reference/gnupg/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name='gnupg_adddecryptkey' from='PECL gnupg &gt;= 0.5'/>
  <function name='gnupg_addencryptkey' from='PECL gnupg &gt;= 0.5'/>
  <function name='gnupg_addsignkey' from='PECL gnupg &gt;= 0.5'/>

--- a/reference/hash/versions.xml
+++ b/reference/hash/versions.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="HashContext" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="HashContext::__construct" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
  <function name="HashContext::__debugInfo" from="PHP 8 &gt;= 8.4.0"/>
  <function name="HashContext::__serialize" from="PHP 8"/>
  <function name="HashContext::__unserialize" from="PHP 8"/>
- 
+
  <function name="hash" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL hash &gt;= 1.1"/>
  <function name="hash_algos" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL hash &gt;= 1.1"/>
  <function name="hash_copy" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
@@ -26,6 +24,7 @@
  <function name="hash_update_file" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL hash &gt;= 1.1"/>
  <function name="hash_update_stream" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL hash &gt;= 1.1"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/hrtime/versions.xml
+++ b/reference/hrtime/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/ibase/versions.xml
+++ b/reference/ibase/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="ibase_add_user" from="PHP 5, PHP 7 &lt; 7.4.0"/>
  <function name="ibase_affected_rows" from="PHP 5, PHP 7 &lt; 7.4.0"/>
@@ -104,6 +102,7 @@
  <function name="fbird_trans" from="PHP 5, PHP 7 &lt; 7.4.0"/>
  <function name="fbird_wait_event" from="PHP 5, PHP 7 &lt; 7.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ibm_db2/versions.xml
+++ b/reference/ibm_db2/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name='db2_autocommit' from='PECL ibm_db2 &gt;= 1.0.0'/>
  <function name='db2_bind_param' from='PECL ibm_db2 &gt;= 1.0.0'/>
  <function name='db2_client_info' from='PECL ibm_db2 &gt;= 1.1.1'/>

--- a/reference/iconv/versions.xml
+++ b/reference/iconv/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="iconv" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
  <function name="iconv_get_encoding" from="PHP 4 &gt;= 4.0.5, PHP 5, PHP 7, PHP 8"/>
  <function name="iconv_mime_decode" from="PHP 5, PHP 7, PHP 8"/>

--- a/reference/igbinary/versions.xml
+++ b/reference/igbinary/versions.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do NOT translate this file -->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name='igbinary_serialize' from='PECL igbinary &gt;= 1.1.1'/>
  <function name='igbinary_unserialize' from='PECL igbinary &gt;= 1.1.1'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/image/versions.xml
+++ b/reference/image/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="gd_info" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="getimagesize" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="getimagesizefromstring" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
@@ -125,6 +123,7 @@
  <function name="gdimage" from="PHP 8"/>
  <function name="gdfont" from="PHP 8 &gt;= 8.1.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/imagick/versions.xml
+++ b/reference/imagick/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='imagickexception' from='PECL imagick 3'/>
  <function name='imagickdrawexception' from='PECL imagick 3'/>
@@ -539,7 +537,6 @@
  <function name='ImagickKernel::separate' from='PECL imagick &gt;= 3.3.0'/>
  <function name='ImagickKernel::scale' from='PECL imagick &gt;= 3.3.0'/>
  <function name='ImagickKernel::addUnityKernel' from='PECL imagick &gt;= 3.3.0'/>
-
 </versions>
 
 <!-- Keep this comment at the end of the file

--- a/reference/imap/versions.xml
+++ b/reference/imap/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name="imap_8bit" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_alerts" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="imap_append" from="PHP 4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/info/versions.xml
+++ b/reference/info/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="assert" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="assert_options" from="PHP 4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.3.0" />

--- a/reference/inotify/versions.xml
+++ b/reference/inotify/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='inotify_add_watch' from='PECL inotify &gt;= 0.1.2'/>

--- a/reference/intl/versions.xml
+++ b/reference/intl/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="intlexception" from="PHP 5 &gt; 5.5.0, PHP 7, PHP 8, PECL intl &gt; 3.0.0a1"/>
  <!-- Methods -->
@@ -264,7 +262,7 @@
  <function name="intlbreakiterator::getpartsiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlbreakiterator::geterrorcode" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlbreakiterator::geterrormessage" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
- 
+
  <function name="intlcodepointbreakiterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlcodepointbreakiterator::getlastcodepoint" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 
@@ -281,7 +279,7 @@
  <function name="intlrulebasedbreakiterator::getrulestatus" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlrulebasedbreakiterator::getrulestatusvec" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlrulebasedbreakiterator::getbinaryrules" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
- 
+
  <function name="intlgregoriancalendar" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlgregoriancalendar::__construct" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlgregoriancalendar::createfromdate" from="PHP 8 &gt;= 8.3.0"/>
@@ -289,7 +287,7 @@
  <function name="intlgregoriancalendar::setgregorianchange" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlgregoriancalendar::getgregorianchange" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intlgregoriancalendar::isleapyear" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
- 
+
  <function name="intliterator" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="intliterator::current" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="IntlIterator::key" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
@@ -449,6 +447,7 @@
  <function name="numfmt_get_error_code" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
  <function name="numfmt_get_error_message" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL intl &gt;= 1.0.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/json/versions.xml
+++ b/reference/json/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='json_decode' from='PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL json &gt;= 1.2.0'/>
  <function name='json_encode' from='PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL json &gt;= 1.2.0'/>
@@ -38,4 +36,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/ldap/versions.xml
+++ b/reference/ldap/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="ldap_8859_to_t61" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
  <function name="ldap_add" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -71,6 +69,7 @@
  <function name='ldap\result' from='PHP 8 &gt;= 8.1.0'/>
  <function name='ldap\resultentry' from='PHP 8 &gt;= 8.1.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/libxml/versions.xml
+++ b/reference/libxml/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="libxml_clear_errors" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="libxml_get_errors" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
@@ -12,9 +10,10 @@
  <function name="libxml_disable_entity_loader" from="PHP 5 &gt;= 5.2.11, PHP 7, PHP 8" deprecated="PHP 8.0.0"/>
  <function name="libxml_set_external_entity_loader" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  <function name="libxml_get_external_entity_loader" from="PHP 8 &gt;= 8.2.0"/>
- 
+
  <function name="libxmlerror" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/litespeed/versions.xml
+++ b/reference/litespeed/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name="litespeed_request_headers" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
@@ -10,23 +7,23 @@
  <function name="litespeed_finish_request" from="PHP 7 &gt;= 7.2.18, PHP 8"/>
 </versions>
 
- <!-- Keep this comment at the end of the file
- Local variables:
- mode: sgml
- sgml-omittag:t
- sgml-shorttag:t
- sgml-minimize-attributes:nil
- sgml-always-quote-attributes:t
- sgml-indent-step:1
- sgml-indent-data:t
- indent-tabs-mode:nil
- sgml-parent-document:nil
- sgml-default-dtd-file:"~/.phpdoc/manual.ced"
- sgml-exposed-tags:nil
- sgml-local-catalogs:nil
- sgml-local-ecat-files:nil
- End:
- vim600: syn=xml fen fdm=syntax fdl=2 si
- vim: et tw=78 syn=sgml
- vi: ts=1 sw=1
- -->
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/lua/versions.xml
+++ b/reference/lua/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Methods -->

--- a/reference/luasandbox/versions.xml
+++ b/reference/luasandbox/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/lzf/versions.xml
+++ b/reference/lzf/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='lzf_compress' from='PECL lzf &gt;= 0.1.0'/>

--- a/reference/mail/versions.xml
+++ b/reference/mail/versions.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="ezmlm_hash" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7" deprecated="PHP 7.2.0" removed="PHP 8"/>
  <function name="mail" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mailparse/versions.xml
+++ b/reference/mailparse/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='mailparse_determine_best_xfer_encoding' from='PECL mailparse &gt;= 0.9.0'/>

--- a/reference/math/versions.xml
+++ b/reference/math/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="abs" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="acos" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -52,6 +50,7 @@
  <!-- RoundingMode -->
  <function name="roundingmode" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mbstring/versions.xml
+++ b/reference/mbstring/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="mb_check_encoding" from="PHP 4 &gt;= 4.4.3, PHP 5 &gt;= 5.1.3, PHP 7, PHP 8"/>
  <function name="mb_chr" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
@@ -70,6 +68,7 @@
  <function name="mb_trim" from="PHP 8 &gt;= 8.4.0"/>
  <function name="mb_ucfirst" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mcrypt/versions.xml
+++ b/reference/mcrypt/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="mcrypt_create_iv" from="PHP 4, PHP 5, PHP 7 &lt; 7.2.0, PECL mcrypt &gt;= 1.0.0"/>
  <function name="mcrypt_decrypt" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7 &lt; 7.2.0, PECL mcrypt &gt;= 1.0.0"/>
@@ -37,6 +35,7 @@
  <function name="mcrypt_module_self_test" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7 &lt; 7.2.0, PECL mcrypt &gt;= 1.0.0"/>
  <function name="mdecrypt_generic" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7 &lt; 7.2.0, PECL mcrypt &gt;= 1.0.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/memcache/versions.xml
+++ b/reference/memcache/versions.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions>
+<?do-not-translate?>
 
+<versions>
  <function name='memcache' from='PECL memcache &gt;= 0.2.0'/>
  <function name='memcache::add' from='PECL memcache &gt;= 0.2.0'/>
  <function name='Memcache::addServer' from='PECL memcache &gt;= 2.0.0'/>

--- a/reference/memcached/versions.xml
+++ b/reference/memcached/versions.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions>
+<?do-not-translate?>
 
+<versions>
  <function name='memcached' from='PECL memcached &gt;= 0.1.0'/>
  <function name='memcached::__construct' from='PECL memcached &gt;= 0.1.0'/>
  <function name='memcached::add' from='PECL memcached &gt;= 0.1.0'/>
@@ -58,7 +55,7 @@
  <function name='memcached::setSaslAuthData' from='PECL memcached &gt;= 2.0.0'/>
  <function name='memcached::touch' from='PECL memcached &gt;= 2.0.0'/>
  <function name='memcached::touchByKey' from='PECL memcached &gt;= 2.0.0'/>
- 
+
  <function name='memcachedexception' from='PECL memcached &gt;= 0.1.0'/>
 </versions>
 

--- a/reference/mhash/versions.xml
+++ b/reference/mhash/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="mhash" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="mhash_count" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -10,6 +8,7 @@
  <function name="mhash_get_hash_name" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="mhash_keygen_s2k" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/misc/versions.xml
+++ b/reference/misc/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="__halt_compiler" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="connection_aborted" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -36,6 +34,7 @@
  <function name="unpack" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="usleep" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- BSON functions -->

--- a/reference/mqseries/versions.xml
+++ b/reference/mqseries/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='mqseries_back' from='PECL mqseries &gt;= 0.10.0'/>
  <function name='mqseries_begin' from='PECL mqseries &gt;= 0.10.0'/>

--- a/reference/mysql/versions.xml
+++ b/reference/mysql/versions.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <!--
  NOTE: Version info for the MySQL PECL Extension (1.0) is
        considered irrelevant so is not listed here.
 -->
+
 <versions>
  <function name='mysql' from='PHP 4, PHP 5'/>
  <function name='mysql_affected_rows' from='PHP 4, PHP 5'/>

--- a/reference/mysql_xdevapi/versions.xml
+++ b/reference/mysql_xdevapi/versions.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->
  <function name='mysql_xdevapi\getsession' from='PECL mysql-xdevapi &gt;= 8.0.11'/>
  <function name='mysql_xdevapi\expression' from='PECL mysql-xdevapi &gt;= 8.0.11'/>
- <!-- Classes and Methods -->
 
+ <!-- Classes and Methods -->
  <function name='mysql_xdevapi\databaseobject' from='PECL mysql-xdevapi &gt;= 8.0.11'/>
  <function name='mysql_xdevapi\databaseobject::getsession' from='PECL mysql-xdevapi &gt;= 8.0.11'/>
  <function name='mysql_xdevapi\databaseobject::getname' from='PECL mysql-xdevapi &gt;= 8.0.11'/>

--- a/reference/mysqli/versions.xml
+++ b/reference/mysqli/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="mysqli_affected_rows" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_autocommit" from="PHP 5, PHP 7, PHP 8"/>
@@ -221,6 +219,7 @@
  <function name="mysqli_sql_exception" from="PHP 5, PHP 7, PHP 8"/>
  <function name="mysqli_sql_exception::getSqlState" from="PHP 8 &gt;= 8.1.2"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/network/versions.xml
+++ b/reference/network/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="checkdnsrr" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="closelog" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -42,6 +40,7 @@
  <function name="socket_set_timeout" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="syslog" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/oauth/versions.xml
+++ b/reference/oauth/versions.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name='oauth_urlencode' from='PECL OAuth &gt;=0.99.2'/>
  <function name='oauth_get_sbs' from='PECL OAuth &gt;=0.99.7'/>
 
  <!-- Methods -->
-
  <function name='oauth' from='PECL OAuth &gt;= 0.99.1'/>
  <function name='oauth::__construct' from='PECL OAuth &gt;= 0.99.1'/>
  <function name='oauth::__destruct' from='PECL OAuth &gt;= 0.99.9'/>

--- a/reference/oci8/versions.xml
+++ b/reference/oci8/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="oci_bind_array_by_name" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL OCI8 &gt;= 1.2.0"/>
  <function name="oci_bind_by_name" from="PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.1.0"/>
@@ -146,6 +144,7 @@
  <function name="ociwritelobtofile" from="PHP 4, PHP 5, PHP 7, PHP 8, PECL OCI8 &gt;= 1.0.0"/>
  <function name="ociwritetemporarylob" from="PHP 4 &gt;= 4.0.6, PHP 5, PHP 7, PECL OCI8 1.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/opcache/versions.xml
+++ b/reference/opcache/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="opcache_compile_file" from="PHP 5 &gt;= 5.5.5, PHP 7, PHP 8, PECL ZendOpcache &gt; 7.0.2"/>
  <function name="opcache_get_configuration" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL ZendOpcache &gt; 7.0.2"/>
@@ -13,6 +11,7 @@
  <function name="opcache_jit_blacklist" from="PHP 8 &gt;= 8.4.0"/>
  <function name="opcache_reset" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8, PECL ZendOpcache &gt;= 7.0.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/openal/versions.xml
+++ b/reference/openal/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='openal_buffer_create' from='PECL openal &gt;= 0.1.0'/>

--- a/reference/openssl/versions.xml
+++ b/reference/openssl/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="openssl_cipher_iv_length" from="PHP 5 &gt;= 5.3.3, PHP 7, PHP 8"/>
  <function name="openssl_cipher_key_length" from="PHP 8 &gt;= 8.2.0"/>
@@ -74,6 +72,7 @@
  <function name="opensslcertificate" from="PHP 8"/>
  <function name="opensslcertificatesigningrequest" from="PHP 8"/>
  <function name="opensslasymmetrickey" from="PHP 8"/>
+
 </versions>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/outcontrol/versions.xml
+++ b/reference/outcontrol/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="flush" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="ob_clean" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
@@ -24,6 +22,7 @@
  <function name="output_add_rewrite_var" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="output_reset_rewrite_vars" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/parallel/versions.xml
+++ b/reference/parallel/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/parle/versions.xml
+++ b/reference/parle/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/password/versions.xml
+++ b/reference/password/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="password_algos" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
  <function name="password_get_info" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
@@ -10,6 +8,7 @@
  <function name="password_needs_rehash" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
  <function name="password_verify" from="PHP 5 &gt;= 5.5.0, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pcntl/versions.xml
+++ b/reference/pcntl/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pcntl_alarm" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_async_signals" from="PHP 7 &gt;= 7.1.0, PHP 8"/>
@@ -36,6 +34,7 @@
  <function name="pcntl_wtermsig" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl\qosclass" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pcre/versions.xml
+++ b/reference/pcre/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="preg_filter" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="preg_grep" from="PHP 4, PHP 5, PHP 7, PHP 8"/>

--- a/reference/pdo/versions.xml
+++ b/reference/pdo/versions.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <!--
  FIXME: Discuss how/where to keep PDO version info...
 -->
+
 <versions>
  <function name="pdo" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
  <function name="pdo::__construct" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.1.0"/>
@@ -77,8 +76,8 @@
  <function name="pdo_pgsql dsn" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL PDO_PGSQL &gt;= 0.1.0"/>
  <function name="pdo_sqlite dsn" from="PHP 5 &gt;= 5.1.0, PHP 7, PECL PDO_SQLITE &gt;= 0.2.0"/>
  <function name="pdo_sqlsrv dsn" from="PECL pdo_sqlsrv &gt;= 2.0.1"/>
-
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_dblib/versions.xml
+++ b/reference/pdo_dblib/versions.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pdo\dblib" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_firebird/versions.xml
+++ b/reference/pdo_firebird/versions.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pdo\firebird" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pdo\firebird::getapiversion" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_mysql/versions.xml
+++ b/reference/pdo_mysql/versions.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pdo\mysql" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pdo\mysql::getwarningcount" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_odbc/versions.xml
+++ b/reference/pdo_odbc/versions.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pdo\odbc" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_pgsql/versions.xml
+++ b/reference/pdo_pgsql/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pdo\pgsql" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pdo\pgsql::copyfromarray" from="PHP 8 &gt;= 8.4.0"/>
@@ -17,6 +15,7 @@
  <function name="pdo\pgsql::lobunlink" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pdo\pgsql::setnoticecallback" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pdo_sqlite/versions.xml
+++ b/reference/pdo_sqlite/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pdo\sqlite" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pdo\sqlite::createaggregate" from="PHP 8 &gt;= 8.4.0"/>
@@ -11,6 +9,7 @@
  <function name="pdo\sqlite::loadextension" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pdo\sqlite::openblob" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pgsql/versions.xml
+++ b/reference/pgsql/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pg_affected_rows" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_cancel_query" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
@@ -107,6 +105,7 @@
  <function name="pgsql\result" from="PHP 8 &gt;= 8.1.0"/>
  <function name="pgsql\lob" from="PHP 8 &gt;= 8.1.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/phar/versions.xml
+++ b/reference/phar/versions.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions>
+<?do-not-translate?>
 
+<versions>
  <function name="phar" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
  <function name="phar::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>
  <function name="phar::__destruct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL phar &gt;= 1.0.0"/>

--- a/reference/phpdbg/versions.xml
+++ b/reference/phpdbg/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/posix/versions.xml
+++ b/reference/posix/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="posix_access" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="posix_ctermid" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -46,6 +44,7 @@
  <function name="posix_ttyname" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="posix_uname" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ps/versions.xml
+++ b/reference/ps/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='ps_add_annotation' from='PECL ps &gt;= 1.1.0'/>
  <function name='ps_add_bookmark' from='PECL ps &gt;= 1.1.0'/>

--- a/reference/pspell/versions.xml
+++ b/reference/pspell/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="pspell_add_to_personal" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
  <function name="pspell_add_to_session" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
@@ -24,10 +22,10 @@
  <function name="pspell_store_replacement" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
  <function name="pspell_suggest" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
 
-<function name='pspell\dictionary' from='PHP 8 &gt;= 8.1.0'/>
-<function name='pspell\config' from='PHP 8 &gt;= 8.1.0'/>
-
+ <function name='pspell\dictionary' from='PHP 8 &gt;= 8.1.0'/>
+ <function name='pspell\config' from='PHP 8 &gt;= 8.1.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/pthreads/versions.xml
+++ b/reference/pthreads/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Classes and Methods -->
@@ -47,7 +44,7 @@
  <function name='pool::submitto' from='PECL pthreads &gt;= 2.0.0'/>
  <function name='pool::collect' from='PECL pthreads &gt;= 2.0.0'/>
  <function name='pool::shutdown' from='PECL pthreads &gt;= 2.0.0'/>
- 
+
  <function name='collectable' from='PECL pthreads &gt;= 2.0.8'/>
  <function name='collectable::isgarbage' from='PECL pthreads &gt;= 2.0.8'/>
 

--- a/reference/quickhash/versions.xml
+++ b/reference/quickhash/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Methods -->

--- a/reference/radius/versions.xml
+++ b/reference/radius/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='radius_acct_open' from='PECL radius &gt;= 1.1.0'/>
  <function name='radius_add_server' from='PECL radius &gt;= 1.1.0'/>

--- a/reference/random/versions.xml
+++ b/reference/random/versions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do NOT translate this file -->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name="lcg_value" from="PHP 4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.4.0"/>
@@ -11,8 +12,8 @@
  <function name="getrandmax" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="random_bytes" from="PHP 7, PHP 8"/>
  <function name="random_int" from="PHP 7, PHP 8"/>
- <!-- Classes and Methods -->
 
+ <!-- Classes and Methods -->
  <function name='random\engine' from='PHP 8 &gt;= 8.2.0'/>
  <function name='random\engine::generate' from='PHP 8 &gt;= 8.2.0'/>
 
@@ -99,6 +100,7 @@
  <!-- RoundingMode enum -->
  <function name='random\intervalboundary' from='PHP 8 &gt;= 8.3.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rar/versions.xml
+++ b/reference/rar/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->
@@ -17,7 +14,6 @@
  <function name='rar_wrapper_cache_stats' from='PECL rar &gt;= 3.0.0'/>
 
  <!-- Methods -->
-
  <function name='rararchive' from='PECL rar &gt;= 2.0.0'/>
  <function name='rararchive::open' from='PECL rar &gt;= 2.0.0'/>
  <function name='rararchive::getentries' from='PECL rar &gt;= 2.0.0'/>
@@ -25,7 +21,7 @@
  <function name='rararchive::issolid' from='PECL rar &gt;= 2.0.0'/>
  <function name='rararchive::getcomment' from='PECL rar &gt;= 2.0.0'/>
  <function name='rararchive::isbroken' from='PECL rar &gt;= 3.0.0'/>
- <function name='rararchive::setallowbroken' from='PECL rar &gt;= 3.0.0'/> 
+ <function name='rararchive::setallowbroken' from='PECL rar &gt;= 3.0.0'/>
  <function name='rararchive::close' from='PECL rar &gt;= 2.0.0'/>
  <function name='rararchive::__tostring' from='PECL rar &gt;= 2.0.0'/>
  <function name='rararchive::__construct' from='PECL rar &gt;= 2.0.0'/>

--- a/reference/readline/versions.xml
+++ b/reference/readline/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="readline" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="readline_add_history" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -18,6 +16,7 @@
  <function name="readline_redisplay" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="readline_write_history" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/recode/versions.xml
+++ b/reference/recode/versions.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="recode" from="PHP 4, PHP 5, PHP 7 &lt; 7.4.0"/>
  <function name="recode_file" from="PHP 4, PHP 5, PHP 7 &lt; 7.4.0"/>
  <function name="recode_string" from="PHP 4, PHP 5, PHP 7 &lt; 7.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/reflection/versions.xml
+++ b/reference/reflection/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="reflectionexception" from="PHP 5, PHP 7, PHP 8"/>
  <function name="reflectionexception::__clone" from="PHP 5, PHP 7, PHP 8"/>
@@ -440,6 +438,7 @@
 
  <function name="propertyhooktype" from="PHP 8 &gt;= 8.4"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rnp/versions.xml
+++ b/reference/rnp/versions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do NOT translate this file -->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name='rnp_backend_string' from='PECL rnp &gt;= 0.1.1'/>
@@ -34,10 +35,11 @@
  <function name='rnp_key_revoke' from='PECL rnp &gt;= 0.1.1'/>
  <function name='rnp_key_export_revocation' from='PECL rnp &gt;= 0.1.1'/>
  <function name='rnp_import_signatures' from='PECL rnp &gt;= 0.1.1'/>
- <!-- Classes and Methods -->
 
+ <!-- Classes and Methods -->
  <function name='rnpffi' from='PECL rnp &gt;= 0.1.1'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/rpminfo/versions.xml
+++ b/reference/rpminfo/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/rrd/versions.xml
+++ b/reference/rrd/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->
@@ -20,8 +17,8 @@
  <function name='rrd_xport' from='PECL rrd &gt;= 0.9.0'/>
  <function name='rrd_version' from='PECL rrd &gt;= 1.0.0'/>
  <function name='rrdc_disconnect' from='PECL rrd &gt;= 1.1.2'/>
- <!-- Methods -->
 
+ <!-- Methods -->
  <function name='rrdgraph' from='PECL rrd &gt;= 0.9.0'/>
  <function name='rrdgraph::__construct' from='PECL rrd &gt;= 0.9.0'/>
  <function name='rrdgraph::save' from='PECL rrd &gt;= 0.9.0'/>

--- a/reference/runkit7/versions.xml
+++ b/reference/runkit7/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/scoutapm/versions.xml
+++ b/reference/scoutapm/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/seaslog/versions.xml
+++ b/reference/seaslog/versions.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->
  <function name='seaslog_get_version' from='PECL seaslog &gt;=1.0.0'/>
  <function name='seaslog_get_author' from='PECL seaslog &gt;=1.0.0'/>
- <!-- Classes and Methods -->
 
+ <!-- Classes and Methods -->
  <function name='seaslog' from='PECL seaslog &gt;=1.0.0'/>
  <function name='seaslog::__construct' from='PECL seaslog &gt;=1.0.0'/>
  <function name='seaslog::__destruct' from='PECL seaslog &gt;=1.0.0'/>

--- a/reference/sem/versions.xml
+++ b/reference/sem/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="ftok" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="msg_get_queue" from="PHP 4 &gt;= 4.3.0, PHP 5, PHP 7, PHP 8"/>
@@ -28,6 +26,7 @@
  <function name="sysvsemaphore" from="PHP 8"/>
  <function name="sysvsharedmemory" from="PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/session/versions.xml
+++ b/reference/session/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="session_cache_expire" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="session_cache_limiter" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
@@ -42,14 +40,15 @@
  <function name="sessionhandlerinterface::open" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  <function name="sessionhandlerinterface::read" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
  <function name="sessionhandlerinterface::write" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
- 
+
  <function name="SessionIdInterface" from="PHP 5 &gt;= 5.5.1, PHP 7, PHP 8"/>
  <function name="SessionIdInterface::create_sid" from="PHP 5 &gt;= 5.5.1, PHP 7, PHP 8"/>
- 
+
  <function name="sessionupdatetimestamphandlerinterface" from="PHP 7, PHP 8"/>
  <function name="sessionupdatetimestamphandlerinterface::updatetimestamp" from="PHP 7, PHP 8"/>
  <function name="sessionupdatetimestamphandlerinterface::validateid" from="PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/shmop/versions.xml
+++ b/reference/shmop/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="shmop_close" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.0.0"/>
  <function name="shmop_delete" from="PHP 4 &gt;= 4.0.4, PHP 5, PHP 7, PHP 8"/>
@@ -13,6 +11,7 @@
 
  <function name="shmop" from="PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/simdjson/versions.xml
+++ b/reference/simdjson/versions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do NOT translate this file -->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name='simdjson_is_valid' from='PECL simdjson &gt;= 2.0.0'/>
@@ -7,12 +8,12 @@
  <function name='simdjson_key_value' from='PECL simdjson &gt;= 2.0.0'/>
  <function name='simdjson_key_exists' from='PECL simdjson &gt;= 2.0.0'/>
  <function name='simdjson_key_count' from='PECL simdjson &gt;= 2.0.0'/>
+
  <!-- Classes and Methods -->
-
  <function name='simdjsonexception' from='PECL simdjson &gt;= 2.1.0'/>
-
  <function name='simdjsonvalueerror' from='PECL simdjson &gt;= 3.0.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/simplexml/versions.xml
+++ b/reference/simplexml/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="simplexml_import_dom" from="PHP 5, PHP 7, PHP 8"/>
  <function name="simplexml_load_file" from="PHP 5, PHP 7, PHP 8"/>
@@ -33,15 +31,16 @@
  <function name="simplexmlelement::key" from="PHP 8"/>
  <function name="simplexmlelement::next" from="PHP 8"/>
  <function name="simplexmlelement::rewind" from="PHP 8"/>
-<function name="simplexmliterator::count" from="PHP 8"/>
-<function name="simplexmliterator::current" from="PHP 8"/>
-<function name="simplexmliterator::getchildren" from="PHP 8"/>
-<function name="simplexmliterator::haschildren" from="PHP 8"/>
-<function name="simplexmliterator::key" from="PHP 8"/>
-<function name="simplexmliterator::next" from="PHP 8"/>
-<function name="simplexmliterator::rewind" from="PHP 8"/>
-<function name="simplexmliterator::valid" from="PHP 8"/>
+ <function name="simplexmliterator::count" from="PHP 8"/>
+ <function name="simplexmliterator::current" from="PHP 8"/>
+ <function name="simplexmliterator::getchildren" from="PHP 8"/>
+ <function name="simplexmliterator::haschildren" from="PHP 8"/>
+ <function name="simplexmliterator::key" from="PHP 8"/>
+ <function name="simplexmliterator::next" from="PHP 8"/>
+ <function name="simplexmliterator::rewind" from="PHP 8"/>
+ <function name="simplexmliterator::valid" from="PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/snmp/versions.xml
+++ b/reference/snmp/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="snmp_get_quick_print" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="snmp_get_valueretrieval" from="PHP 4 &gt;= 4.3.3, PHP 5, PHP 7, PHP 8"/>
@@ -44,8 +42,9 @@
  <function name="snmp::getError" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 
  <function name="snmpexception" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
- 
+
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/soap/versions.xml
+++ b/reference/soap/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name="use_soap_error_handler" from="PHP 5, PHP 7, PHP 8"/>
@@ -62,6 +60,7 @@
  <function name="soapvar" from="PHP 5, PHP 7, PHP 8"/>
  <function name="soapvar::__construct" from="PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/sockets/versions.xml
+++ b/reference/sockets/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="socket_accept" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="socket_addrinfo_bind" from="PHP 7 &gt;= 7.2.0, PHP 8"/>
@@ -51,6 +49,7 @@
  <function name="socket" from="PHP 8"/>
  <function name="addressinfo" from="PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/sodium/versions.xml
+++ b/reference/sodium/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/solr/versions.xml
+++ b/reference/solr/versions.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->
  <function name='solr_get_version' from='PECL solr &gt;= 0.9.1'/>
- <!-- Methods -->
 
+ <!-- Methods -->
  <function name='solrobject' from='PECL solr &gt;= 0.9.2'/>
  <function name='solrobject::__construct' from='PECL solr &gt;= 0.9.2'/>
  <function name='solrobject::__destruct' from='PECL solr &gt;= 0.9.2'/>
@@ -88,7 +85,7 @@
  <function name='solrinputdocument::getchilddocuments' from='PECL solr &gt;= 2.3.0'/>
  <function name='solrinputdocument::haschilddocuments' from='PECL solr &gt;= 2.3.0'/>
  <function name='solrinputdocument::getchilddocumentscount' from='PECL solr &gt;= 2.3.0'/>
- 
+
  <function name='solrclient' from='PECL solr &gt;= 0.9.2'/>
  <function name='solrclient::__construct' from='PECL solr &gt;= 0.9.2'/>
  <function name='solrclient::__destruct' from='PECL solr &gt;= 0.9.2'/>
@@ -407,7 +404,7 @@
  <function name='solrexception::getprevious' from='PECL solr &gt;= 0.9.2'/>
  <function name='solrexception::gettraceasstring' from='PECL solr &gt;= 0.9.2'/>
  <function name='solrexception::__tostring' from='PECL solr &gt;= 0.9.2'/>
- 
+
  <function name='solrserverexception' from='PECL Solr &gt;= 1.1.0, &gt;=2.0.0'/>
  <function name='solrserverexception::getinternalinfo' from='PECL solr &gt;= 1.1.0, &gt;=2.0.0'/>
 
@@ -449,7 +446,7 @@
  <function name='solrclientexception::getprevious' from='PECL solr &gt;= 0.9.2'/>
  <function name='solrclientexception::gettraceasstring' from='PECL solr &gt;= 0.9.2'/>
  <function name='solrclientexception::__tostring' from='PECL solr &gt;= 0.9.2'/>
- 
+
  <function name='solrcollapsefunction' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrcollapsefunction::__construct' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrcollapsefunction::setfield' from='PECL solr &gt;= 2.2.0'/>
@@ -465,7 +462,7 @@
  <function name='solrcollapsefunction::setnullpolicy' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrcollapsefunction::getnullpolicy' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrcollapsefunction::__tostring' from='PECL solr &gt;= 2.2.0'/>
- 
+
  <function name='solrquery::addgroupfield' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrquery::addgroupfunction' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrquery::addgroupquery' from='PECL solr &gt;= 2.2.0'/>
@@ -492,8 +489,8 @@
  <function name='solrquery::setgroupoffset' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrquery::setgrouptruncate' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrquery::setgroup' from='PECL solr &gt;= 2.2.0'/>
- 
- 
+
+
  <function name='solrquery::setexpand' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrquery::getexpand' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrquery::addexpandfilterquery' from='PECL solr &gt;= 2.2.0'/>
@@ -507,7 +504,6 @@
  <function name='solrquery::setexpandquery' from='PECL solr &gt;= 2.2.0'/>
  <function name='solrquery::setexpandrows' from='PECL solr &gt;= 2.2.0'/>
 
- 
 </versions>
 
 <!-- Keep this comment at the end of the file

--- a/reference/spl/versions.xml
+++ b/reference/spl/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name="class_parents" from="PHP 5, PHP 7, PHP 8"/>
@@ -1009,6 +1007,7 @@
  <function name="recursivecallbackfilteriterator::haschildren" from="PHP 5 &gt;= 5.4.0, PHP 7, PHP 8"/>
 
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/sqlite3/versions.xml
+++ b/reference/sqlite3/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
 
  <function name="SQLite3" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
@@ -52,6 +50,7 @@
  <function name="SQLite3Result::numColumns" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Result::reset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/ssdeep/versions.xml
+++ b/reference/ssdeep/versions.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
- <!-- Functions -->
  <function name='ssdeep_fuzzy_hash' from='PECL ssdeep &gt;= 1.0.0'/>
  <function name='ssdeep_fuzzy_hash_filename' from='PECL ssdeep &gt;= 1.0.0'/>
  <function name='ssdeep_fuzzy_compare' from='PECL ssdeep &gt;= 1.0.0'/>

--- a/reference/ssh2/versions.xml
+++ b/reference/ssh2/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='ssh2_auth_agent' from='PECL ssh2 &gt;= 0.12'/>
  <function name='ssh2_auth_hostbased_file' from='PECL ssh2 &gt;= 0.9.0'/>

--- a/reference/stats/versions.xml
+++ b/reference/stats/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='stats_absolute_deviation' from='PECL stats &gt;= 1.0.0'/>
  <function name='stats_cdf_beta' from='PECL stats &gt;= 1.0.0'/>

--- a/reference/stomp/versions.xml
+++ b/reference/stomp/versions.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->
  <function name='stomp_version' from='PECL stomp &gt;= 0.1.0'/>
  <function name='stomp_connect_error' from='PECL stomp &gt;= 0.3.0'/>
- <!-- Methods -->
 
+ <!-- Methods -->
  <function name='stomp' from='PECL stomp &gt;= 0.1.0'/>
  <function name='stomp::__construct' from='PECL stomp &gt;= 0.1.0'/>
  <function name='stomp::getsessionid' from='PECL stomp &gt;= 0.1.0'/>

--- a/reference/stream/versions.xml
+++ b/reference/stream/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="streambucket" from="PHP 8 &gt;= 8.4.0"/>
  <function name="stream_bucket_append" from="PHP 5, PHP 7, PHP 8"/>
@@ -57,7 +55,7 @@
  <function name="php_user_filter::filter" from="PHP 5, PHP 7, PHP 8"/>
  <function name="php_user_filter::onclose" from="PHP 5, PHP 7, PHP 8"/>
  <function name="php_user_filter::oncreate" from="PHP 5, PHP 7, PHP 8"/>
- 
+
  <function name="streamwrapper" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
  <function name="streamwrapper::__construct" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
  <function name="streamwrapper::__destruct" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
@@ -85,6 +83,7 @@
  <function name="streamwrapper::unlink" from="PHP 5, PHP 7, PHP 8"/>
  <function name="streamwrapper::url_stat" from="PHP 4 &gt;= 4.3.2, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/strings/versions.xml
+++ b/reference/strings/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="addcslashes" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="addslashes" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -110,6 +108,7 @@
  <function name="vsprintf" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="wordwrap" from="PHP 4 &gt;= 4.0.2, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/svm/versions.xml
+++ b/reference/svm/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Methods -->
@@ -21,9 +18,9 @@
  <function name='svmmodel::predict' from='PECL svm &gt;= 0.1.0'/>
  <function name='svmmodel::predict_probability' from='PECL svm &gt;= 0.1.4'/>
  <function name='svmmodel::getlabels' from='PECL svm &gt;= 0.1.5'/>
- <function name='svmmodel::getnrclass' from='PECL svm &gt;= 0.1.5'/>  
- <function name='svmmodel::getsvmtype' from='PECL svm &gt;= 0.1.5'/>  
- <function name='svmmodel::getsvrprobability' from='PECL svm &gt;= 0.1.5'/>   
+ <function name='svmmodel::getnrclass' from='PECL svm &gt;= 0.1.5'/>
+ <function name='svmmodel::getsvmtype' from='PECL svm &gt;= 0.1.5'/>
+ <function name='svmmodel::getsvrprobability' from='PECL svm &gt;= 0.1.5'/>
  <function name='svmmodel::checkprobabilitymodel' from='PECL svm &gt;= 0.1.5'/>
 
  <function name='svmexception' from='PECL svm &gt;= 0.1.0'/>

--- a/reference/svn/versions.xml
+++ b/reference/svn/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='svn_add' from='PECL svn &gt;= 0.1.0'/>

--- a/reference/swoole/versions.xml
+++ b/reference/swoole/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/sync/versions.xml
+++ b/reference/sync/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/taint/versions.xml
+++ b/reference/taint/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/tcpwrap/versions.xml
+++ b/reference/tcpwrap/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='tcpwrap_check' from='PECL tcpwrap &gt;= 0.1.0'/>

--- a/reference/tidy/versions.xml
+++ b/reference/tidy/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
 
  <function name="tidy" from="PHP 5, PHP 7, PHP 8, PECL tidy &gt;= 0.5.2"/>
@@ -52,6 +50,7 @@
  <function name="tidynode::getnextsibling" from="PHP 8 &gt;= 8.4.0"/>
  <function name="tidynode::getprevioussibling" from="PHP 8 &gt;= 8.4.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/tokenizer/versions.xml
+++ b/reference/tokenizer/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="token_get_all" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="token_name" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
@@ -14,6 +12,7 @@
  <function name="phptoken::tokenize" from="PHP 8"/>
  <function name="phptoken::__tostring" from="PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/trader/versions.xml
+++ b/reference/trader/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/ui/versions.xml
+++ b/reference/ui/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/uodbc/versions.xml
+++ b/reference/uodbc/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <!-- Classes -->
  <function name="odbc\connection" from="PHP 8 &gt;= 8.4.0"/>
@@ -58,6 +56,7 @@
  <function name="odbc_tableprivileges" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="odbc_tables" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/uopz/versions.xml
+++ b/reference/uopz/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/uri/versions.xml
+++ b/reference/uri/versions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do NOT translate this file -->
+<?do-not-translate?>
+
 <versions>
  <!-- Classes and Methods -->
 
@@ -91,6 +92,7 @@
  <!-- Uri\WhatWg\UrlValidationErrorType class -->
  <function name='uri\whatwg\urlvalidationerrortype' from='PHP 8 &gt;= 8.5.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/url/versions.xml
+++ b/reference/url/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="base64_decode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="base64_encode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -15,6 +13,7 @@
  <function name="urldecode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="urlencode" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/v8js/versions.xml
+++ b/reference/v8js/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Methods -->

--- a/reference/var/versions.xml
+++ b/reference/var/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='boolval' from='PHP 5 &gt;= 5.5.0, PHP 7, PHP 8'/>

--- a/reference/var_representation/versions.xml
+++ b/reference/var_representation/versions.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do NOT translate this file -->
+<?do-not-translate?>
+
 <versions>
- <!-- Functions -->
  <function name='var_representation' from='PECL var_representation &gt;= 0.1.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/varnish/versions.xml
+++ b/reference/varnish/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- VarnishAdmin class -->

--- a/reference/wddx/versions.xml
+++ b/reference/wddx/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="wddx_add_vars" from="PHP 4, PHP 5, PHP 7"/>
  <function name="wddx_deserialize" from="PHP 4, PHP 5, PHP 7"/>
@@ -12,6 +10,7 @@
  <function name="wddx_serialize_vars" from="PHP 4, PHP 5, PHP 7"/>
  <function name="wddx_unserialize" from="PHP 4, PHP 5, PHP 7"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/win32service/versions.xml
+++ b/reference/win32service/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='win32-continue-service' from='PECL win32service &gt;=0.1.0'/>
  <function name='win32-create-service' from='PECL win32service &gt;=0.1.0'/>

--- a/reference/wincache/versions.xml
+++ b/reference/wincache/versions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions> 
+<?do-not-translate?>
+
+<versions>
  <function name='wincache_fcache_fileinfo' from='PECL wincache &gt;= 1.0.0'/>
  <function name='wincache_fcache_meminfo' from='PECL wincache &gt;= 1.0.0'/>
  <function name='wincache_ocache_fileinfo' from='PECL wincache &gt;= 1.0.0' deprecated='PECL wincache = 2.0.0.0'/>

--- a/reference/wkhtmltox/versions.xml
+++ b/reference/wkhtmltox/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/xattr/versions.xml
+++ b/reference/xattr/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <function name='xattr_get' from='PECL xattr &gt;= 0.9.0'/>

--- a/reference/xdiff/versions.xml
+++ b/reference/xdiff/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='xdiff_file_diff' from='PECL xdiff &gt;= 0.2.0'/>
  <function name='xdiff_file_diff_binary' from='PECL xdiff &gt;= 0.2.0'/>

--- a/reference/xhprof/versions.xml
+++ b/reference/xhprof/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/xlswriter/versions.xml
+++ b/reference/xlswriter/versions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
+<?do-not-translate?>
 
 <versions>
  <function name='Vtiful\Kernel\Excel'                from='PECL xlswriter &gt;= 1.2.1'/>

--- a/reference/xml/versions.xml
+++ b/reference/xml/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="xml_error_string" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="xml_get_current_byte_index" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
@@ -29,6 +27,7 @@
 
  <function name="xmlparser" from="PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/xmldiff/versions.xml
+++ b/reference/xmldiff/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/xmlreader/versions.xml
+++ b/reference/xmlreader/versions.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions>
+<?do-not-translate?>
 
+<versions>
  <function name="xmlreader" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="xmlreader::close" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="xmlreader::expand" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
@@ -35,6 +32,7 @@
  <function name="xmlreader::setschema" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8"/>
  <function name="xmlreader::xml" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/xmlrpc/versions.xml
+++ b/reference/xmlrpc/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="xmlrpc_decode" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7"/>
  <function name="xmlrpc_decode_request" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7"/>
@@ -19,6 +17,7 @@
  <function name="xmlrpc_server_register_method" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7"/>
  <function name="xmlrpc_set_type" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/xmlwriter/versions.xml
+++ b/reference/xmlwriter/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <!-- OOP -->
 
@@ -97,6 +95,7 @@
  <function name="xmlwriter_write_pi" from="PHP 5 &gt;= 5.1.2, PHP 7, PHP 8, PECL xmlwriter &gt;= 0.1.0"/>
  <function name="xmlwriter_write_raw" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL xmlwriter &gt;= 2.0.4"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/xpass/versions.xml
+++ b/reference/xpass/versions.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <!-- Functions -->
  <function name='crypt_gensalt' from='PECL xpass &gt;= 1.1.0'/>
  <function name='crypt_preferred_method' from='PECL xpass &gt;= 1.1.0'/>
  <function name='crypt_checksalt' from='PECL xpass &gt;= 1.1.0'/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/xsl/versions.xml
+++ b/reference/xsl/versions.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
-<versions>
+<?do-not-translate?>
 
+<versions>
  <function name="XSLTProcessor" from="PHP 5, PHP 7, PHP 8"/>
  <function name="XSLTProcessor::__construct" from="PHP 5, PHP 7, PHP 8"/>
  <function name="XSLTProcessor::getParameter" from="PHP 5, PHP 7, PHP 8"/>
@@ -21,6 +18,7 @@
  <function name="XSLTProcessor::setSecurityPrefs" from="PHP &gt;= 5.4.0, PHP 7, PHP 8"/>
  <function name="XSLTProcessor::getSecurityPrefs" from="PHP &gt;= 5.4.0, PHP 7, PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/yac/versions.xml
+++ b/reference/yac/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/yaconf/versions.xml
+++ b/reference/yaconf/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Classes and Methods -->

--- a/reference/yaf/versions.xml
+++ b/reference/yaf/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Methods -->

--- a/reference/yaml/versions.xml
+++ b/reference/yaml/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
  <!-- Functions -->

--- a/reference/yar/versions.xml
+++ b/reference/yar/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Methods -->

--- a/reference/yaz/versions.xml
+++ b/reference/yaz/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name='yaz_addinfo' from='PHP 4 &gt;= 4.0.1, PECL yaz &gt;= 0.9.0'/>
  <function name='yaz_ccl_conf' from='PHP 4 &gt;= 4.0.5, PECL yaz &gt;= 0.9.0'/>

--- a/reference/zip/versions.xml
+++ b/reference/zip/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
 
  <function name="ZipArchive" from="PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.1.0"/>
@@ -70,6 +68,7 @@
  <function name="zip_open" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
  <function name="zip_read" from="PHP 4 &gt;= 4.1.0, PHP 5 &gt;= 5.2.0, PHP 7, PHP 8, PECL zip &gt;= 1.0.0" deprecated="PHP 8.0.0"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/zlib/versions.xml
+++ b/reference/zlib/versions.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
+
 <versions>
  <function name="deflate_add" from="PHP 7, PHP 8"/>
  <function name="deflate_init" from="PHP 7, PHP 8"/>
@@ -38,6 +36,7 @@
  <function name="deflatecontext" from="PHP 8"/>
  <function name="inflatecontext" from="PHP 8"/>
 </versions>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/zmq/versions.xml
+++ b/reference/zmq/versions.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?do-not-translate?>
 
 <versions>
   <!-- Methods -->
@@ -13,7 +10,7 @@
  <function name='zmqcontext::getsocket' from='PECL zmq &gt;= 0.5.0'/>
  <function name='zmqcontext::ispersistent' from='PECL zmq &gt;= 0.5.0'/>
  <function name='zmqcontext::getopt' from='PECL zmq &gt;= 1.0.4'/>
- <function name='zmqcontext::setopt' from='PECL zmq &gt;= 1.0.4'/>  
+ <function name='zmqcontext::setopt' from='PECL zmq &gt;= 1.0.4'/>
  <function name='zmqsocket' from='PECL zmq &gt;= 0.5.0'/>
  <function name='zmqsocket::__construct' from='PECL zmq &gt;= 0.5.0'/>
  <function name='zmqsocket::send' from='PECL zmq &gt;= 0.5.0'/>
@@ -29,7 +26,7 @@
  <function name='zmqsocket::getpersistentid' from='PECL zmq &gt;= 0.5.0'/>
  <function name='zmqsocket::getsockopt' from='PECL zmq &gt;= 0.5.0'/>
  <function name='zmqsocket::unbind' from='PECL zmq &gt;= 1.0.4'/>
- <function name='zmqsocket::disconnect' from='PECL zmq &gt;= 1.0.4'/> 
+ <function name='zmqsocket::disconnect' from='PECL zmq &gt;= 1.0.4'/>
  <function name='zmqpoll' from='PECL zmq &gt;= 0.5.0'/>
  <function name='zmqpoll::add' from='PECL zmq &gt;= 0.5.0'/>
  <function name='zmqpoll::poll' from='PECL zmq &gt;= 0.5.0'/>

--- a/reference/zookeeper/versions.xml
+++ b/reference/zookeeper/versions.xml
@@ -1,8 +1,6 @@
-<?xml version='1.0' encoding='utf-8'?>
-<!-- $Revision$ -->
-<!--
-  Do NOT translate this file
--->
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
+
 <versions>
  <function name='zookeeper' from='PECL zookeeper &gt;= 0.1.0'/>
  <function name='zookeeper::addauth' from='PECL zookeeper &gt;= 0.1.0'/>


### PR DESCRIPTION
This is the secontd part of https://github.com/php/doc-en/pull/5657. This is *not* marked as skip-revcheck as these files are expected to not exist in translations.

All `<!-- $Revisions$ -->` removed, some ws normalized. No functional differences detected.

Plan to merge this next wednesday, if 5657 goes ok.