### PR TITLE
mcrypt: fix MCRYPT_ENIGMA to the real MCRYPT_ENIGNA and add MCRYPT_BLOWFISH_COMPAT

### DIFF
--- a/reference/mcrypt/ciphers.xml
+++ b/reference/mcrypt/ciphers.xml
@@ -15,12 +15,13 @@
    <listitem><simpara>MCRYPT_ARCFOUR_IV (libmcrypt &gt; 2.4.x only)</simpara></listitem>
    <listitem><simpara>MCRYPT_ARCFOUR (libmcrypt &gt; 2.4.x only)</simpara></listitem>
    <listitem><simpara>MCRYPT_BLOWFISH</simpara></listitem>
+   <listitem><simpara>MCRYPT_BLOWFISH_COMPAT</simpara></listitem>
    <listitem><simpara>MCRYPT_CAST_128</simpara></listitem>
    <listitem><simpara>MCRYPT_CAST_256</simpara></listitem>
    <listitem><simpara>MCRYPT_CRYPT</simpara></listitem>
    <listitem><simpara>MCRYPT_DES</simpara></listitem>
    <listitem><simpara>MCRYPT_DES_COMPAT (libmcrypt 2.2.x only)</simpara></listitem>
-   <listitem><simpara>MCRYPT_ENIGMA (libmcrypt &gt; 2.4.x only, alias for MCRYPT_CRYPT)</simpara></listitem>
+   <listitem><simpara>MCRYPT_ENIGNA (libmcrypt &gt; 2.4.x only, alias for MCRYPT_CRYPT)</simpara></listitem>
    <listitem><simpara>MCRYPT_GOST</simpara></listitem>
    <listitem><simpara>MCRYPT_IDEA (non-free)</simpara></listitem>
    <listitem><simpara>MCRYPT_LOKI97 (libmcrypt &gt; 2.4.x only)</simpara></listitem>


### PR DESCRIPTION
The cipher list documented `MCRYPT_ENIGMA`, but the constant registered by ext/mcrypt is spelled `MCRYPT_ENIGNA` (see ext/mcrypt/mcrypt.c: `MCRYPT_ENTRY2_2_4(ENIGNA, "crypt")`), so the documented name never existed.

Also adds `MCRYPT_BLOWFISH_COMPAT`, which is registered (`MCRYPT_ENTRY2_2_4(BLOWFISH_COMPAT, "blowfish-compat")`) but was missing from the list.