### PR TITLE
chapters/intro: drop obsolete WDDX and Java integration claims

### DIFF
--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -145,16 +145,12 @@
     <link linkend="book.curl">cURL</link> or <link linkend="book.sockets">sockets</link>,
     like CouchDB.
    </para>
-   <para>
+   <simpara>
     PHP also has support for talking to other services using protocols
     such as LDAP, IMAP, SNMP, NNTP, POP3, HTTP, COM (on Windows) and
     countless others. It can also open raw network sockets and
-    interact using any other protocol. PHP has support for the WDDX
-    complex data exchange between virtually all Web programming
-    languages. Talking about interconnection, PHP has support for
-    instantiation of Java objects and using them transparently
-    as PHP objects.
-   </para>
+    interact using any other protocol.
+   </simpara>
    <para>
     PHP has useful <link linkend="refs.basic.text">text processing</link> features,
     which includes the Perl compatible regular expressions (<link linkend="book.pcre">PCRE</link>),


### PR DESCRIPTION
The "What can PHP do?" section still advertises WDDX (removed from core in 7.4) and the PHP-to-Java object bridge (long abandoned, no Java extension ships with PHP 8.x, like since 2000) as current capabilities. 