### PR TITLE
CURLOPT_TCP_KEEPCNT instead of CURL_TCP_KEEPCNT

### DIFF
--- a/appendices/migration84/constants.xml
+++ b/appendices/migration84/constants.xml
@@ -26,7 +26,7 @@
     <constant>CURL_HTTP_VERSION_3ONLY</constant>
    </member>
    <member>
-    <constant>CURL_TCP_KEEPCNT</constant>
+    <constant>CURLOPT_TCP_KEEPCNT</constant>
    </member>
    <member>
     <constant>CURLOPT_PREREQFUNCTION</constant>


### PR DESCRIPTION
CURL_TCP_KEEPCNT does not exist and CURLOPT_TCP_KEEPCNT does, so this seems like a mistake.