### PR TITLE
Document default stream context support for gzfile/gzopen/readgzfile in PHP 8.5

### DIFF
--- a/reference/zlib/functions/gzfile.xml
+++ b/reference/zlib/functions/gzfile.xml
@@ -62,6 +62,12 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
+       This function now respects the default stream context.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
        <parameter>use_include_path</parameter> is now of type <type>bool</type>.
        Previously, it was of type <type>int</type>.
       </entry>

--- a/reference/zlib/functions/gzopen.xml
+++ b/reference/zlib/functions/gzopen.xml
@@ -86,6 +86,12 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
+       This function now respects the default stream context.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
        <parameter>use_include_path</parameter> is now of type <type>bool</type>.
        Previously, it was of type <type>int</type>.
       </entry>

--- a/reference/zlib/functions/readgzfile.xml
+++ b/reference/zlib/functions/readgzfile.xml
@@ -75,6 +75,12 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
+       This function now respects the default stream context.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
        <parameter>use_include_path</parameter> is now of type <type>bool</type>.
        Previously, it was of type <type>int</type>.
       </entry>


### PR DESCRIPTION
`gzfile()`, `gzopen()` and `readgzfile()` now respect the default stream context as of PHP 8.5.

Changes: add a PHP 8.5.0 changelog entry in each of the three function pages.