### PR TITLE
DocbookCS: remove SimparaSniff

### DIFF
--- a/docbookcs.xml
+++ b/docbookcs.xml
@@ -10,7 +10,6 @@
  </project>
 
  <sniffs>
-  <sniff class="DocbookCS\Sniff\SimparaSniff" />
   <sniff class="DocbookCS\Sniff\ExceptionNameSniff" />
   <sniff class="DocbookCS\Sniff\AttributeOrderSniff" />
   <sniff class="DocbookCS\Sniff\WhitespaceSniff" />


### PR DESCRIPTION
I don't see any purpose for this rule. This argument makes no sense to me:

> You can't have block elements in a simpara tags. Which helps prevent people writing dumb stuff inside para tags just because they think they might need it.

If people want to write dumb stuff inside `para` tags then they would just use them.

Moreover, `simpara` renders differently (the first uses simpara, second para):

<img width="1618" height="510" alt="image" src="https://github.com/user-attachments/assets/db9a83c8-9214-446d-bec5-0992ca6d7471" />

Changing all `para` to `simpara` to satisfy this rule would completely break how the docs is rendered and what was the intent of the author.