### PR TITLE
Fix dead external links in the English manual

### DIFF
--- a/install/windows/commandline.xml
+++ b/install/windows/commandline.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
 <sect1 xml:id="install.windows.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Running PHP on the command line on Windows systems</title>
  <para>

--- a/install/windows/commandline.xml
+++ b/install/windows/commandline.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <sect1 xml:id="install.windows.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Running PHP on the command line on Windows systems</title>
  <para>
@@ -177,13 +176,10 @@ Windows Registry Editor Version 5.00
 "InheritConsoleHandles"=dword:00000001
 ]]>
    </screen>
-   Further information regarding this issue can be found in this <link
-   xlink:href="http://support.microsoft.com/default.aspx?scid=kb;en-us;321788">Microsoft
-   Knowledgebase Article : 321788</link>.
+   Further information regarding this issue can be found in Microsoft
+   Knowledgebase Article 321788.
    As of Windows 10, this setting seems to be reversed, making the default install of
-   Windows 10 support inherited console handles automatically. This <link
-   xlink:href="https://social.msdn.microsoft.com/Forums/en-US/f19d740d-21c8-4dc2-a9ab-d5c0527e932b/nasty-file-association-regression-bug-in-windows-10-console?forum=windowssdk">
-   Microsoft forum post</link> provides the explanation.
+   Windows 10 support inherited console handles automatically.
   </para>
  </note>
 </sect1>

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
@@ -558,7 +557,7 @@
    </term>
    <listitem>
     <simpara>
-     Control Constant - Assertion (<link xlink:href="&url.rfc;45282">RFC 4528</link>).
+     Control Constant - Assertion (<link xlink:href="&url.rfc;4528">RFC 4528</link>).
      Available as of PHP 7.3.0.
     </simpara>
    </listitem>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 
 <chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Driver Architecture and Internals</titleabbrev>
@@ -34,7 +33,7 @@
    At the top of this stack sits a
    <link xlink:href="&url.mongodb.library;">PHP library</link>,
    which is distributed as a
-   <link xlink:href="&url.packagist.package;/mongodb/mongodb">Composer package</link>.
+   <link xlink:href="&url.packagist.package;mongodb/mongodb">Composer package</link>.
    This library provides an API consistent with other MongoDB
    <link xlink:href="&url.mongodb.drivers;">drivers</link>
    and implements various cross-driver

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-
+<!-- $Revision$ -->
 <chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Driver Architecture and Internals</titleabbrev>
  <title>Explains the driver architecture, and special features</title>


### PR DESCRIPTION
Fixes dead external links, verified against the resolved targets:

* `reference/ldap/constants.xml`: `&url.rfc;45282` had a stray digit (link text reads "RFC 4528").
* `reference/mongodb/architecture.xml`: removed the double slash after `&url.packagist.package;` (already ends in `/`).
* `install/windows/commandline.xml`: Microsoft KB 321788 and the retired MSDN forum post (both 404, no archive) are unlinked, keeping the reference text.