### PR TITLE
Document Dom\Element::$outerHTML property (PHP 8.5)

### DIFF
--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -128,6 +128,12 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="dom-element.props.outerhtml">outerHTML</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type>string</type>
      <varname linkend="dom-element.props.substitutednodevalue">substitutedNodeValue</varname>
     </fieldsynopsis>
@@ -235,6 +241,15 @@
      <term><varname>innerHTML</varname></term>
      <listitem>
       <simpara>The inner HTML (or XML for XML documents) of the element.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.outerhtml">
+     <term><varname>outerHTML</varname></term>
+     <listitem>
+      <simpara>
+       The outer HTML (or XML for XML documents) of the element, including the
+       element itself. Read-only. Available as of PHP 8.5.0.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.substitutednodevalue">

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -128,7 +128,6 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
-     <modifier>readonly</modifier>
      <type>string</type>
      <varname linkend="dom-element.props.outerhtml">outerHTML</varname>
     </fieldsynopsis>
@@ -248,7 +247,7 @@
      <listitem>
       <simpara>
        The outer HTML (or XML for XML documents) of the element, including the
-       element itself. Read-only. Available as of PHP 8.5.0.
+       element itself. Available as of PHP 8.5.0.
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
PHP 8.5 adds the `Dom\Element::$outerHTML` virtual property. Documents it in the class synopsis and property list.

Verified against php-src: `ext/dom/php_dom.stub.php` declares `public string $outerHTML;` (`@virtual`, no `readonly`), and `ext/dom/php_dom.c` registers both `dom_element_outer_html_read` and `dom_element_outer_html_write` handlers, so the property is writable (mirrors `innerHTML`).