### PR TITLE
hash: HashContext::__serialize returns an array, not void

### DIFF
--- a/reference/hash/hashcontext/serialize.xml
+++ b/reference/hash/hashcontext/serialize.xml
@@ -26,9 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.void;
-  </para>
+  <simpara>
+   Returns an &array; containing the serialized representation of the
+   <classname>HashContext</classname> object.
+  </simpara>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
The Return Values section used `&return.void;`, but the method returns an array (the methodsynopsis on the same page already declares `array`).

Verified in php-src: `ext/hash/hash.stub.php` declares `__serialize(): array`, and `PHP_METHOD(HashContext, __serialize)` in `ext/hash/hash.c` does `array_init(return_value)` then fills it with the serialized state.