### PR TITLE
Document ReflectionProperty::getMangledName() (PHP 8.5)

### DIFF
--- a/reference/reflection/reflectionproperty/getmangledname.xml
+++ b/reference/reflection/reflectionproperty/getmangledname.xml
@@ -39,35 +39,31 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>8.5.0</entry>
-       <entry>
-        This method was introduced.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       This method was introduced.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>ReflectionProperty::getName</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>ReflectionProperty::getName</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/reflection/reflectionproperty/getmangledname.xml
+++ b/reference/reflection/reflectionproperty/getmangledname.xml
@@ -12,17 +12,17 @@
    <modifier>public</modifier> <type>string</type><methodname>ReflectionProperty::getMangledName</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Returns the mangled (internal) name of the property, which encodes the
    visibility scope for private and protected properties.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For public properties, the mangled name is identical to the property name.
    For protected properties, the mangled name has the form
    <literal>\0*\0<replaceable>name</replaceable></literal>.
    For private properties, the mangled name has the form
    <literal>\0<replaceable>ClassName</replaceable>\0<replaceable>name</replaceable></literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The mangled name of the reflected property.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/reflection/reflectionproperty/getmangledname.xml
+++ b/reference/reflection/reflectionproperty/getmangledname.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="reflectionproperty.getmangledname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionProperty::getMangledName</refname>
+  <refpurpose>Gets the mangled name of the property</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionProperty">
+   <modifier>public</modifier> <type>string</type><methodname>ReflectionProperty::getMangledName</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Returns the mangled (internal) name of the property, which encodes the
+   visibility scope for private and protected properties.
+  </para>
+  <para>
+   For public properties, the mangled name is identical to the property name.
+   For protected properties, the mangled name has the form
+   <literal>\0*\0<replaceable>name</replaceable></literal>.
+   For private properties, the mangled name has the form
+   <literal>\0<replaceable>ClassName</replaceable>\0<replaceable>name</replaceable></literal>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   The mangled name of the reflected property.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        This method was introduced.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionProperty::getName</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Adds the missing page for `ReflectionProperty::getMangledName()`, added in PHP 8.5, which returns the internal mangled property name encoding the visibility scope.