### PR TITLE
Document flock() support on zlib streams in PHP 8.5

### DIFF
--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -91,6 +91,29 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <function>flock</function> is now supported on zlib streams.
+       Previously, this always failed to perform any locking action.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
`flock()` now supports zlib streams as of PHP 8.5. Previously, calling `flock()` on a zlib stream always failed to perform any locking action.