### PR TITLE
Document more curl deprecations

### DIFF
--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -740,7 +740,7 @@
   </term>
   <listitem>
    <simpara>
-    Average upload speed. Deprecated since 7.55.0. Use <constant>CURLINFO_SPEED_UPLOAD_T</constant> instead.
+    Average upload speed. Deprecated since cURL 7.55.0. Use <constant>CURLINFO_SPEED_UPLOAD_T</constant> instead.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -112,7 +112,7 @@
   </term>
   <listitem>
    <simpara>
-    Content length of download, read from Content-Length: field
+    Content length of download, read from Content-Length: field. Deprecated since cURL 7.55.0. Use <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> instead.
    </simpara>
   </listitem>
  </varlistentry>
@@ -135,7 +135,7 @@
   </term>
   <listitem>
    <simpara>
-    Specified size of upload
+    Specified size of upload. Deprecated since cURL 7.55.0. Use <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> instead.
    </simpara>
   </listitem>
  </varlistentry>
@@ -453,7 +453,7 @@
   <listitem>
    <simpara>
     The protocol used in the last HTTP connection. The returned value will be exactly one of the <constant>CURLPROTO_<replaceable>*</replaceable></constant> values.
-    Available as of PHP 7.3.0 and cURL 7.52.0
+    Available as of PHP 7.3.0 and cURL 7.52.0. Deprecated since cURL 7.85.0. Use <constant>CURLINFO_SCHEME</constant> instead.
    </simpara>
   </listitem>
  </varlistentry>
@@ -671,7 +671,7 @@
   </term>
   <listitem>
    <simpara>
-    Total number of bytes downloaded
+    Total number of bytes downloaded. Deprecated since cURL 7.55.0. Use <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> instead.
    </simpara>
   </listitem>
  </varlistentry>
@@ -694,7 +694,7 @@
   </term>
   <listitem>
    <simpara>
-    Total number of bytes uploaded
+    Total number of bytes uploaded. Deprecated since cURL 7.55.0. Use <constant>CURLINFO_SIZE_UPLOAD_T</constant> instead.
    </simpara>
   </listitem>
  </varlistentry>
@@ -717,7 +717,7 @@
   </term>
   <listitem>
    <simpara>
-    Average download speed
+    Average download speed. Deprecated since cURL 7.55.0. Use <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> instead.
    </simpara>
   </listitem>
  </varlistentry>
@@ -740,7 +740,7 @@
   </term>
   <listitem>
    <simpara>
-    Average upload speed
+    Average upload speed. Deprecated since 7.55.0. Use <constant>CURLINFO_SPEED_UPLOAD_T</constant> instead.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -2280,13 +2280,13 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Bitmask of <constant>CURLPROTO_<replaceable>*</replaceable></constant> values.
      If used, this bitmask limits what protocols cURL may use in the transfer.
      Defaults to <constant>CURLPROTO_ALL</constant>, ie. cURL will accept all protocols it supports.
      See also <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant>.
      Available as of cURL 7.19.4 and deprecated as of cURL 7.85.0.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-protocols-str">
@@ -3723,12 +3723,12 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &true; to enable and &false; to disable TLS false start
      which is a mode where a TLS client starts sending application data
      before verifying the server's <literal>Finished</literal> message.
      Available as of PHP 7.0.7 and cURL 7.42.0. Deprecated since cURL 8.15.0.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssl-options">

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1528,7 +1528,7 @@
      <literal>private</literal> is used.
      Setting this option to &null; will disable kerberos support for FTP.
      Defaults to &null;.
-     Available as of cURL 7.16.4.
+     Available as of cURL 7.16.4 and deprecated as of cURL 8.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2284,7 +2284,7 @@
      Bitmask of <constant>CURLPROTO_<replaceable>*</replaceable></constant> values.
      If used, this bitmask limits what protocols cURL may use in the transfer.
      Defaults to <constant>CURLPROTO_ALL</constant>, ie. cURL will accept all protocols it supports.
-     See also <constant>CURLOPT_REDIR_PROTOCOLS</constant>.
+     See also <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant>.
      Available as of cURL 7.19.4 and deprecated as of cURL 7.85.0.
     </para>
    </listitem>
@@ -3727,7 +3727,7 @@
      &true; to enable and &false; to disable TLS false start
      which is a mode where a TLS client starts sending application data
      before verifying the server's <literal>Finished</literal> message.
-     Available as of PHP 7.0.7 and cURL 7.42.0.
+     Available as of PHP 7.0.7 and cURL 7.42.0. Deprecated since cURL 8.15.0.
     </para>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
I compiled against cURL 8.18 with enabled deprecation warnings, and documented the results.