### PR TITLE
ssh2: document five previously undocumented functions

### DIFF
--- a/reference/ssh2/functions/ssh2-auth-agent.xml
+++ b/reference/ssh2/functions/ssh2-auth-agent.xml
@@ -19,7 +19,7 @@
   <note>
     <simpara>
      The <function>ssh2_auth_agent</function> function will only be available
-     when the ssh2 extension is compiled with libssh &gt;= 1.2.3.
+     when the ssh2 extension is compiled with libssh2 &gt;= 1.2.3.
     </simpara>
   </note>
  </refsect1>

--- a/reference/ssh2/functions/ssh2-auth-pubkey-file.xml
+++ b/reference/ssh2/functions/ssh2-auth-pubkey-file.xml
@@ -104,7 +104,7 @@ if (ssh2_auth_pubkey_file($connection, 'username',
   &reftitle.notes;
   <note>
    <simpara>
-    The underlying libssh library doesn't support partial auths very cleanly.
+    The underlying libssh2 library doesn't support partial auths very cleanly.
     That is, if you need to supply both a public key and a password it will
     appear as if this function has failed. In this particular case a failure
     from this call may just mean that auth hasn't been completed yet. You

--- a/reference/ssh2/functions/ssh2-auth-pubkey.xml
+++ b/reference/ssh2/functions/ssh2-auth-pubkey.xml
@@ -106,7 +106,7 @@ if (ssh2_auth_pubkey($connection, 'username',
   &reftitle.notes;
   <note>
    <simpara>
-    The underlying libssh library doesn't support partial auths very cleanly.
+    The underlying libssh2 library doesn't support partial auths very cleanly.
     That is, if you need to supply both a public key and a password it will
     appear as if this function has failed. In this particular case a failure
     from this call may just mean that auth hasn't been completed yet. You

--- a/reference/ssh2/functions/ssh2-keepalive-config.xml
+++ b/reference/ssh2/functions/ssh2-keepalive-config.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-keepalive-config" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_keepalive_config</refname>
+  <refpurpose>Configure how often keepalive messages should be sent</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type>void</type><methodname>ssh2_keepalive_config</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>want_reply</parameter></methodparam>
+   <methodparam><type>int</type><parameter>interval</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Configures how often keepalive messages are sent on the given
+   <parameter>session</parameter>, and whether the server is asked to reply to
+   them.
+  </simpara>
+  <simpara>
+   Keepalive messages are not sent automatically. Once configured,
+   <function>ssh2_keepalive_send</function> must be called to actually send a
+   keepalive message.
+  </simpara>
+  <note>
+   <simpara>
+    The <function>ssh2_keepalive_config</function> function will only be
+    available when the ssh2 extension is compiled with libssh keepalive
+    support.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH connection link identifier, obtained from a call to
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>want_reply</parameter></term>
+    <listitem>
+     <simpara>
+      Whether the server is requested to reply to keepalive messages.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>interval</parameter></term>
+    <listitem>
+     <simpara>
+      The number of seconds that may pass without any traffic before a
+      keepalive message should be sent. A value of <literal>0</literal>
+      disables keepalive messages.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_keepalive_send</function></member>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-keepalive-config.xml
+++ b/reference/ssh2/functions/ssh2-keepalive-config.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-keepalive-config" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_keepalive_config</refname>
+  <refpurpose>Configure how often keepalive messages should be sent</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>ssh2_keepalive_config</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>want_reply</parameter></methodparam>
+   <methodparam><type>int</type><parameter>interval</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Configures how often keepalive messages are sent on the given
+   <parameter>session</parameter>, and whether the server is asked to reply to
+   them.
+  </simpara>
+  <simpara>
+   Keepalive messages are not sent automatically. Once configured,
+   <function>ssh2_keepalive_send</function> must be called to actually send a
+   keepalive message.
+  </simpara>
+  <note>
+   <simpara>
+    This function is only available when the extension is built against a
+    libssh2 version providing keepalive support.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH connection link identifier, obtained from a call to
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>want_reply</parameter></term>
+    <listitem>
+     <simpara>
+      Whether the server is requested to reply to keepalive messages.
+      Requesting a reply makes an unresponsive server detectable, at the cost
+      of some extra traffic.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>interval</parameter></term>
+    <listitem>
+     <simpara>
+      The number of seconds that may pass without any traffic before a
+      keepalive message should be sent. A value of <literal>0</literal>
+      disables keepalive messages, and a value of <literal>1</literal> is
+      treated as <literal>2</literal> by the underlying library.
+     </simpara>
+     <simpara>
+      Accepted values range from <literal>0</literal> to
+      <literal>4294967295</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   An <constant>E_WARNING</constant> is emitted when
+   <parameter>interval</parameter> is outside the accepted range, in which
+   case the keepalive configuration is left unchanged.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Sending keepalive messages</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+// Ask the server to reply, after 30 seconds without any traffic
+ssh2_keepalive_config($connection, true, 30);
+
+// Keepalive messages are only sent when this function is called
+ssh2_keepalive_send($connection);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_keepalive_send</function></member>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-keepalive-send.xml
+++ b/reference/ssh2/functions/ssh2-keepalive-send.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-keepalive-send" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_keepalive_send</refname>
+  <refpurpose>Send a keepalive message</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type class="union"><type>int</type><type>false</type></type><methodname>ssh2_keepalive_send</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sends a keepalive message on the given <parameter>session</parameter>,
+   according to the configuration set with
+   <function>ssh2_keepalive_config</function>.
+  </simpara>
+  <note>
+   <simpara>
+    The <function>ssh2_keepalive_send</function> function will only be
+    available when the ssh2 extension is compiled with libssh keepalive
+    support.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH connection link identifier, obtained from a call to
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns the number of seconds that may pass before another keepalive message
+   must be sent, or &false; on failure.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_keepalive_config</function></member>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-keepalive-send.xml
+++ b/reference/ssh2/functions/ssh2-keepalive-send.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-keepalive-send" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_keepalive_send</refname>
+  <refpurpose>Send a keepalive message</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>ssh2_keepalive_send</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sends a keepalive message on the given <parameter>session</parameter>,
+   according to the configuration set with
+   <function>ssh2_keepalive_config</function>.
+  </simpara>
+  <note>
+   <simpara>
+    This function is only available when the extension is built against a
+    libssh2 version providing keepalive support.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH connection link identifier, obtained from a call to
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns the number of seconds that may pass before another keepalive message
+   must be sent, or &false; on failure. <literal>0</literal> is returned when
+   keepalive messages are disabled.
+  </simpara>
+  <simpara>
+   Since <literal>0</literal> and &false; are both falsy, the
+   <literal>===</literal> operator has to be used to tell them apart.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Sending a keepalive message</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+ssh2_keepalive_config($connection, true, 30);
+
+$seconds = ssh2_keepalive_send($connection);
+
+if ($seconds === false) {
+    echo "The keepalive message could not be sent", PHP_EOL;
+} elseif ($seconds === 0) {
+    echo "Keepalive messages are disabled", PHP_EOL;
+} else {
+    echo "Next keepalive message due in $seconds seconds", PHP_EOL;
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_keepalive_config</function></member>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-send-signal.xml
+++ b/reference/ssh2/functions/ssh2-send-signal.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-send-signal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_send_signal</refname>
+  <refpurpose>Send a signal to the remote process of a channel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type>bool</type><methodname>ssh2_send_signal</methodname>
+   <methodparam><type>resource</type><parameter>channel</parameter></methodparam>
+   <methodparam><type>string</type><parameter>signal</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sends a signal to the process running at the remote end of the given
+   <parameter>channel</parameter>.
+  </simpara>
+  <note>
+   <simpara>
+    The <function>ssh2_send_signal</function> function will only be available
+    when the ssh2 extension is compiled with libssh &gt;= 1.9.0.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>channel</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH channel stream, as returned by <function>ssh2_exec</function> or
+      <function>ssh2_shell</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>signal</parameter></term>
+    <listitem>
+     <simpara>
+      The name of the signal to send, without the <literal>SIG</literal>
+      prefix, as defined by the SSH connection protocol
+      (<link xlink:href="&url.rfc;4254">RFC 4254</link>); for
+      example <literal>TERM</literal>, <literal>KILL</literal> or
+      <literal>INT</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_exec</function></member>
+   <member><function>ssh2_shell</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-send-signal.xml
+++ b/reference/ssh2/functions/ssh2-send-signal.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-send-signal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_send_signal</refname>
+  <refpurpose>Send a signal to a remote process</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>ssh2_send_signal</methodname>
+   <methodparam><type>resource</type><parameter>channel</parameter></methodparam>
+   <methodparam><type>string</type><parameter>signal</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sends a signal to the process running at the remote end of the given
+   <parameter>channel</parameter>.
+  </simpara>
+  <note>
+   <simpara>
+    This function is only available when the extension is built against
+    libssh2 &gt;= 1.9.0.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>channel</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH channel stream, as returned by <function>ssh2_exec</function> or
+      <function>ssh2_shell</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>signal</parameter></term>
+    <listitem>
+     <simpara>
+      The name of the signal to send, without the <literal>SIG</literal>
+      prefix, as defined by the SSH connection protocol
+      (<link xlink:href="&url.rfc;4254">RFC 4254</link>); for
+      example <literal>TERM</literal>, <literal>KILL</literal> or
+      <literal>INT</literal>.
+     </simpara>
+     <simpara>
+      The value is forwarded to the server as is; it is not validated
+      against the names listed by the protocol.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   An <constant>E_WARNING</constant> is emitted when
+   <parameter>channel</parameter> is not an SSH channel stream, and when the
+   signal could not be sent.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Interrupting a remote command</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+$stream = ssh2_exec($connection, 'trap "echo interrupted" INT; sleep 60');
+
+ssh2_send_signal($stream, 'INT');
+
+stream_set_blocking($stream, true);
+echo stream_get_contents($stream);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_exec</function></member>
+   <member><function>ssh2_shell</function></member>
+   <member><function>ssh2_send_eof</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-set-timeout.xml
+++ b/reference/ssh2/functions/ssh2-set-timeout.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-set-timeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_set_timeout</refname>
+  <refpurpose>Set timeout for the SSH session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type>void</type><methodname>ssh2_set_timeout</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+   <methodparam><type>int</type><parameter>seconds</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>microseconds</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sets how long a blocking operation on the given
+   <parameter>session</parameter> may wait before it is considered to have
+   timed out.
+  </simpara>
+  <note>
+   <simpara>
+    The <function>ssh2_set_timeout</function> function will only be available
+    when the ssh2 extension is compiled with libssh &gt;= 1.2.9.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH connection link identifier, obtained from a call to
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>seconds</parameter></term>
+    <listitem>
+     <simpara>
+      The timeout, in seconds. A value of <literal>0</literal> means that no
+      timeout is applied and blocking operations may wait indefinitely.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>microseconds</parameter></term>
+    <listitem>
+     <simpara>
+      An additional number of microseconds added to the timeout.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-set-timeout.xml
+++ b/reference/ssh2/functions/ssh2-set-timeout.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-set-timeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_set_timeout</refname>
+  <refpurpose>Set the timeout for blocking operations on a session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>ssh2_set_timeout</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+   <methodparam><type>int</type><parameter>seconds</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>microseconds</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sets how long a blocking operation on the given
+   <parameter>session</parameter> may wait before it is considered to have
+   timed out.
+  </simpara>
+  <simpara>
+   When the resulting timeout is <literal>0</literal>, which is the default,
+   no timeout is applied and blocking operations may wait indefinitely.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH connection link identifier, obtained from a call to
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>seconds</parameter></term>
+    <listitem>
+     <simpara>
+      The timeout, in seconds.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>microseconds</parameter></term>
+    <listitem>
+     <simpara>
+      An additional number of microseconds added to the timeout. The
+      underlying library only supports millisecond precision, so this value
+      is rounded up to the next whole millisecond.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Limiting how long blocking operations may wait</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+
+// Give up on blocking operations after 5.5 seconds
+ssh2_set_timeout($connection, 5, 500000);
+
+ssh2_auth_password($connection, 'username', 'password');
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_connect</function></member>
+   <member><function>ssh2_keepalive_config</function></member>
+   <member><function>stream_set_timeout</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-shell-resize.xml
+++ b/reference/ssh2/functions/ssh2-shell-resize.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-shell-resize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_shell_resize</refname>
+  <refpurpose>Change the dimensions of a shell's pseudo-terminal</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type>bool</type><methodname>ssh2_shell_resize</methodname>
+   <methodparam><type>resource</type><parameter>shell</parameter></methodparam>
+   <methodparam><type>int</type><parameter>width</parameter></methodparam>
+   <methodparam><type>int</type><parameter>height</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>width_px</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>height_px</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Requests that the pseudo-terminal (PTY) attached to the given
+   <parameter>shell</parameter> be resized to the given dimensions.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>shell</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH shell stream, as returned by <function>ssh2_shell</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width</parameter></term>
+    <listitem>
+     <simpara>
+      The width of the terminal, in characters.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>height</parameter></term>
+    <listitem>
+     <simpara>
+      The height of the terminal, in characters.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width_px</parameter></term>
+    <listitem>
+     <simpara>
+      The width of the terminal, in pixels.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>height_px</parameter></term>
+    <listitem>
+     <simpara>
+      The height of the terminal, in pixels.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_shell</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-shell-resize.xml
+++ b/reference/ssh2/functions/ssh2-shell-resize.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.ssh2-shell-resize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_shell_resize</refname>
+  <refpurpose>Change the dimensions of a channel's pseudo-terminal</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>ssh2_shell_resize</methodname>
+   <methodparam><type>resource</type><parameter>channel</parameter></methodparam>
+   <methodparam><type>int</type><parameter>width</parameter></methodparam>
+   <methodparam><type>int</type><parameter>height</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>width_px</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>height_px</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Requests that the pseudo-terminal (PTY) attached to the given
+   <parameter>channel</parameter> be resized to the given dimensions.
+  </simpara>
+  <note>
+   <simpara>
+    The extension declares only the first three parameters, under the name
+    <literal>session</literal> for <parameter>channel</parameter>. As a
+    result, <parameter>width_px</parameter> and
+    <parameter>height_px</parameter> can only be passed positionally.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>channel</parameter></term>
+    <listitem>
+     <simpara>
+      An SSH channel stream, as returned by <function>ssh2_exec</function> or
+      <function>ssh2_shell</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width</parameter></term>
+    <listitem>
+     <simpara>
+      The width of the terminal, in characters.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>height</parameter></term>
+    <listitem>
+     <simpara>
+      The height of the terminal, in characters.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width_px</parameter></term>
+    <listitem>
+     <simpara>
+      The width of the terminal in pixels, or <literal>0</literal> to leave
+      the pixel dimensions unspecified.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>height_px</parameter></term>
+    <listitem>
+     <simpara>
+      The height of the terminal in pixels, or <literal>0</literal> to leave
+      the pixel dimensions unspecified.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns &true;, or &false; when <parameter>channel</parameter> is not an
+   SSH channel stream.
+  </simpara>
+  <simpara>
+   The outcome of the resize request itself is not reported: &true; is
+   returned even when the remote end does not honour it.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   An <constant>E_WARNING</constant> is emitted when
+   <parameter>channel</parameter> is not an SSH channel stream.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Resizing the pseudo-terminal of a shell</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+$shell = ssh2_shell($connection, 'xterm', null, 80, 24);
+
+// Tell the remote end the terminal is now 132 columns by 43 rows
+ssh2_shell_resize($shell, 132, 43);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_shell</function></member>
+   <member><function>ssh2_exec</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/setup.xml
+++ b/reference/ssh2/setup.xml
@@ -20,11 +20,11 @@
   </simpara>
   <simpara>
    The <function>ssh2_auth_agent</function> function will only be available
-   with libssh &gt;= 1.2.3.
+   with libssh2 &gt;= 1.2.3.
   </simpara>
   <simpara>
    support for <function>stream_set_timeout</function> to channel streams
-   will only be available with libssh &gt;= 1.2.9.
+   will only be available with libssh2 &gt;= 1.2.9.
   </simpara>
   <simpara>
    Libssh2 comes in two flavours: gcrypt or openssl. Some Linux

--- a/reference/ssh2/versions.xml
+++ b/reference/ssh2/versions.xml
@@ -17,6 +17,8 @@
  <function name='ssh2_fingerprint' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_forward_accept' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_forward_listen' from='PECL ssh2 &gt;= 0.9.0'/>
+ <function name='ssh2_keepalive_config' from='PECL ssh2 &gt;= 1.5.0'/>
+ <function name='ssh2_keepalive_send' from='PECL ssh2 &gt;= 1.5.0'/>
  <function name='ssh2_methods_negotiated' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_poll' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_publickey_add' from='PECL ssh2 &gt;= 0.10'/>
@@ -26,6 +28,8 @@
  <function name='ssh2_scp_recv' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_scp_send' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_send_eof' from='PECL ssh2 &gt;= 1.3'/>
+ <function name='ssh2_send_signal' from='PECL ssh2 &gt;= 1.5.0'/>
+ <function name='ssh2_set_timeout' from='PECL ssh2 &gt;= 1.5.0'/>
  <function name='ssh2_sftp' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_sftp_chmod' from='PECL ssh2 &gt;= 0.12'/>
  <function name='ssh2_sftp_lstat' from='PECL ssh2 &gt;= 0.9.0'/>
@@ -38,6 +42,7 @@
  <function name='ssh2_sftp_symlink' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_sftp_unlink' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_shell' from='PECL ssh2 &gt;= 0.9.0'/>
+ <function name='ssh2_shell_resize' from='PECL ssh2 &gt;= 1.4'/>
  <function name='ssh2_tunnel' from='PECL ssh2 &gt;= 0.9.0'/>
 </versions>
 

--- a/reference/ssh2/versions.xml
+++ b/reference/ssh2/versions.xml
@@ -6,7 +6,7 @@
  <function name='ssh2_auth_hostbased_file' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_auth_none' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_auth_password' from='PECL ssh2 &gt;= 0.9.0'/>
- <function name='ssh2_auth_pubkey' from='PECL ssh2 &gt;= 1.4.0'/>
+ <function name='ssh2_auth_pubkey' from='PECL ssh2 &gt;= 1.4'/>
  <function name='ssh2_auth_pubkey_file' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_connect' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_disconnect' from='PECL ssh2 &gt;= 1.0'/>
@@ -15,6 +15,8 @@
  <function name='ssh2_fingerprint' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_forward_accept' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_forward_listen' from='PECL ssh2 &gt;= 0.9.0'/>
+ <function name='ssh2_keepalive_config' from='PECL ssh2 &gt;= 1.5.0'/>
+ <function name='ssh2_keepalive_send' from='PECL ssh2 &gt;= 1.5.0'/>
  <function name='ssh2_methods_negotiated' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_poll' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_publickey_add' from='PECL ssh2 &gt;= 0.10'/>
@@ -24,6 +26,8 @@
  <function name='ssh2_scp_recv' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_scp_send' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_send_eof' from='PECL ssh2 &gt;= 1.3'/>
+ <function name='ssh2_send_signal' from='PECL ssh2 &gt;= 1.5.0'/>
+ <function name='ssh2_set_timeout' from='PECL ssh2 &gt;= 1.5.0'/>
  <function name='ssh2_sftp' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_sftp_chmod' from='PECL ssh2 &gt;= 0.12'/>
  <function name='ssh2_sftp_lstat' from='PECL ssh2 &gt;= 0.9.0'/>
@@ -36,6 +40,7 @@
  <function name='ssh2_sftp_symlink' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_sftp_unlink' from='PECL ssh2 &gt;= 0.9.0'/>
  <function name='ssh2_shell' from='PECL ssh2 &gt;= 0.9.0'/>
+ <function name='ssh2_shell_resize' from='PECL ssh2 &gt;= 1.4'/>
  <function name='ssh2_tunnel' from='PECL ssh2 &gt;= 0.9.0'/>
 </versions>
 


### PR DESCRIPTION
Adds reference pages for five functions registered by the ssh2 extension that had no documentation, and registers them in `versions.xml`.

- `ssh2_keepalive_config`, `ssh2_keepalive_send` (PECL ssh2 >= 1.5.0)
- `ssh2_send_signal` (PECL ssh2 >= 1.5.0)
- `ssh2_set_timeout` (PECL ssh2 >= 1.5.0)
- `ssh2_shell_resize` (PECL ssh2 >= 1.4)

Signatures, parameter types, return values and libssh availability requirements were derived from the ssh2 1.5.0 C sources and `config.m4`; introduction versions from the extension changelog. Pages follow the style of the existing ssh2 function pages.