### PR TITLE
ext/standard: Document partitioned cookie option (8.5.0)

### DIFF
--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -157,7 +157,9 @@
       <simpara>
        An associative <type>array</type> which may have any of the keys
        <literal>expires</literal>, <literal>path</literal>, <literal>domain</literal>,
-       <literal>secure</literal>, <literal>httponly</literal> and <literal>samesite</literal>.
+       <literal>secure</literal>, <literal>httponly</literal>,
+       <literal>samesite</literal> and, as of PHP 8.5.0,
+       <literal>partitioned</literal>.
       </simpara>
       <simpara>
        The values have the same meaning as described for the
@@ -181,6 +183,15 @@
         If <literal>samesite</literal> is <literal>"None"</literal> then
         <literal>secure</literal> must also be enabled or the cookie will be
         blocked by the client.
+       </simpara>
+      </note>
+      <note>
+       <simpara>
+        As of PHP 8.5.0, the <literal>partitioned</literal> option marks the
+        cookie for partitioned storage using an independent partition per
+        top-level site (CHIPS). It must be used together with
+        <literal>secure</literal>; otherwise a
+        <exceptionname>ValueError</exceptionname> is thrown.
        </simpara>
       </note>
      </listitem>
@@ -229,6 +240,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The <parameter>options</parameter> array now supports the
+       <literal>partitioned</literal> key.
+      </entry>
+     </row>
      <row>
       <entry>8.2.0</entry>
       <entry>

--- a/reference/network/functions/setrawcookie.xml
+++ b/reference/network/functions/setrawcookie.xml
@@ -60,6 +60,13 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.5.0</entry>
+       <entry>
+        The <parameter>options</parameter> array now supports the
+        <literal>partitioned</literal> key.
+       </entry>
+      </row>
+      <row>
        <entry>7.3.0</entry>
        <entry>
         An alternative signature supporting an <parameter>options</parameter>


### PR DESCRIPTION
PHP 8.5.0 adds the `partitioned` key to the `options` array of `setcookie()` and `setrawcookie()` (CHIPS). The option requires `secure` to be set, or a `ValueError` is thrown.

Documents the new option and adds changelog entries to both function pages.