### PR TITLE
Document socket_set_timeout() deprecation in PHP 8.5

### DIFF
--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -13,10 +13,10 @@
    <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
    <methodparam><type>int</type><parameter role="reference">still_running</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Processes each of the handles in the stack.  This method can be called whether or not a handle
    needs to read or write data.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,9 +38,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    A cURL code defined in the cURL <link linkend="curl.constants">Predefined Constants</link>.
-  </para>
+  </simpara>
   <note>
    <para>
     This only returns errors regarding the whole multi stack. There might still have

--- a/reference/network/functions/socket-set-timeout.xml
+++ b/reference/network/functions/socket-set-timeout.xml
@@ -3,18 +3,61 @@
 <refentry xml:id="function.socket-set-timeout" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_set_timeout</refname>
-  <refpurpose>&Alias; <function>stream_set_timeout</function></refpurpose> 
+  <refpurpose>&Alias; <function>stream_set_timeout</function></refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;
+  <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
+   <type>bool</type><methodname>socket_set_timeout</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+   <methodparam><type>int</type><parameter>seconds</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>microseconds</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
   <simpara>
    &info.function.alias;
    <function>stream_set_timeout</function>.
+   This function has been deprecated as of PHP 8.5.0; use
+   <function>stream_set_timeout</function> instead.
   </simpara>
  </refsect1>
-</refentry>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       This function has been deprecated.
+       Use <function>stream_set_timeout</function> instead.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>stream_set_timeout</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/network/functions/socket-set-timeout.xml
+++ b/reference/network/functions/socket-set-timeout.xml
@@ -3,8 +3,12 @@
 <refentry xml:id="function.socket-set-timeout" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_set_timeout</refname>
-  <refpurpose>&Alias; <function>stream_set_timeout</function></refpurpose> 
+  <refpurpose>&Alias; <function>stream_set_timeout</function></refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;
@@ -13,6 +17,14 @@
    <function>stream_set_timeout</function>.
   </simpara>
  </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>stream_set_timeout</function></member>
+  </simplelist>
+ </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/network/versions.xml
+++ b/reference/network/versions.xml
@@ -37,7 +37,7 @@
  <function name="setrawcookie" from="PHP 5, PHP 7, PHP 8"/>
  <function name="socket_get_status" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="socket_set_blocking" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
- <function name="socket_set_timeout" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="socket_set_timeout" from="PHP 4, PHP 5, PHP 7, PHP 8" deprecated="PHP 8.5.0"/>
  <function name="syslog" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
 </versions>
 


### PR DESCRIPTION
`socket_set_timeout()` is an alias of `stream_set_timeout()` and was deprecated in PHP 8.5, but its manual page carries no deprecation notice.

- Adds the deprecation banner and a `See Also` entry on the function page, mirroring `mysqli_execute` — the only other alias page deprecated in the same version.
- Flags the function as `deprecated="PHP 8.5.0"` in `versions.xml`, as already done for `curl_close()`, `curl_share_close()`, `finfo_close()`, `imagedestroy()`, `ldap_connect_wallet()` and `xml_parser_free()`.

The deprecation itself is already covered in the 8.5 migration appendix; this only fixes the function page.

**Sources**

- php-src [#19285](https://github.com/php/php-src/pull/19285) (`21625006e5`): `#[\Deprecated(since: '8.5', message: "use stream_set_timeout() instead")]` in `ext/standard/basic_functions.stub.php`
- RFC: https://wiki.php.net/rfc/deprecations_php_8_5#formally_deprecate_socket_set_timeout

Tracker: [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13/views/1?filterQuery=socket_set_timeout&pane=issue&itemId=199834863)
