### PR TITLE
Document SQLite3Stmt::EXPLAIN_MODE_* class constants (PHP 8.5)

### DIFF
--- a/reference/sqlite3/sqlite3stmt.xml
+++ b/reference/sqlite3/sqlite3stmt.xml
@@ -24,6 +24,26 @@
      <classname>SQLite3Stmt</classname>
     </ooclass>
 
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-prepared">SQLite3Stmt::EXPLAIN_MODE_PREPARED</varname>
+     <initializer>0</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-explain">SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-explain-query-plan">SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Stmt'])">
      <xi:fallback/>
@@ -35,6 +55,47 @@
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ SQLite3Stmt constants -->
+  <section xml:id="sqlite3stmt.constants">
+   &reftitle.constants;
+   <variablelist>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-prepared">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_PREPARED</constant></term>
+     <listitem>
+      <para>
+       The statement operates in normal prepared statement mode (no <literal>EXPLAIN</literal>).
+       Available as of PHP 8.5.0.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-explain">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</constant></term>
+     <listitem>
+      <para>
+       The statement operates as if prefixed with <literal>EXPLAIN</literal>,
+       returning opcode information from the virtual machine.
+       Available as of PHP 8.5.0.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-explain-query-plan">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant></term>
+     <listitem>
+      <para>
+       The statement operates as if prefixed with <literal>EXPLAIN QUERY PLAN</literal>,
+       returning high-level query plan information.
+       Available as of PHP 8.5.0.
+      </para>
+     </listitem>
+    </varlistentry>
+
+   </variablelist>
+  </section>
+<!-- }}} -->
 
  </partintro>
 

--- a/reference/sqlite3/versions.xml
+++ b/reference/sqlite3/versions.xml
@@ -32,6 +32,9 @@
  <function name="SQLite3Exception" from="PHP 8 &gt;= 8.3.0"/>
 
  <function name="SQLite3Stmt" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="SQLite3Stmt::EXPLAIN_MODE_PREPARED" from="PHP 8 &gt;= 8.5.0"/>
+ <function name="SQLite3Stmt::EXPLAIN_MODE_EXPLAIN" from="PHP 8 &gt;= 8.5.0"/>
+ <function name="SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN" from="PHP 8 &gt;= 8.5.0"/>
  <function name="SQLite3Stmt::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Stmt::bindParam" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Stmt::bindValue" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>


### PR DESCRIPTION
Document the three new class constants introduced in PHP 8.5 for `SQLite3Stmt`:

- `SQLite3Stmt::EXPLAIN_MODE_PREPARED` (0): normal prepared statement mode
- `SQLite3Stmt::EXPLAIN_MODE_EXPLAIN` (1): behaves as if prefixed with `EXPLAIN`
- `SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN` (2): behaves as if prefixed with `EXPLAIN QUERY PLAN`