### PR TITLE
Document ReflectionConstant::getAttributes() (PHP 8.5)

### DIFF
--- a/reference/reflection/reflectionconstant/getattributes.xml
+++ b/reference/reflection/reflectionconstant/getattributes.xml
@@ -57,6 +57,46 @@
   </para>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Basic usage</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+#[Fruit]
+#[Red]
+const APPLE = 'apple';
+
+$constant = new ReflectionConstant('APPLE');
+$attributes = $constant->getAttributes();
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Fruit
+    [1] => Red
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>

--- a/reference/reflection/reflectionconstant/getattributes.xml
+++ b/reference/reflection/reflectionconstant/getattributes.xml
@@ -13,9 +13,9 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns all attributes declared on this global constant as an array of <classname>ReflectionAttribute</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Array of attributes, as <classname>ReflectionAttribute</classname> objects.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/reflection/reflectionconstant/getattributes.xml
+++ b/reference/reflection/reflectionconstant/getattributes.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="reflectionconstant.getattributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionConstant::getAttributes</refname>
+  <refpurpose>Gets Attributes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionConstant">
+   <modifier>public</modifier> <type>array</type><methodname>ReflectionConstant::getAttributes</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Returns all attributes declared on this global constant as an array of <classname>ReflectionAttribute</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &reflection.getattributes.param.name;
+   &reflection.getattributes.param.flags;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Array of attributes, as <classname>ReflectionAttribute</classname> objects.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        This method was introduced.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionClass::getAttributes</methodname></member>
+    <member><methodname>ReflectionClassConstant::getAttributes</methodname></member>
+    <member><methodname>ReflectionFunctionAbstract::getAttributes</methodname></member>
+    <member><methodname>ReflectionProperty::getAttributes</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionconstant/getattributes.xml
+++ b/reference/reflection/reflectionconstant/getattributes.xml
@@ -59,14 +59,12 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>ReflectionClass::getAttributes</methodname></member>
-    <member><methodname>ReflectionClassConstant::getAttributes</methodname></member>
-    <member><methodname>ReflectionFunctionAbstract::getAttributes</methodname></member>
-    <member><methodname>ReflectionProperty::getAttributes</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>ReflectionClass::getAttributes</methodname></member>
+   <member><methodname>ReflectionClassConstant::getAttributes</methodname></member>
+   <member><methodname>ReflectionFunctionAbstract::getAttributes</methodname></member>
+   <member><methodname>ReflectionProperty::getAttributes</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
PHP 8.5 adds `ReflectionConstant::getAttributes()` (RFC: attributes on constants), which had no documentation. Adds the method page.

Verified against php-src: `ext/reflection/php_reflection.stub.php` declares `getAttributes(?string $name = null, int $flags = 0): array`, matching the documented signature.