### PR TITLE
xmlreader: getAttributeNo()/getAttributeNs() return null, not an empty string

### DIFF
--- a/reference/xmlreader/xmlreader/getattributeno.xml
+++ b/reference/xmlreader/xmlreader/getattributeno.xml
@@ -11,11 +11,10 @@
    <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>XMLReader::getAttributeNo</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Returns the value of an attribute based on its position or an 
-   empty string if attribute does not exist or not positioned on 
-   an element node.
-  </para>
+  <simpara>
+   Returns the value of an attribute based on its position, or &null;
+   if the attribute does not exist or not positioned on an element node.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/xmlreader/xmlreader/getattributens.xml
+++ b/reference/xmlreader/xmlreader/getattributens.xml
@@ -12,10 +12,10 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Returns the value of an attribute by name and namespace URI or an empty 
-   string if attribute does not exist or not positioned on an element node.
-  </para>
+  <simpara>
+   Returns the value of an attribute by name and namespace URI, or &null;
+   if the attribute does not exist or not positioned on an element node.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Both descriptions said they return an empty string when the attribute is missing or the reader is not positioned on an element node. They actually return `null`.

Verified in php-src: the stubs declare `?string`, and in `ext/xmlreader/php_xmlreader.c` `retchar` starts at `NULL` and `return_value` is only written via `RETVAL_STRING` when the attribute exists, so it stays `null` otherwise.