### PR TITLE
Document the new Dom\ParentNode $children property (PHP 8.5)

### DIFF
--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -106,6 +106,12 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-document.props.children">children</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type class="union"><type>Dom\HTMLElement</type><type>null</type></type>
      <varname linkend="dom-document.props.body">body</varname>
     </fieldsynopsis>
@@ -207,6 +213,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-document.props.childelementcount">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -60,6 +60,12 @@
      <type>int</type>
      <varname linkend="dom-documentfragment.props.childelementcount">childElementCount</varname>
     </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-documentfragment.props.children">children</varname>
+    </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
@@ -95,6 +101,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.childelementcount">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documentfragment.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -123,6 +123,12 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-element.props.children">children</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type>string</type>
      <varname linkend="dom-element.props.innerhtml">innerHTML</varname>
     </fieldsynopsis>
@@ -228,6 +234,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-element.props.nextelementsibling">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -21,12 +21,35 @@
      <interfacename>Dom\ParentNode</interfacename>
     </oointerface>
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-parentnode.props.children">children</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])">
      <xi:fallback/>
     </xi:include>
    </classsynopsis>
 
+  </section>
+
+  <section xml:id="dom-parentnode.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-parentnode.props.children">
+     <term><varname>children</varname></term>
+     <listitem>
+      <simpara>
+       A <classname>Dom\HTMLCollection</classname> containing all child
+       elements of this node. Available as of PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </section>
 
  </partintro>


### PR DESCRIPTION
Documents the new read-only `$children` property (`Dom\HTMLCollection`) added to `Dom\ParentNode` and its implementations `Dom\Element`, `Dom\Document` and `Dom\DocumentFragment` in PHP 8.5.

The property is defined once on `Dom\ParentNode` and referenced through a local anchor in each implementing class, matching how the other ParentNode properties are documented.