### PR TITLE
[skip-revcheck] Remove empty xi:fallback elements

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -106,7 +106,7 @@
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bc.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('bc.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.browscap">browscap</link></entry>
        <entry>&null;</entry>
@@ -161,12 +161,12 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('readline.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('features.commandline.ini.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('com.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('curl.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('datetime.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dba.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('readline.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('features.commandline.ini.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('com.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('curl.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('datetime.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dba.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.default-charset">default_charset</link></entry>
        <entry><literal>"UTF-8"</literal></entry>
@@ -295,14 +295,14 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exif.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exif.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.exit-on-timeout">exit_on_timeout</link></entry>
        <entry><literal>""</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('expect.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('expect.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.expose-php">expose_php</link></entry>
        <entry><literal>"1"</literal></entry>
@@ -339,15 +339,15 @@
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('filter.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('filter.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.from">from</link></entry>
        <entry><literal>""</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('image.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('geoip.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('image.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('geoip.configuration.list')/*)"/>
       <row>
        <entry>hard_timeout</entry>
        <entry><literal>"2"</literal></entry>
@@ -390,9 +390,9 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibase.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibm-db2.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iconv.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibase.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ibm-db2.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iconv.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.ignore-repeated-errors">ignore_repeated_errors</link></entry>
        <entry><literal>"0"</literal></entry>
@@ -423,14 +423,14 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('intl.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('intl.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.last-modified">last_modified</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ldap.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('ldap.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.log-errors">log_errors</link></entry>
        <entry><literal>"0"</literal></entry>
@@ -485,21 +485,21 @@
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mbstring.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mcrypt.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('memcache.ini.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mbstring.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mcrypt.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('memcache.ini.list')/*)"/>
       <row>
        <entry><link linkend="ini.memory-limit">memory_limit</link></entry>
        <entry><literal>"128M"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysql.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.config.options.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('oci8.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('odbc.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('opcache.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysql.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.config.options.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('oci8.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('odbc.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('opcache.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.open-basedir">open_basedir</link></entry>
        <entry>&null;</entry>
@@ -518,11 +518,11 @@
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pcre.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-odbc.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pgsql.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('phar.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pcre.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-odbc.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pgsql.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('phar.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.post-max-size">post_max_size</link></entry>
        <entry><literal>"8M"</literal></entry>
@@ -571,7 +571,7 @@
        <entry><constant>INI_PERDIR</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('runkit7.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('runkit7.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.sendmail-from">sendmail_from</link></entry>
        <entry>&null;</entry>
@@ -592,7 +592,7 @@
         Prior to PHP 7.1.0, the default value was <literal>17</literal>.
        </entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('session.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('session.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.short-open-tag">short_open_tag</link></entry>
        <entry><literal>"1"</literal></entry>
@@ -611,14 +611,14 @@
        <entry><constant>INI_ALL</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('soap.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('soap.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.sql.safe-mode">sql.safe_mode</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry>Removed as of PHP 7.2.0</entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sqlite3.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sqlite3.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.syslog.facility">syslog.facility</link></entry>
        <entry><literal>"LOG_USER"</literal></entry>
@@ -643,15 +643,15 @@
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sem.configuration.list')/*)"><xi:fallback/></xi:include>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('tidy.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('sem.configuration.list')/*)"/>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('tidy.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.track-errors">track_errors</link></entry>
        <entry><literal>"0"</literal></entry>
        <entry><constant>INI_ALL</constant></entry>
        <entry>Deprecated as of PHP 7.2.0, removed as of PHP 8.0.0</entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('unserialize.configuration.list')/*)"/>
       <row>
        <entry>uploadprogress.file.filename_template</entry>
        <entry><literal>"/tmp/upt_%s.txt"</literal></entry>
@@ -715,7 +715,7 @@
        <entry><constant>INI_SYSTEM</constant></entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('uopz.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('uopz.configuration.list')/*)"/>
       <row>
        <entry><link linkend="ini.variables-order">variables_order</link></entry>
        <entry><literal>"EGPCS"</literal></entry>
@@ -818,7 +818,7 @@
        <entry>&php.ini; only</entry>
        <entry></entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('zlib.configuration.list')/*)"><xi:fallback/></xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('zlib.configuration.list')/*)"/>
      </tbody>
     </tgroup>
    </table>

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -271,7 +271,7 @@ once libxml2 gets XInclude 1.1 attribute copying support.
 The below <xi:include> will include the appropriate elements
 but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
 
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"><xi:fallback/></xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"/>
 -->
     <title>INI mode constants</title>
     <varlistentry>

--- a/language/predefined/argumentcounterror.xml
+++ b/language/predefined/argumentcounterror.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/arithmeticerror.xml
+++ b/language/predefined/arithmeticerror.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -23,9 +23,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayAccess'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayAccess'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/assertionerror.xml
+++ b/language/predefined/assertionerror.xml
@@ -28,17 +28,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/attributes/allowdynamicproperties.xml
+++ b/language/predefined/attributes/allowdynamicproperties.xml
@@ -33,9 +33,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.allowdynamicproperties')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='AllowDynamicProperties'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.allowdynamicproperties')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='AllowDynamicProperties'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/attributes/attribute.xml
+++ b/language/predefined/attributes/attribute.xml
@@ -83,9 +83,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.attribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Attribute'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.attribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Attribute'])"/>
    </classsynopsis>
   </section>
 

--- a/language/predefined/attributes/deprecated.xml
+++ b/language/predefined/attributes/deprecated.xml
@@ -38,9 +38,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.deprecated')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Deprecated'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.deprecated')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Deprecated'])"/>
    </classsynopsis>
   </section>
 

--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -66,9 +66,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.nodiscard')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoDiscard'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.nodiscard')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoDiscard'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/attributes/override.xml
+++ b/language/predefined/attributes/override.xml
@@ -35,9 +35,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.override')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Override'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.override')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Override'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -42,9 +42,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.returntypewillchange')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReturnTypeWillChange'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.returntypewillchange')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReturnTypeWillChange'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/attributes/sensitiveparameter.xml
+++ b/language/predefined/attributes/sensitiveparameter.xml
@@ -25,9 +25,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SensitiveParameter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SensitiveParameter'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/backedenum.xml
+++ b/language/predefined/backedenum.xml
@@ -29,14 +29,10 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.backedenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BackedEnum'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.backedenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BackedEnum'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unitenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UnitEnum'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unitenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UnitEnum'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/closedgeneratorexception.xml
+++ b/language/predefined/closedgeneratorexception.xml
@@ -27,17 +27,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/closure.xml
+++ b/language/predefined/closure.xml
@@ -39,12 +39,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.closure')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Closure'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.closure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Closure'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.closure')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Closure'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.closure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Closure'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/compileerror.xml
+++ b/language/predefined/compileerror.xml
@@ -28,17 +28,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/countable.xml
+++ b/language/predefined/countable.xml
@@ -24,9 +24,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Countable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Countable'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/divisionbyzeroerror.xml
+++ b/language/predefined/divisionbyzeroerror.xml
@@ -28,17 +28,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/error.xml
+++ b/language/predefined/error.xml
@@ -70,12 +70,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
  
   </section>

--- a/language/predefined/errorexception.xml
+++ b/language/predefined/errorexception.xml
@@ -35,22 +35,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.errorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ErrorException'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.errorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ErrorException'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.errorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ErrorException'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.errorexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ErrorException'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
  
   </section>

--- a/language/predefined/exception.xml
+++ b/language/predefined/exception.xml
@@ -70,12 +70,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
  
   </section>

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -24,12 +24,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fiber')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Fiber'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fiber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Fiber'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fiber')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Fiber'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fiber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Fiber'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/fibererror.xml
+++ b/language/predefined/fibererror.xml
@@ -29,19 +29,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fibererror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FiberError'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fibererror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FiberError'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/generator.xml
+++ b/language/predefined/generator.xml
@@ -37,9 +37,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.generator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Generator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.generator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Generator'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/internaliterator.xml
+++ b/language/predefined/internaliterator.xml
@@ -28,12 +28,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.internaliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='InternalIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.internaliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='InternalIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.internaliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='InternalIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.internaliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='InternalIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -29,9 +29,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/iteratoraggregate.xml
+++ b/language/predefined/iteratoraggregate.xml
@@ -28,9 +28,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorAggregate'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorAggregate'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/parseerror.xml
+++ b/language/predefined/parseerror.xml
@@ -35,17 +35,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
  
   </section>

--- a/language/predefined/requestparsebodyexception.xml
+++ b/language/predefined/requestparsebodyexception.xml
@@ -29,17 +29,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/sensitiveparametervalue.xml
+++ b/language/predefined/sensitiveparametervalue.xml
@@ -36,12 +36,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparametervalue')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SensitiveParameterValue'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparametervalue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SensitiveParameterValue'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparametervalue')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SensitiveParameterValue'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sensitiveparametervalue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SensitiveParameterValue'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -40,9 +40,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Serializable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Serializable'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -32,9 +32,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/throwable.xml
+++ b/language/predefined/throwable.xml
@@ -37,14 +37,10 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.throwable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Throwable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.throwable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Throwable'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/typeerror.xml
+++ b/language/predefined/typeerror.xml
@@ -41,17 +41,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/unhandledmatcherror.xml
+++ b/language/predefined/unhandledmatcherror.xml
@@ -29,17 +29,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/unitenum.xml
+++ b/language/predefined/unitenum.xml
@@ -24,9 +24,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unitenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UnitEnum'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.unitenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UnitEnum'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/valueerror.xml
+++ b/language/predefined/valueerror.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/weakmap.xml
+++ b/language/predefined/weakmap.xml
@@ -47,9 +47,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakmap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakMap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakmap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakMap'])"/>
    </classsynopsis>
 
   </section>

--- a/language/predefined/weakreference.xml
+++ b/language/predefined/weakreference.xml
@@ -33,12 +33,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='WeakReference'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakReference'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='WeakReference'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakReference'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/apcu/apcuiterator.xml
+++ b/reference/apcu/apcuiterator.xml
@@ -42,12 +42,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/bc/bcmath.number.xml
+++ b/reference/bc/bcmath.number.xml
@@ -62,12 +62,8 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='BcMath\\Number'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BcMath\\Number'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='BcMath\\Number'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.bcmath-number')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='BcMath\\Number'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/com/com-exception.xml
+++ b/reference/com/com-exception.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/com/com.xml
+++ b/reference/com/com.xml
@@ -31,9 +31,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.com')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='com'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.com')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='com'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/com/compersisthelper.xml
+++ b/reference/com/compersisthelper.xml
@@ -29,12 +29,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.compersisthelper')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='COMPersistHelper'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.compersisthelper')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='COMPersistHelper'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.compersisthelper')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='COMPersistHelper'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.compersisthelper')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='COMPersistHelper'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/com/dotnet.xml
+++ b/reference/com/dotnet.xml
@@ -55,9 +55,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dotnet')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='dotnet'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dotnet')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='dotnet'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/com/variant.xml
+++ b/reference/com/variant.xml
@@ -27,9 +27,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.variant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='variant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.variant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='variant'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/curl/curlfile.xml
+++ b/reference/curl/curlfile.xml
@@ -51,12 +51,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CURLFile'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CURLFile'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CURLFile'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlfile')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CURLFile'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/curl/curlstringfile.xml
+++ b/reference/curl/curlstringfile.xml
@@ -44,9 +44,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlstringfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CURLStringFile'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.curlstringfile')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CURLStringFile'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateerror.xml
+++ b/reference/datetime/dateerror.xml
@@ -35,17 +35,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateexception.xml
+++ b/reference/datetime/dateexception.xml
@@ -40,17 +40,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -101,12 +101,8 @@
     </fieldsynopsis>
     
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateInterval'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateInterval'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateInterval'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateInterval'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/datetime/dateinvalidoperationexception.xml
+++ b/reference/datetime/dateinvalidoperationexception.xml
@@ -37,17 +37,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateinvalidtimezoneexception.xml
+++ b/reference/datetime/dateinvalidtimezoneexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/datemalformedintervalstringexception.xml
+++ b/reference/datetime/datemalformedintervalstringexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/datemalformedperiodstringexception.xml
+++ b/reference/datetime/datemalformedperiodstringexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/datemalformedstringexception.xml
+++ b/reference/datetime/datemalformedstringexception.xml
@@ -36,17 +36,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateobjecterror.xml
+++ b/reference/datetime/dateobjecterror.xml
@@ -35,17 +35,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/dateperiod.xml
+++ b/reference/datetime/dateperiod.xml
@@ -93,12 +93,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateperiod')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DatePeriod'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateperiod')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DatePeriod'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateperiod')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DatePeriod'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateperiod')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DatePeriod'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/daterangeerror.xml
+++ b/reference/datetime/daterangeerror.xml
@@ -32,17 +32,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/datetime/datetime.xml
+++ b/reference/datetime/datetime.xml
@@ -43,20 +43,12 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetime')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTime'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetime')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTime'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTime'])">
-    <xi:fallback/>
-   </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetime')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTime'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetime')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTime'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTime'])"/>
   </classsynopsis>
 
   </section>

--- a/reference/datetime/datetimeimmutable.xml
+++ b/reference/datetime/datetimeimmutable.xml
@@ -33,20 +33,12 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeimmutable')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTimeImmutable'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeimmutable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeImmutable'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeImmutable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeimmutable')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTimeImmutable'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeimmutable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeImmutable'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeImmutable'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -135,9 +135,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeInterface'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeInterface'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/datetime/datetimezone.xml
+++ b/reference/datetime/datetimezone.xml
@@ -112,12 +112,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTimeZone'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeZone'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateTimeZone'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.datetimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateTimeZone'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/dir/directory.xml
+++ b/reference/dir/directory.xml
@@ -42,9 +42,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directory')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Directory'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directory')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Directory'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/dom/dom/attr/isid.xml
+++ b/reference/dom/dom/attr/isid.xml
@@ -26,9 +26,7 @@
  </refsect1>
 
  <refsect1 role="returnvalues">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domattr.isid')/db:refsect1[@role='returnvalues']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domattr.isid')/db:refsect1[@role='returnvalues']/*)"/>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/dom/dom/dom-attr.xml
+++ b/reference/dom/dom/dom-attr.xml
@@ -31,9 +31,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -79,20 +77,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-attr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Attr'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-attr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Attr'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-cdatasection.xml
+++ b/reference/dom/dom/dom-cdatasection.xml
@@ -33,32 +33,18 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-characterdata.xml
+++ b/reference/dom/dom/dom-characterdata.xml
@@ -6,9 +6,7 @@
 
  <partintro>
   <section xml:id="dom-characterdata.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.intro')/*)"/>
    <simpara>
     This is the modern, spec-compliant equivalent of
     <classname>DOMCharacterData</classname>.
@@ -33,9 +31,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -63,20 +59,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -84,24 +74,16 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-characterdata.props.previouselementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.previouselementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.previouselementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-characterdata.props.nextelementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.nextelementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.nextelementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-characterdata.props.data">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.data')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.data')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-characterdata.props.length">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.length')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcharacterdata.props.length')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-childnode.xml
+++ b/reference/dom/dom/dom-childnode.xml
@@ -22,9 +22,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-childnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ChildNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-childnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ChildNode'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-comment.xml
+++ b/reference/dom/dom/dom-comment.xml
@@ -7,9 +7,7 @@
  <partintro>
 
   <section xml:id="dom-comment.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcomment.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domcomment.intro')/*)"/>
    <simpara>
     This is the modern, spec-compliant equivalent of
     <classname>DOMComment</classname>.
@@ -30,26 +28,16 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -7,9 +7,7 @@
  <partintro>
 
   <section xml:id="dom-document.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.intro')/*)"/>
    <simpara>
     This is the modern, spec-compliant equivalent of
     <classname>DOMDocument</classname>.
@@ -38,9 +36,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -128,21 +124,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -150,14 +140,10 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-document.props.implementation">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.implementation')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.implementation')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.doctype">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.doctype')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.doctype')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.url">
      <term><varname>URL</varname></term>
@@ -188,9 +174,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.documenturi">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.documenturi')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.documenturi')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.documentelement">
      <term><varname>documentElement</varname></term>
@@ -202,24 +186,16 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.firstelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.firstelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.firstelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.lastelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.lastelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.lastelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.childelementcount">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.children">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-document.props.body">
      <term><varname>body</varname></term>

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -37,9 +37,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -68,21 +66,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentFragment'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentFragment'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -90,24 +82,16 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-documentfragment.props.firstelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.firstelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.firstelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.lastelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.lastelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.lastelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.childelementcount">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.children">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-documenttype.xml
+++ b/reference/dom/dom/dom-documenttype.xml
@@ -35,9 +35,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -78,21 +76,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documenttype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentType'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-documenttype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DocumentType'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -100,19 +92,13 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-documenttype.props.publicid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.publicid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.publicid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documenttype.props.systemid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.systemid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.systemid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documenttype.props.name">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.name')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.name')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-documenttype.props.entities">
      <term><varname>entities</varname></term>
@@ -133,9 +119,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-documenttype.props.internalsubset">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.internalsubset')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumenttype.props.internalsubset')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-dtdnamednodemap.xml
+++ b/reference/dom/dom/dom-dtdnamednodemap.xml
@@ -41,9 +41,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-dtdnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DtdNamedNodeMap'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-dtdnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\DtdNamedNodeMap'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -40,9 +40,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -144,21 +142,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -190,9 +182,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.classname">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.classname')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.classname')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.classlist">
      <term><varname>classList</varname></term>
@@ -213,39 +203,25 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.id">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.id')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.id')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.firstelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.firstelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.firstelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.lastelementchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.lastelementchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.lastelementchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.childelementcount">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.childelementcount')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.childelementcount')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.previouselementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.previouselementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.previouselementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.nextelementsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.children">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.innerhtml">
      <term><varname>innerHTML</varname></term>

--- a/reference/dom/dom/dom-entity.xml
+++ b/reference/dom/dom/dom-entity.xml
@@ -6,9 +6,7 @@
 
  <partintro>
   <section xml:id="dom-entity.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.intro')/*)"/>
    <simpara>
     This is the modern, spec-compliant equivalent of
     <classname>DOMEntity</classname>.
@@ -28,9 +26,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -53,15 +49,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -69,19 +61,13 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-entity.props.publicid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.publicid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.publicid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-entity.props.systemid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.systemid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.systemid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-entity.props.notationname">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.notationname')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domentity.props.notationname')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-entityreference.xml
+++ b/reference/dom/dom/dom-entityreference.xml
@@ -28,20 +28,14 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmlcollection.xml
+++ b/reference/dom/dom/dom-htmlcollection.xml
@@ -40,9 +40,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmlcollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLCollection'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmlcollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLCollection'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmldocument.xml
+++ b/reference/dom/dom/dom-htmldocument.xml
@@ -28,31 +28,19 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLDocument'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-htmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\HTMLDocument'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-htmlelement.xml
+++ b/reference/dom/dom/dom-htmlelement.xml
@@ -27,26 +27,16 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])">
-     <xi:fallback/>
-    </xi:include>-->
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-element')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Element'])"/>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-implementation.xml
+++ b/reference/dom/dom/dom-implementation.xml
@@ -9,9 +9,7 @@
   <section xml:id="dom-implementation.intro">
    &reftitle.intro;
    <simpara>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domimplementation.intro.brief')/text())">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domimplementation.intro.brief')/text())"/>
    </simpara>
    <simpara>
     This is the modern, spec-compliant equivalent of
@@ -28,9 +26,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-implementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Implementation'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-implementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Implementation'])"/>-->
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-namednodemap.xml
+++ b/reference/dom/dom/dom-namednodemap.xml
@@ -40,9 +40,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NamedNodeMap'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NamedNodeMap'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-namespaceinfo.xml
+++ b/reference/dom/dom/dom-namespaceinfo.xml
@@ -40,9 +40,7 @@
     </fieldsynopsis>
 
     <!--<classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namespaceinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\NamespaceInfo'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-namespaceinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\NamespaceInfo'])"/>-->
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-node.xml
+++ b/reference/dom/dom/dom-node.xml
@@ -151,9 +151,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
 
   </section>
@@ -162,34 +160,22 @@
    &reftitle.constants;
    <variablelist>
     <varlistentry xml:id="dom-node.constants.document-position-disconnected">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-disconnected')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-disconnected')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-preceding">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-preceding')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-preceding')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-following">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-following')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-following')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-contains">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contains')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contains')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-contained-by">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contained-by')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-contained-by')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.constants.document-position-implementation-specific">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-implementation-specific')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.constants.document-position-implementation-specific')/*)"/>
     </varlistentry>
    </variablelist>
   </section>
@@ -198,9 +184,7 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-node.props.nodetype">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nodetype')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nodetype')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.nodename">
      <term><varname>nodeName</varname></term>
@@ -215,14 +199,10 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.baseuri">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.baseuri')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.baseuri')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.isconnected">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.isconnected')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.isconnected')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.ownerdocument">
      <term><varname>ownerDocument</varname></term>
@@ -234,14 +214,10 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.parentnode">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentnode')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentnode')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.parentelement">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentelement')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.parentelement')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.childnodes">
      <term><varname>childNodes</varname></term>
@@ -254,24 +230,16 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.firstchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.firstchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.firstchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.lastchild">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.lastchild')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.lastchild')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.previoussibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.previoussibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.previoussibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.nextsibling">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nextsibling')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.nextsibling')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.nodevalue">
      <term><varname>nodeValue</varname></term>
@@ -282,9 +250,7 @@
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-node.props.textcontent">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.textcontent')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnode.props.textcontent')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-nodelist.xml
+++ b/reference/dom/dom/dom-nodelist.xml
@@ -7,9 +7,7 @@
  <partintro>
 
   <section xml:id="dom-nodelist.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.intro')/*)"/>
    <simpara>
     This is the modern, spec-compliant equivalent of
     <classname>DOMNodeList</classname>.
@@ -42,9 +40,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-nodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NodeList'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-nodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\NodeList'])"/>-->
    </classsynopsis>
   </section>
 
@@ -52,9 +48,7 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-nodelist.props.length">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.props.length')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnodelist.props.length')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-notation.xml
+++ b/reference/dom/dom/dom-notation.xml
@@ -19,9 +19,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -38,15 +36,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -54,14 +48,10 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-notation.props.publicid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.publicid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.publicid')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-notation.props.systemid">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.systemid')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domnotation.props.systemid')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -30,9 +30,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/dom/dom/dom-processinginstruction.xml
+++ b/reference/dom/dom/dom-processinginstruction.xml
@@ -7,9 +7,7 @@
  <partintro>
 
   <section xml:id="dom-processinginstruction.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.intro')/*)"/>
    <simpara>
     This is the modern, spec-compliant equivalent of
     <classname>DOMProcessingInstruction</classname>.
@@ -30,9 +28,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -43,21 +39,13 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -65,9 +53,7 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-processinginstruction.props.target">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.props.target')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domprocessinginstruction.props.target')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-text.xml
+++ b/reference/dom/dom/dom-text.xml
@@ -32,9 +32,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -45,26 +43,16 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-text')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Text'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-characterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\CharacterData'])"/>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Node'])"/>-->
    </classsynopsis>
   </section>
 
@@ -72,9 +60,7 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-text.props.wholetext">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.props.wholetext')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domtext.props.wholetext')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/dom/dom-tokenlist.xml
+++ b/reference/dom/dom/dom-tokenlist.xml
@@ -45,9 +45,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\TokenList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-tokenlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\TokenList'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/dom/dom/dom-xmldocument.xml
+++ b/reference/dom/dom/dom-xmldocument.xml
@@ -28,9 +28,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -56,27 +54,17 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XMLDocument'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xmldocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XMLDocument'])"/>-->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\Document'])"/>-->
    </classsynopsis>
   </section>
 
@@ -92,19 +80,13 @@
    </note>
    <variablelist>
     <varlistentry xml:id="dom-xmldocument.props.xmlencoding">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlencoding')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlencoding')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-xmldocument.props.xmlstandalone">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlstandalone')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlstandalone')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-xmldocument.props.xmlversion">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlversion')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.xmlversion')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-xmldocument.props.formatoutput">
      <term><varname>formatOutput</varname></term>

--- a/reference/dom/dom/dom-xpath.xml
+++ b/reference/dom/dom/dom-xpath.xml
@@ -7,9 +7,7 @@
  <partintro>
 
   <section xml:id="dom-xpath.intro">
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.intro')/*)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.intro')/*)"/>
    <simpara>
     This is the modern, spec-compliant equivalent of
     <classname>DOMXPath</classname>.
@@ -40,12 +38,8 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <classsynopsisinfo role="comment">Not documented yet</classsynopsisinfo>
-    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\XPath'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XPath'])">
-     <xi:fallback/>
-    </xi:include>-->
+    <!--<xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Dom\\XPath'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-xpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\XPath'])"/>-->
    </classsynopsis>
   </section>
 
@@ -53,14 +47,10 @@
    &reftitle.properties;
    <variablelist>
     <varlistentry xml:id="dom-xpath.props.document">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.document')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.document')/*)"/>
     </varlistentry>
     <varlistentry xml:id="dom-xpath.props.registernodenamespaces">
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.registernodenamespaces')/*)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domxpath.props.registernodenamespaces')/*)"/>
     </varlistentry>
    </variablelist>
   </section>

--- a/reference/dom/domattr.xml
+++ b/reference/dom/domattr.xml
@@ -31,9 +31,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -67,22 +65,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMAttr'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMAttr'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMAttr'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domattr')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMAttr'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domcdatasection.xml
+++ b/reference/dom/domcdatasection.xml
@@ -33,36 +33,20 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcdatasection')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMCdataSection'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcdatasection')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMCdataSection'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMText'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMText'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/dom/domcharacterdata.xml
+++ b/reference/dom/domcharacterdata.xml
@@ -36,9 +36,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -66,19 +64,13 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domchildnode.xml
+++ b/reference/dom/domchildnode.xml
@@ -15,9 +15,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domchildnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMChildNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domchildnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMChildNode'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/dom/domcomment.xml
+++ b/reference/dom/domcomment.xml
@@ -31,30 +31,18 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcomment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMComment'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcomment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMComment'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -36,9 +36,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -162,22 +160,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMDocument'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMDocument'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMDocument'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocument')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMDocument'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domdocumentfragment.xml
+++ b/reference/dom/domdocumentfragment.xml
@@ -37,9 +37,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -62,22 +60,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMDocumentFragment'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMDocumentFragment'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMDocumentFragment'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domdocumentfragment')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMDocumentFragment'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/dom/domdocumenttype.xml
+++ b/reference/dom/domdocumenttype.xml
@@ -31,9 +31,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -74,14 +72,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domelement.xml
+++ b/reference/dom/domelement.xml
@@ -41,9 +41,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -100,22 +98,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMElement'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMElement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMElement'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMElement'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domentity.xml
+++ b/reference/dom/domentity.xml
@@ -30,9 +30,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -73,14 +71,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domentityreference.xml
+++ b/reference/dom/domentityreference.xml
@@ -40,24 +40,16 @@ Remove me once you perform substitutions
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domentityreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMEntityReference'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domentityreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMEntityReference'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domexception.xml
+++ b/reference/dom/domexception.xml
@@ -54,17 +54,11 @@ FIXME: Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domimplementation.xml
+++ b/reference/dom/domimplementation.xml
@@ -33,9 +33,7 @@ Remove me once you perform substitutions
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domimplementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMImplementation'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domimplementation')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMImplementation'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domnamednodemap.xml
+++ b/reference/dom/domnamednodemap.xml
@@ -50,9 +50,7 @@ Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNamedNodeMap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamednodemap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNamedNodeMap'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domnamespacenode.xml
+++ b/reference/dom/domnamespacenode.xml
@@ -86,9 +86,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamespacenode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNameSpaceNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnamespacenode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNameSpaceNode'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -176,9 +176,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -45,9 +45,7 @@ Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNodeList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnodelist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNodeList'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/dom/domnotation.xml
+++ b/reference/dom/domnotation.xml
@@ -41,9 +41,7 @@ Remove me once you perform substitutions
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -60,14 +58,10 @@ Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domparentnode.xml
+++ b/reference/dom/domparentnode.xml
@@ -15,9 +15,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domparentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMParentNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domparentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMParentNode'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/dom/domprocessinginstruction.xml
+++ b/reference/dom/domprocessinginstruction.xml
@@ -29,9 +29,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -47,19 +45,13 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domprocessinginstruction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMProcessingInstruction'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domprocessinginstruction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMProcessingInstruction'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domtext.xml
+++ b/reference/dom/domtext.xml
@@ -33,9 +33,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
@@ -46,28 +44,16 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMText'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMText'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMText'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domtext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMText'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domcharacterdata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMCharacterData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMNode'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/domxpath.xml
+++ b/reference/dom/domxpath.xml
@@ -44,12 +44,8 @@ Remove me once you perform substitutions
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMXPath'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMXPath'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DOMXPath'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.domxpath')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DOMXPath'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/dom/functions/dom-ns-import-simplexml.xml
+++ b/reference/dom/functions/dom-ns-import-simplexml.xml
@@ -24,9 +24,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.dom-import-simplexml')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.dom-import-simplexml')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/ds/ds.collection.xml
+++ b/reference/ds/ds.collection.xml
@@ -38,15 +38,9 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-collection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])"/>
 
    </classsynopsis>
 

--- a/reference/ds/ds.deque.xml
+++ b/reference/ds/ds.deque.xml
@@ -88,9 +88,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-deque')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-deque')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis)"/>
    </classsynopsis>
 
   </section>

--- a/reference/ds/ds.pair.xml
+++ b/reference/ds/ds.pair.xml
@@ -32,12 +32,8 @@
     </classsynopsisinfo>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-pair')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis)">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-pair')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-pair')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis)"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-pair')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])"/>
     </classsynopsis>
 
   </section>

--- a/reference/ds/ds.sequence.xml
+++ b/reference/ds/ds.sequence.xml
@@ -49,21 +49,11 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-sequence')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-collection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-collection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.countable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoraggregate')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural') and not(modifier='private')])"/>
 
    </classsynopsis>
 

--- a/reference/ds/ds.vector.xml
+++ b/reference/ds/ds.vector.xml
@@ -75,9 +75,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-vector')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-vector')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis)"/>
    </classsynopsis>
 
   </section>

--- a/reference/event/eventexception.xml
+++ b/reference/event/eventexception.xml
@@ -29,17 +29,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/fann/fannconnection.xml
+++ b/reference/fann/fannconnection.xml
@@ -48,12 +48,8 @@
 
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fannconnection')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fannconnection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fannconnection')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.fannconnection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/ffi/ffi.ctype.xml
+++ b/reference/ffi/ffi.ctype.xml
@@ -260,9 +260,7 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ffi-ctype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FFI\\CType'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ffi-ctype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FFI\\CType'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/ffi/ffi.exception.xml
+++ b/reference/ffi/ffi.exception.xml
@@ -34,17 +34,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/ffi/ffi.parserexception.xml
+++ b/reference/ffi/ffi.parserexception.xml
@@ -35,17 +35,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/ffi/ffi.xml
+++ b/reference/ffi/ffi.xml
@@ -53,9 +53,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ffi')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FFI'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ffi')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FFI'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/fileinfo/finfo.xml
+++ b/reference/fileinfo/finfo.xml
@@ -27,12 +27,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.finfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='finfo'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.finfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='finfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.finfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='finfo'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.finfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='finfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/filesystem/functions/fputcsv.xml
+++ b/reference/filesystem/functions/fputcsv.xml
@@ -43,15 +43,9 @@
       </para>
      </listitem>
     </varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)"/>
     <varlistentry>
      <term><parameter>eol</parameter></term>
      <listitem>
@@ -80,9 +74,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -96,9 +88,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>8.1.0</entry>
        <entry>

--- a/reference/filter/filter.filterexception.xml
+++ b/reference/filter/filter.filterexception.xml
@@ -28,17 +28,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/filter/filter.filterfailedexception.xml
+++ b/reference/filter/filter.filterfailedexception.xml
@@ -29,17 +29,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/filter/functions/filter-input-array.xml
+++ b/reference/filter/functions/filter-input-array.xml
@@ -40,12 +40,8 @@
      </warning>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='add_empty']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='add_empty']]]/.)"/>
   </variablelist>
  </refsect1>
 

--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -45,12 +45,8 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='filter']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='filter']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)"/>
   </variablelist>
  </refsect1>
 

--- a/reference/gearman/gearmanclient.xml
+++ b/reference/gearman/gearmanclient.xml
@@ -28,12 +28,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanClient'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanClient'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanClient'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanClient'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gearman/gearmanexception.xml
+++ b/reference/gearman/gearmanexception.xml
@@ -30,9 +30,7 @@
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <!-- GearmanException doesn't have any methods.
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])">
-     <xi:fallback />
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])"/>
     -->
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>

--- a/reference/gearman/gearmanjob.xml
+++ b/reference/gearman/gearmanjob.xml
@@ -26,9 +26,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanjob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanJob'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanjob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanJob'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gearman/gearmantask.xml
+++ b/reference/gearman/gearmantask.xml
@@ -26,12 +26,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmantask')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanTask'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmantask')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanTask'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmantask')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanTask'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmantask')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanTask'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gearman/gearmanworker.xml
+++ b/reference/gearman/gearmanworker.xml
@@ -26,12 +26,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanWorker'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanWorker'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GearmanWorker'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gearmanworker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GearmanWorker'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gender/gender.xml
+++ b/reference/gender/gender.xml
@@ -405,12 +405,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gender')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gmagick/gmagick.xml
+++ b/reference/gmagick/gmagick.xml
@@ -31,12 +31,8 @@
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagick')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagick')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagick')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagick')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gmagick/gmagickpixel.xml
+++ b/reference/gmagick/gmagickpixel.xml
@@ -32,12 +32,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagickpixel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagickpixel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagickpixel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmagickpixel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -33,12 +33,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GMP'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.gmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GMP'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/hash/hashcontext.xml
+++ b/reference/hash/hashcontext.xml
@@ -27,12 +27,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.hashcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='HashContext'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.hashcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='HashContext'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.hashcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='HashContext'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.hashcontext')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='HashContext'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/imagick/imagick.xml
+++ b/reference/imagick/imagick.xml
@@ -14,12 +14,8 @@
       <interfacename>Iterator</interfacename>
      </oointerface>
     </classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagick')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagick')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagick')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.imagick')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
   </section>
 

--- a/reference/intl/collator.xml
+++ b/reference/intl/collator.xml
@@ -172,12 +172,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.collator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Collator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.collator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Collator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.collator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Collator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.collator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Collator'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/dateformatter.xml
+++ b/reference/intl/dateformatter.xml
@@ -106,12 +106,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldateformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlDateFormatter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldateformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlDateFormatter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldateformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlDateFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldateformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlDateFormatter'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/intlbreakiterator.xml
+++ b/reference/intl/intlbreakiterator.xml
@@ -163,12 +163,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlBreakIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intlcalendar.xml
+++ b/reference/intl/intlcalendar.xml
@@ -262,12 +262,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlCalendar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCalendar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlCalendar'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCalendar'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intlchar.xml
+++ b/reference/intl/intlchar.xml
@@ -4028,9 +4028,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlchar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlChar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlchar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlChar'])"/>
    </classsynopsis>
 
    <section xml:id="intlchar.constants">

--- a/reference/intl/intlcodepointbreakiterator.xml
+++ b/reference/intl/intlcodepointbreakiterator.xml
@@ -32,19 +32,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcodepointbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCodePointBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcodepointbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCodePointBreakIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intldatepatterngenerator.xml
+++ b/reference/intl/intldatepatterngenerator.xml
@@ -25,12 +25,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlDatePatternGenerator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlDatePatternGenerator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlDatePatternGenerator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intldatepatterngenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlDatePatternGenerator'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/intlexception.xml
+++ b/reference/intl/intlexception.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intlgregoriancalendar.xml
+++ b/reference/intl/intlgregoriancalendar.xml
@@ -31,22 +31,14 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlgregoriancalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlGregorianCalendar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlgregoriancalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlGregorianCalendar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlgregoriancalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlGregorianCalendar'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlgregoriancalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlGregorianCalendar'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCalendar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlcalendar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlCalendar'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intliterator.xml
+++ b/reference/intl/intliterator.xml
@@ -45,9 +45,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intllistformatter.xml
+++ b/reference/intl/intllistformatter.xml
@@ -64,12 +64,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlListFormatter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlListFormatter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlListFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlListFormatter'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/intlpartsiterator.xml
+++ b/reference/intl/intlpartsiterator.xml
@@ -61,14 +61,10 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlpartsiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlPartsIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlpartsiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlPartsIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intlrulebasedbreakiterator.xml
+++ b/reference/intl/intlrulebasedbreakiterator.xml
@@ -37,22 +37,14 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlrulebasedbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlRuleBasedBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlrulebasedbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlRuleBasedBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlrulebasedbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlRuleBasedBreakIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlrulebasedbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlRuleBasedBreakIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intlbreakiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlBreakIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/intltimezone.xml
+++ b/reference/intl/intltimezone.xml
@@ -94,12 +94,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intltimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlTimeZone'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intltimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlTimeZone'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intltimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlTimeZone'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intltimezone')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlTimeZone'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -119,9 +119,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.locale')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Locale'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.locale')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Locale'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/messageformatter.xml
+++ b/reference/intl/messageformatter.xml
@@ -55,12 +55,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.messageformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MessageFormatter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.messageformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MessageFormatter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.messageformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MessageFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.messageformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MessageFormatter'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/normalizer.xml
+++ b/reference/intl/normalizer.xml
@@ -112,9 +112,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.normalizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Normalizer'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.normalizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Normalizer'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/numberformatter.xml
+++ b/reference/intl/numberformatter.xml
@@ -558,12 +558,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.numberformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NumberFormatter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.numberformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='NumberFormatter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.numberformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NumberFormatter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.numberformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='NumberFormatter'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/resourcebundle.xml
+++ b/reference/intl/resourcebundle.xml
@@ -53,12 +53,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.resourcebundle')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ResourceBundle'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.resourcebundle')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ResourceBundle'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.resourcebundle')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ResourceBundle'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.resourcebundle')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ResourceBundle'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/spoofchecker.xml
+++ b/reference/intl/spoofchecker.xml
@@ -150,12 +150,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Spoofchecker'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Spoofchecker'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Spoofchecker'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spoofchecker')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Spoofchecker'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/intl/transliterator.xml
+++ b/reference/intl/transliterator.xml
@@ -47,12 +47,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.transliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Transliterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.transliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Transliterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.transliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Transliterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.transliterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Transliterator'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/intl/uconverter.xml
+++ b/reference/intl/uconverter.xml
@@ -274,12 +274,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uconverter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='UConverter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uconverter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UConverter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uconverter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='UConverter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uconverter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='UConverter'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/json/jsonexception.xml
+++ b/reference/json/jsonexception.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/json/jsonserializable.xml
+++ b/reference/json/jsonserializable.xml
@@ -28,9 +28,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='JsonSerializable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.jsonserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='JsonSerializable'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/memcached/memcached.xml
+++ b/reference/memcached/memcached.xml
@@ -32,12 +32,8 @@
     </classsynopsisinfo>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.memcached')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Memcached'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.memcached')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Memcached'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.memcached')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Memcached'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.memcached')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Memcached'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/mysqli/mysqli.xml
+++ b/reference/mysqli/mysqli.xml
@@ -135,12 +135,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_result.xml
+++ b/reference/mysqli/mysqli_result.xml
@@ -61,12 +61,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-result')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_result'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-result')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_result'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-result')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_result'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-result')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_result'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_result/fetch-field-direct.xml
+++ b/reference/mysqli/mysqli_result/fetch-field-direct.xml
@@ -51,9 +51,7 @@
    if no field information for specified <parameter>index</parameter> is
    available.
   </para>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)"/>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli_result/fetch-field.xml
+++ b/reference/mysqli/mysqli_result/fetch-field.xml
@@ -41,9 +41,7 @@
    Returns an object which contains field definition information or &false;
    if no field information is available.
   </para>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)"/>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli_sql_exception.xml
+++ b/reference/mysqli/mysqli_sql_exception.xml
@@ -36,22 +36,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-sql-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_sql_exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-sql-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_sql_exception'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/mysqli/mysqli_stmt.xml
+++ b/reference/mysqli/mysqli_stmt.xml
@@ -86,12 +86,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_stmt'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_stmt'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_stmt'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_stmt'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_warning.xml
+++ b/reference/mysqli/mysqli_warning.xml
@@ -43,12 +43,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-warning')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_warning'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-warning')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_warning'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-warning')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='mysqli_warning'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mysqli-warning')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='mysqli_warning'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -171,9 +171,7 @@
       EOF can vary in size depending on the server version.
       Also, EOF can transport an error message.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -201,9 +199,7 @@
       (<literal>LOAD LOCAL INFILE</literal>, <literal>INSERT</literal>,
       <literal>UPDATE</literal>, <literal>SELECT</literal>, error message).
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -226,9 +222,7 @@
       The packet may also transport an error or an EOF packet in case of
       COM_LIST_FIELDS.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -254,9 +248,7 @@
       and <literal>rows_fetched_from_server_ps</literal>
       from <literal>bytes_received_rset_row_packet</literal>.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -278,9 +270,7 @@
       The packet may also transport an error.
       The packet size depends on the MySQL version.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -301,9 +291,7 @@
       Total size in bytes of MySQL Client Server protocol COM_CHANGE_USER packets.
       The packet may also transport an error or EOF.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.bytes-received-ok-packet')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -434,9 +422,7 @@ $res->close();
       The statistic will not be incremented if there is an error reading
       the result set header packet from the line.
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.result-set-queries')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.result-set-queries')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -465,9 +451,7 @@ $res->close();
       Number of queries that have generated a result set and did not use a good index.
       (See also the mysqld start option <literal>--log-slow-queries</literal>).
      </simpara>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.no-index-used')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.no-index-used')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 
@@ -604,9 +588,7 @@ $res->close();
       with unread data that have been silently flushed.
      </simpara>
 
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:note)">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqlnd.stats.statistics.flushed-normal-sets')/db:listitem/db:note)"/>
     </listitem>
    </varlistentry>
 

--- a/reference/oauth/oauth.xml
+++ b/reference/oauth/oauth.xml
@@ -47,12 +47,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.oauth')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.oauth')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.oauth')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.oauth')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/oci8/ocicollection.xml
+++ b/reference/oci8/ocicollection.xml
@@ -31,9 +31,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ocicollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OCICollection'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ocicollection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OCICollection'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/oci8/ocilob.xml
+++ b/reference/oci8/ocilob.xml
@@ -30,9 +30,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ocilob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OCILob'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ocilob')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OCILob'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -17,7 +17,7 @@
    is everything that PHP would display or send back to the browser.
    In practical terms, output is non-zero length data that is:
    <itemizedlist>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('outputcontrol.what-is-output')/*)"><xi:fallback/></xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('outputcontrol.what-is-output')/*)"/>
    </itemizedlist>
   </para>
   <note>

--- a/reference/parallel/parallel.channel.xml
+++ b/reference/parallel/parallel.channel.xml
@@ -66,24 +66,16 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">Anonymous Constructor</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='anonymous']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='anonymous']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Access</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='access']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='access']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Sharing</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='sharing']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='sharing']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Closing</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='close']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='close']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Constant for Infinitely Buffered</classsynopsisinfo>
     <fieldsynopsis>

--- a/reference/parallel/parallel.events.input.xml
+++ b/reference/parallel/parallel.events.input.xml
@@ -38,15 +38,9 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events-input')/db:refentry/db:refsect1[@audience='adding']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events-input')/db:refentry/db:refsect1[@audience='removing']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events-input')/db:refentry/db:refsect1[@audience='clearing']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events-input')/db:refentry/db:refsect1[@audience='adding']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events-input')/db:refentry/db:refsect1[@audience='removing']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events-input')/db:refentry/db:refsect1[@audience='clearing']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/parallel/parallel.events.xml
+++ b/reference/parallel/parallel.events.xml
@@ -35,24 +35,16 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">Input</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='input']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='input']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Targets</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='targets']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='targets']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Behaviour</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='behaviour']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='behaviour']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Polling</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='polling']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-events')/db:refentry/db:refsect1[@audience='polling']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/parallel/parallel.future.xml
+++ b/reference/parallel/parallel.future.xml
@@ -83,19 +83,13 @@ parent continues
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">Resolution</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-future')/db:refentry/db:refsect1[@audience='resolution']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-future')/db:refentry/db:refsect1[@audience='resolution']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">State</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-future')/db:refentry/db:refsect1[@audience='state']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-future')/db:refentry/db:refsect1[@audience='state']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Cancellation</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-future')/db:refentry/db:refsect1[@audience='cancellation']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-future')/db:refentry/db:refsect1[@audience='cancellation']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/parallel/parallel.runtime.xml
+++ b/reference/parallel/parallel.runtime.xml
@@ -54,19 +54,13 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">Create</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='create']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='create']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Execute</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='execute']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='execute']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Join</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='join']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-runtime')/db:refentry/db:refsect1[@audience='join']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/parallel/parallel.sync.xml
+++ b/reference/parallel/parallel.sync.xml
@@ -36,19 +36,13 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">Constructor</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-sync')/db:refentry/db:refsect1[@audience='construction']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-sync')/db:refentry/db:refsect1[@audience='construction']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Access</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-sync')/db:refentry/db:refsect1[@audience='access']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-sync')/db:refentry/db:refsect1[@audience='access']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
     <classsynopsisinfo role="comment">Synchronization</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-sync')/db:refentry/db:refsect1[@audience='synchronization']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-sync')/db:refentry/db:refsect1[@audience='synchronization']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/pdo/pdo.xml
+++ b/reference/pdo/pdo.xml
@@ -476,12 +476,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/pdo/pdo/connect.xml
+++ b/reference/pdo/pdo/connect.xml
@@ -21,9 +21,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)"/>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -34,9 +32,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo/pdoexception.xml
+++ b/reference/pdo/pdoexception.xml
@@ -43,17 +43,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;'] and (not(@xml:id) or @xml:id != 'class.exception..code')]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;'] and (not(@xml:id) or @xml:id != 'class.exception..code')]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/pdo/pdostatement.xml
+++ b/reference/pdo/pdostatement.xml
@@ -38,9 +38,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdostatement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDOStatement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdostatement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDOStatement'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -32,9 +32,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -81,12 +79,8 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_firebird/pdo-firebird.xml
+++ b/reference/pdo_firebird/pdo-firebird.xml
@@ -32,9 +32,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -87,17 +85,11 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-firebird')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Firebird'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-firebird')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Firebird'])"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_mysql/pdo-mysql.xml
+++ b/reference/pdo_mysql/pdo-mysql.xml
@@ -51,9 +51,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -172,17 +170,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-mysql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Mysql'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-mysql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Mysql'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
    </classsynopsis>
    <!-- }}} -->
 
@@ -239,9 +231,7 @@ foreach ($unbufferedResult as $row) {
        Allows restricting LOCAL DATA loading to files located in this
        designated directory.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-init-command">
@@ -251,9 +241,7 @@ foreach ($unbufferedResult as $row) {
        Command to execute when connecting to the MySQL server.
        Will automatically be re-executed when reconnecting.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-read-default-file">
@@ -310,9 +298,7 @@ foreach ($unbufferedResult as $row) {
        Return the number of found (matched) rows,
        not the number of changed rows.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ignore-space">
@@ -322,9 +308,7 @@ foreach ($unbufferedResult as $row) {
        Permit spaces after SQL function names.
        Makes all SQL functions names reserved words.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-max-buffer-size">
@@ -348,9 +332,7 @@ foreach ($unbufferedResult as $row) {
        <methodname>PDO::prepare</methodname> and
        <methodname>PDO::query</methodname> when set to &false;.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-server-public-key">
@@ -359,9 +341,7 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        <acronym>RSA</acronym> public key file used with the SHA-256 based authentication.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-key">
@@ -370,9 +350,7 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        The file path to the <acronym>SSL</acronym> key.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-cert">
@@ -381,9 +359,7 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        The file path to the <acronym>SSL</acronym> certificate.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-ca">
@@ -392,9 +368,7 @@ foreach ($unbufferedResult as $row) {
       <simpara>
        The file path to the <acronym>SSL</acronym> certificate authority.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-capath">
@@ -405,9 +379,7 @@ foreach ($unbufferedResult as $row) {
        <acronym>SSL</acronym> <acronym>CA</acronym> certificates,
        which are stored in <acronym>PEM</acronym> format.
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-cipher">
@@ -418,9 +390,7 @@ foreach ($unbufferedResult as $row) {
        <acronym>SSL</acronym> encryption, in a format understood by OpenSSL.
        For example: <literal>DHE-RSA-AES256-SHA:AES128-SHA</literal>
       </simpara>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-mysql.constants.attr-ssl-verify-server-cert">
@@ -434,9 +404,7 @@ foreach ($unbufferedResult as $row) {
         This option is available only with mysqlnd.
        </simpara>
       </note>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-mysql.constants.attr-local-infile')//db:note/.)"/>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/pdo_odbc/pdo-odbc.xml
+++ b/reference/pdo_odbc/pdo-odbc.xml
@@ -33,9 +33,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -70,12 +68,8 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -65,9 +65,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -114,17 +112,11 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-pgsql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Pgsql'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-pgsql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Pgsql'])"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
@@ -25,9 +25,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)"/>
    <varlistentry>
     <term><parameter>filename</parameter></term>
     <listitem>
@@ -36,15 +34,9 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='fields']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='fields']]]/.)"/>
   </variablelist>
  </refsect1>
 

--- a/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
@@ -22,15 +22,9 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)"/>
    <varlistentry>
     <term><parameter>fields</parameter></term>
     <listitem>

--- a/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
@@ -25,9 +25,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='tableName']]]/.)"/>
    <varlistentry>
     <term><parameter>filename</parameter></term>
     <listitem>
@@ -36,12 +34,8 @@
      </simpara>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.copyfromarray')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='nullAs']]]/.)"/>
    <varlistentry>
     <term><parameter>fields</parameter></term>
     <listitem>

--- a/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
@@ -19,9 +19,7 @@
    <function>fwrite</function> or <function>fgets</function> can be used
    to manipulate the contents of the stream.
   </simpara>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.lobcreate')/db:refsect1[@role='description']/db:note/.)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.lobcreate')/db:refsect1[@role='description']/db:note/.)"/>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
@@ -14,9 +14,7 @@
   <simpara>
    Deletes a large object from the database identified by OID.
   </simpara>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.lobcreate')/db:refsect1[@role='description']/db:note/.)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo-pgsql.lobcreate')/db:refsect1[@role='description']/db:note/.)"/>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -51,9 +51,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -100,17 +98,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-sqlite')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Sqlite'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-sqlite')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Sqlite'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/phar/Phar.xml
+++ b/reference/phar/Phar.xml
@@ -40,9 +40,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -127,29 +125,15 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Phar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Phar'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='Phar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Phar'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Phar'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phar')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='Phar'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/phar/PharData.xml
+++ b/reference/phar/PharData.xml
@@ -43,34 +43,18 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PharData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PharData'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='PharData'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PharData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PharData'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phardata')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='PharData'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/phar/PharException.xml
+++ b/reference/phar/PharException.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/phar/PharFileInfo.xml
+++ b/reference/phar/PharFileInfo.xml
@@ -31,20 +31,12 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PharFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PharFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='PharFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PharFileInfo'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PharFileInfo'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pharfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:destructorsynopsis[@role='PharFileInfo'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/pthreads/pool.xml
+++ b/reference/pthreads/pool.xml
@@ -56,12 +56,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pool')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pool')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pool')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pool')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/pthreads/volatile.xml
+++ b/reference/pthreads/volatile.xml
@@ -45,9 +45,7 @@
     </classsynopsisinfo>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.threaded')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.threaded')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 
   </section>

--- a/reference/random/random.brokenrandomengineerror.xml
+++ b/reference/random/random.brokenrandomengineerror.xml
@@ -32,17 +32,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.cryptosafeengine.xml
+++ b/reference/random/random.cryptosafeengine.xml
@@ -32,9 +32,7 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.mt19937.xml
+++ b/reference/random/random.engine.mt19937.xml
@@ -33,12 +33,8 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Mt19937'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Mt19937'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Mt19937'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-mt19937')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Mt19937'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.pcgoneseq128xslrr64.xml
+++ b/reference/random/random.engine.pcgoneseq128xslrr64.xml
@@ -34,12 +34,8 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-pcgoneseq128xslrr64')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\PcgOneseq128XslRr64'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.secure.xml
+++ b/reference/random/random.engine.secure.xml
@@ -42,9 +42,7 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-secure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Secure'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-secure')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Secure'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.xml
+++ b/reference/random/random.engine.xml
@@ -41,9 +41,7 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.engine.xoshiro256starstar.xml
+++ b/reference/random/random.engine.xoshiro256starstar.xml
@@ -33,12 +33,8 @@
      </oointerface>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-engine-xoshiro256starstar')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Engine\\Xoshiro256StarStar'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.randomerror.xml
+++ b/reference/random/random.randomerror.xml
@@ -32,17 +32,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.randomexception.xml
+++ b/reference/random/random.randomexception.xml
@@ -32,17 +32,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/random/random.randomizer.xml
+++ b/reference/random/random.randomizer.xml
@@ -36,12 +36,8 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Randomizer'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Randomizer'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Random\\Randomizer'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.random-randomizer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Random\\Randomizer'])"/>
     </classsynopsis>
    </packagesynopsis>
 <!-- }}} -->

--- a/reference/reflection/reflection.xml
+++ b/reference/reflection/reflection.xml
@@ -26,9 +26,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Reflection'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflection')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Reflection'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionattribute.xml
+++ b/reference/reflection/reflectionattribute.xml
@@ -47,12 +47,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionAttribute'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionAttribute'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionAttribute'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionAttribute'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionclass.xml
+++ b/reference/reflection/reflectionclass.xml
@@ -77,12 +77,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionClass'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionClass'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionclass/newlazyproxy.xml
+++ b/reference/reflection/reflectionclass/newlazyproxy.xml
@@ -66,9 +66,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost.parameters.options')/*)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost.parameters.options')/*)"/>
    </varlistentry>
   </variablelist>
  </refsect1>
@@ -84,9 +82,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost')/db:refsect1[@role='errors'])">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost')/db:refsect1[@role='errors'])"/>
 
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/reflection/reflectionclass/resetaslazyproxy.xml
+++ b/reference/reflection/reflectionclass/resetaslazyproxy.xml
@@ -48,9 +48,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost.parameters.options')/*)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost.parameters.options')/*)"/>
    </varlistentry>
   </variablelist>
  </refsect1>
@@ -62,9 +60,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost')/db:refsect1[@role='errors'])">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost')/db:refsect1[@role='errors'])"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectionclassconstant.xml
+++ b/reference/reflection/reflectionclassconstant.xml
@@ -70,12 +70,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionClassConstant'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionClassConstant'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionconstant.xml
+++ b/reference/reflection/reflectionconstant.xml
@@ -33,12 +33,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionConstant'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionConstant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionConstant'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionConstant'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/reflection/reflectionenum.xml
+++ b/reference/reflection/reflectionenum.xml
@@ -30,27 +30,17 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnum'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnum'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnum'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnum'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/reflection/reflectionenumbackedcase.xml
+++ b/reference/reflection/reflectionenumbackedcase.xml
@@ -30,30 +30,18 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumBackedCase'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumBackedCase'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumBackedCase'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumBackedCase'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionenumunitcase.xml
+++ b/reference/reflection/reflectionenumunitcase.xml
@@ -30,27 +30,17 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumUnitCase'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumUnitCase'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionexception.xml
+++ b/reference/reflection/reflectionexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionextension.xml
+++ b/reference/reflection/reflectionextension.xml
@@ -39,12 +39,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionextension')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionExtension'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionextension')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionExtension'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionextension')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionExtension'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionextension')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionExtension'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionfiber.xml
+++ b/reference/reflection/reflectionfiber.xml
@@ -25,12 +25,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfiber')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionFiber'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfiber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFiber'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfiber')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionFiber'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfiber')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFiber'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionfunction.xml
+++ b/reference/reflection/reflectionfunction.xml
@@ -40,22 +40,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionFunction'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunction')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunction'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionFunction'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunction')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunction'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/reflection/reflectionfunctionabstract.xml
+++ b/reference/reflection/reflectionfunctionabstract.xml
@@ -40,9 +40,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionfunctionabstract/getclosurescopeclass.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosurescopeclass.xml
@@ -34,9 +34,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionfunctionabstract.getclosurecalledclass')/db:refsect1[@role='examples']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionfunctionabstract.getclosurecalledclass')/db:refsect1[@role='examples']/.)"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectionfunctionabstract/getclosurethis.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosurethis.xml
@@ -33,9 +33,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionfunctionabstract.getclosurecalledclass')/db:refsect1[@role='examples']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionfunctionabstract.getclosurecalledclass')/db:refsect1[@role='examples']/.)"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/reflection/reflectiongenerator.xml
+++ b/reference/reflection/reflectiongenerator.xml
@@ -28,12 +28,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiongenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionGenerator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiongenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionGenerator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiongenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionGenerator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiongenerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionGenerator'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/reflection/reflectionintersectiontype.xml
+++ b/reference/reflection/reflectionintersectiontype.xml
@@ -30,14 +30,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionintersectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionIntersectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionintersectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionIntersectionType'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionmethod.xml
+++ b/reference/reflection/reflectionmethod.xml
@@ -77,22 +77,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionmethod')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionMethod'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionmethod')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionMethod'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionmethod')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionMethod'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionmethod')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionMethod'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionfunctionabstract')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionFunctionAbstract'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionnamedtype.xml
+++ b/reference/reflection/reflectionnamedtype.xml
@@ -31,14 +31,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionnamedtype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionNamedType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionnamedtype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionNamedType'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionobject.xml
+++ b/reference/reflection/reflectionobject.xml
@@ -32,24 +32,16 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionObject'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionparameter.xml
+++ b/reference/reflection/reflectionparameter.xml
@@ -46,12 +46,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionParameter'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionParameter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionParameter'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionparameter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionParameter'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionproperty.xml
+++ b/reference/reflection/reflectionproperty.xml
@@ -106,12 +106,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionproperty')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionProperty'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionproperty')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionProperty'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionproperty')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionProperty'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionproperty')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionProperty'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionreference.xml
+++ b/reference/reflection/reflectionreference.xml
@@ -28,12 +28,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionReference'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionReference'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionReference'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionReference'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectiontype.xml
+++ b/reference/reflection/reflectiontype.xml
@@ -36,9 +36,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/reflection/reflectionuniontype.xml
+++ b/reference/reflection/reflectionuniontype.xml
@@ -31,14 +31,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionuniontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionUnionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionuniontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionUnionType'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectiontype')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionType'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflectionzendextension.xml
+++ b/reference/reflection/reflectionzendextension.xml
@@ -39,12 +39,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionzendextension')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionZendExtension'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionzendextension')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionZendExtension'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionzendextension')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionZendExtension'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionzendextension')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionZendExtension'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/reflection/reflector.xml
+++ b/reference/reflection/reflector.xml
@@ -32,9 +32,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.stringable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Stringable'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/rrd/rrdcreator.xml
+++ b/reference/rrd/rrdcreator.xml
@@ -31,12 +31,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdcreator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdcreator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdcreator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdcreator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/rrd/rrdgraph.xml
+++ b/reference/rrd/rrdgraph.xml
@@ -32,12 +32,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdgraph')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdgraph')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdgraph')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdgraph')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/rrd/rrdupdater.xml
+++ b/reference/rrd/rrdupdater.xml
@@ -32,12 +32,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdupdater')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdupdater')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdupdater')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.rrdupdater')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/session/sessionhandler.xml
+++ b/reference/session/sessionhandler.xml
@@ -76,9 +76,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionhandler')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionHandler'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionhandler')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionHandler'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/session/sessionhandlerinterface.xml
+++ b/reference/session/sessionhandlerinterface.xml
@@ -33,9 +33,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionhandlerinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionHandlerInterface'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionhandlerinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionHandlerInterface'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/session/sessionidinterface.xml
+++ b/reference/session/sessionidinterface.xml
@@ -33,9 +33,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionidinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionIdInterface'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionidinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionIdInterface'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/session/sessionupdatetimestamphandlerinterface.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface.xml
@@ -33,9 +33,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionupdatetimestamphandlerinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionUpdateTimestampHandlerInterface'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sessionupdatetimestamphandlerinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SessionUpdateTimestampHandlerInterface'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/simdjson/simdjsonexception.xml
+++ b/reference/simdjson/simdjsonexception.xml
@@ -40,7 +40,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"><xi:fallback/></xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('exception.synopsis')/descendant::db:fieldsynopsis)"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/simdjson/simdjsonvalueerror.xml
+++ b/reference/simdjson/simdjsonvalueerror.xml
@@ -37,10 +37,10 @@
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('error.synopsis')/descendant::db:fieldsynopsis)"><xi:fallback/></xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('error.synopsis')/descendant::db:fieldsynopsis)"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"><xi:fallback/></xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 
    </classsynopsis>
 <!-- }}} -->

--- a/reference/simplexml/simplexmlelement.xml
+++ b/reference/simplexml/simplexmlelement.xml
@@ -38,12 +38,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/simplexml/simplexmliterator.xml
+++ b/reference/simplexml/simplexmliterator.xml
@@ -30,12 +30,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/snmp/snmp.xml
+++ b/reference/snmp/snmp.xml
@@ -142,12 +142,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.snmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SNMP'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.snmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SNMP'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.snmp')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SNMP'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.snmp')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SNMP'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/snmp/snmpexception.xml
+++ b/reference/snmp/snmpexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/soap/soapclient.xml
+++ b/reference/soap/soapclient.xml
@@ -244,12 +244,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapfault.xml
+++ b/reference/soap/soapfault.xml
@@ -80,22 +80,14 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapfault')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapFault'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapfault')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapFault'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapfault')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapFault'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapfault')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapFault'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapheader.xml
+++ b/reference/soap/soapheader.xml
@@ -54,9 +54,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapheader')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapHeader'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapheader')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapHeader'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapparam.xml
+++ b/reference/soap/soapparam.xml
@@ -38,9 +38,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapparam')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapParam'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapparam')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapParam'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapserver.xml
+++ b/reference/soap/soapserver.xml
@@ -36,12 +36,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapserver')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapServer'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapserver')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapServer'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapserver')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapServer'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapserver')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapServer'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/soap/soapvar.xml
+++ b/reference/soap/soapvar.xml
@@ -63,9 +63,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapvar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapVar'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapvar')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapVar'])"/>
    </classsynopsis>
 <!-- }}} -->
   </section>

--- a/reference/sodium/sodiumexception.xml
+++ b/reference/sodium/sodiumexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/solr/solrcollapsefunction.xml
+++ b/reference/solr/solrcollapsefunction.xml
@@ -52,9 +52,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.solrcollapsefunction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.solrcollapsefunction')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.solrcollapsefunction')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/spl/appenditerator.xml
+++ b/reference/spl/appenditerator.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.appenditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='AppendIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.appenditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='AppendIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.appenditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='AppendIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.appenditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='AppendIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/arrayiterator.xml
+++ b/reference/spl/arrayiterator.xml
@@ -64,12 +64,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -61,12 +61,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayObject'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/badfunctioncallexception.xml
+++ b/reference/spl/badfunctioncallexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/badmethodcallexception.xml
+++ b/reference/spl/badmethodcallexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/cachingiterator.xml
+++ b/reference/spl/cachingiterator.xml
@@ -81,17 +81,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CachingIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/callbackfilteriterator.xml
+++ b/reference/spl/callbackfilteriterator.xml
@@ -31,20 +31,12 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CallbackFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CallbackFilterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/directoryiterator.xml
+++ b/reference/spl/directoryiterator.xml
@@ -36,17 +36,11 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/domainexception.xml
+++ b/reference/spl/domainexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/emptyiterator.xml
+++ b/reference/spl/emptyiterator.xml
@@ -31,9 +31,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.emptyiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='EmptyIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.emptyiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='EmptyIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/filesystemiterator.xml
+++ b/reference/spl/filesystemiterator.xml
@@ -105,20 +105,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
    <!-- }}} -->
 

--- a/reference/spl/filteriterator.xml
+++ b/reference/spl/filteriterator.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/globiterator.xml
+++ b/reference/spl/globiterator.xml
@@ -37,28 +37,16 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.globiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GlobIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.globiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GlobIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.globiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='GlobIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.globiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='GlobIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/infiniteiterator.xml
+++ b/reference/spl/infiniteiterator.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.infiniteiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='InfiniteIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.infiniteiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='InfiniteIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.infiniteiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='InfiniteIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.infiniteiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='InfiniteIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/invalidargumentexception.xml
+++ b/reference/spl/invalidargumentexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/iteratoriterator.xml
+++ b/reference/spl/iteratoriterator.xml
@@ -33,12 +33,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IteratorIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/lengthexception.xml
+++ b/reference/spl/lengthexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/limititerator.xml
+++ b/reference/spl/limititerator.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.limititerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='LimitIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.limititerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='LimitIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.limititerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='LimitIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.limititerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='LimitIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/logicexception.xml
+++ b/reference/spl/logicexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/multipleiterator.xml
+++ b/reference/spl/multipleiterator.xml
@@ -57,12 +57,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MultipleIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MultipleIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MultipleIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MultipleIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/norewinditerator.xml
+++ b/reference/spl/norewinditerator.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.norewinditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoRewindIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.norewinditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='NoRewindIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.norewinditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='NoRewindIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.norewinditerator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='NoRewindIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/outeriterator.xml
+++ b/reference/spl/outeriterator.xml
@@ -32,14 +32,10 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.outeriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OuterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.outeriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='OuterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/outofboundsexception.xml
+++ b/reference/spl/outofboundsexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/outofrangeexception.xml
+++ b/reference/spl/outofrangeexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/overflowexception.xml
+++ b/reference/spl/overflowexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/parentiterator.xml
+++ b/reference/spl/parentiterator.xml
@@ -32,23 +32,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parentiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ParentIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parentiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ParentIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parentiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ParentIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parentiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ParentIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/rangeexception.xml
+++ b/reference/spl/rangeexception.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/recursivearrayiterator.xml
+++ b/reference/spl/recursivearrayiterator.xml
@@ -37,9 +37,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -50,17 +48,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivearrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivearrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveArrayIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/recursivecachingiterator.xml
+++ b/reference/spl/recursivecachingiterator.xml
@@ -35,25 +35,15 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveCachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveCachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveCachingIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveCachingIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/recursivecallbackfilteriterator.xml
+++ b/reference/spl/recursivecallbackfilteriterator.xml
@@ -36,23 +36,13 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecallbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveCallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecallbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveCallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecallbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveCallbackFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivecallbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveCallbackFilterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CallbackFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.callbackfilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CallbackFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/recursivedirectoryiterator.xml
+++ b/reference/spl/recursivedirectoryiterator.xml
@@ -36,28 +36,16 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveDirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveDirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivedirectoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveDirectoryIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/recursivefilteriterator.xml
+++ b/reference/spl/recursivefilteriterator.xml
@@ -39,20 +39,12 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveFilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveFilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivefilteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveFilterIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/recursiveiterator.xml
+++ b/reference/spl/recursiveiterator.xml
@@ -32,14 +32,10 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/recursiveiteratoriterator.xml
+++ b/reference/spl/recursiveiteratoriterator.xml
@@ -56,12 +56,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveIteratorIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/recursiveregexiterator.xml
+++ b/reference/spl/recursiveregexiterator.xml
@@ -35,33 +35,19 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveregexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveRegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveregexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveRegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveregexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveRegexIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveregexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveRegexIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/recursivetreeiterator.xml
+++ b/reference/spl/recursivetreeiterator.xml
@@ -31,9 +31,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -91,17 +89,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveTreeIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveTreeIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveTreeIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveTreeIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -82,20 +82,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RegexIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/runtimeexception.xml
+++ b/reference/spl/runtimeexception.xml
@@ -30,17 +30,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/seekableiterator.xml
+++ b/reference/spl/seekableiterator.xml
@@ -28,14 +28,10 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.seekableiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SeekableIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.seekableiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SeekableIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
 
   </section>

--- a/reference/spl/spldoublylinkedlist.xml
+++ b/reference/spl/spldoublylinkedlist.xml
@@ -68,9 +68,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splfileinfo.xml
+++ b/reference/spl/splfileinfo.xml
@@ -32,12 +32,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileInfo'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splfileobject.xml
+++ b/reference/spl/splfileobject.xml
@@ -66,17 +66,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -17,9 +17,7 @@
   <para>
    Gets a line from the file which is in <acronym>CSV</acronym> format and returns an array containing the fields read.
   </para>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)"/>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -86,9 +84,7 @@
   </note>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -102,9 +98,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/spl/splfileobject/fputcsv.xml
+++ b/reference/spl/splfileobject/fputcsv.xml
@@ -33,15 +33,9 @@
      </para>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('splfileobject.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)"/>
    <varlistentry>
     <term><parameter>eol</parameter></term>
     <listitem>
@@ -69,9 +63,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -85,9 +77,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>8.1.0</entry>
        <entry>

--- a/reference/spl/splfileobject/setcsvcontrol.xml
+++ b/reference/spl/splfileobject/setcsvcontrol.xml
@@ -23,15 +23,9 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-    <xi:fallback><varlistentry><term></term><listitem><simpara></simpara></listitem></varlistentry></xi:fallback>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)"/>
   </variablelist>
   &warning.csv.escape-parameter;
  </refsect1>
@@ -43,9 +37,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -59,9 +51,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -46,12 +46,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFixedArray'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFixedArray'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFixedArray'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFixedArray'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splheap.xml
+++ b/reference/spl/splheap.xml
@@ -35,9 +35,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splmaxheap.xml
+++ b/reference/spl/splmaxheap.xml
@@ -30,14 +30,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splmaxheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplMaxHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splmaxheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplMaxHeap'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splminheap.xml
+++ b/reference/spl/splminheap.xml
@@ -30,14 +30,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splminheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplMinHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splminheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplMinHeap'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splheap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplHeap'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splobjectstorage.xml
+++ b/reference/spl/splobjectstorage.xml
@@ -45,9 +45,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splobjectstorage')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplObjectStorage'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splobjectstorage')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplObjectStorage'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splobserver.xml
+++ b/reference/spl/splobserver.xml
@@ -27,9 +27,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splobserver')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplObserver'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splobserver')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplObserver'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/splpriorityqueue.xml
+++ b/reference/spl/splpriorityqueue.xml
@@ -61,9 +61,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splpriorityqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplPriorityQueue'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splpriorityqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplPriorityQueue'])"/>
    </classsynopsis>
  
   </section>

--- a/reference/spl/splqueue.xml
+++ b/reference/spl/splqueue.xml
@@ -31,19 +31,13 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplQueue'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplQueue'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/spl/splstack.xml
+++ b/reference/spl/splstack.xml
@@ -31,14 +31,10 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])"/>
    </classsynopsis>
   </section>
 

--- a/reference/spl/splsubject.xml
+++ b/reference/spl/splsubject.xml
@@ -27,9 +27,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splsubject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplSubject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splsubject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplSubject'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/spltempfileobject.xml
+++ b/reference/spl/spltempfileobject.xml
@@ -31,22 +31,14 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spltempfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplTempFileObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spltempfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplTempFileObject'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/spl/underflowexception.xml
+++ b/reference/spl/underflowexception.xml
@@ -31,17 +31,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/spl/unexpectedvalueexception.xml
+++ b/reference/spl/unexpectedvalueexception.xml
@@ -33,17 +33,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -249,12 +249,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/sqlite3/sqlite3exception.xml
+++ b/reference/sqlite3/sqlite3exception.xml
@@ -29,17 +29,11 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/sqlite3/sqlite3result.xml
+++ b/reference/sqlite3/sqlite3result.xml
@@ -25,12 +25,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3result')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Result'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3result')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Result'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3result')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Result'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3result')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Result'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/sqlite3/sqlite3stmt.xml
+++ b/reference/sqlite3/sqlite3stmt.xml
@@ -25,12 +25,8 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Stmt'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Stmt'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Stmt'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Stmt'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/stream/php-user-filter.xml
+++ b/reference/stream/php-user-filter.xml
@@ -50,9 +50,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.php-user-filter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='php_user_filter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.php-user-filter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='php_user_filter'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -21,9 +21,7 @@
    Parses a string input for fields in <acronym>CSV</acronym> format
    and returns an array containing the fields read.
   </para>
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='description']//db:note/.)"/>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,15 +36,9 @@
       </para>
      </listitem>
     </varlistentry>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='separator']]]/.)"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='enclosure']]]/.)"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='escape']]]/.)"/>
    </variablelist>
   </para>
   &warning.csv.escape-parameter;
@@ -59,9 +51,7 @@
   </para>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -75,9 +65,7 @@
       </row>
      </thead>
      <tbody>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.4.0']]/.)"/>
       <row>
        <entry>8.4.0</entry>
        <entry>
@@ -88,9 +76,7 @@
         <function>fputcsv</function>.
        </entry>
       </row>
-      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.3.0']]/.)">
-       <xi:fallback/>
-      </xi:include>
+      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.fgetcsv')/db:refsect1[@role='changelog']//db:row[db:entry[text()='8.3.0']]/.)"/>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/svm/svm.xml
+++ b/reference/svm/svm.xml
@@ -165,12 +165,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svm')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svm')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svm')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svm')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/svm/svmmodel.xml
+++ b/reference/svm/svmmodel.xml
@@ -33,12 +33,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.svmmodel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/tidy/tidy.xml
+++ b/reference/tidy/tidy.xml
@@ -39,12 +39,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidy')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='tidy'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidy')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='tidy'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidy')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='tidy'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidy')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='tidy'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/tidy/tidynode.xml
+++ b/reference/tidy/tidynode.xml
@@ -82,12 +82,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidynode')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='tidyNode'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidynode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='tidyNode'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidynode')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='tidyNode'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.tidynode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='tidyNode'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/tokenizer/phptoken.xml
+++ b/reference/tokenizer/phptoken.xml
@@ -56,12 +56,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phptoken')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PhpToken'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phptoken')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PhpToken'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phptoken')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PhpToken'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.phptoken')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PhpToken'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/uri/uri.invaliduriexception.xml
+++ b/reference/uri/uri.invaliduriexception.xml
@@ -28,17 +28,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.rfc3986.uri.xml
+++ b/reference/uri/uri.rfc3986.uri.xml
@@ -24,12 +24,8 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\Rfc3986\\Uri'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\Rfc3986\\Uri'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\Rfc3986\\Uri'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-rfc3986-uri')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\Rfc3986\\Uri'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.urierror.xml
+++ b/reference/uri/uri.urierror.xml
@@ -28,17 +28,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.uriexception.xml
+++ b/reference/uri/uri.uriexception.xml
@@ -28,17 +28,11 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.whatwg.invalidurlexception.xml
+++ b/reference/uri/uri.whatwg.invalidurlexception.xml
@@ -38,19 +38,13 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-invalidurlexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\InvalidUrlException'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-invalidurlexception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\InvalidUrlException'])"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.whatwg.url.xml
+++ b/reference/uri/uri.whatwg.url.xml
@@ -24,12 +24,8 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\Url'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\WhatWg\\Url'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\Url'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-url')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Uri\\WhatWg\\Url'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/uri/uri.whatwg.urlvalidationerror.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerror.xml
@@ -43,9 +43,7 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-urlvalidationerror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\UrlValidationError'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.uri-whatwg-urlvalidationerror')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Uri\\WhatWg\\UrlValidationError'])"/>
     </classsynopsis>
    </packagesynopsis>
   </section>

--- a/reference/v8js/v8js.xml
+++ b/reference/v8js/v8js.xml
@@ -55,12 +55,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.v8js')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/win32service/win32serviceexception.xml
+++ b/reference/win32service/win32serviceexception.xml
@@ -44,9 +44,7 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback />
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
 <!-- Comment this section out if the exception does not contain any methods -->
 <!--

--- a/reference/wkhtmltox/wkhtmltox/image/converter/construct.xml
+++ b/reference/wkhtmltox/wkhtmltox/image/converter/construct.xml
@@ -148,7 +148,7 @@
          </row>
          <xi:include xpointer="xpointer(
           id('wkhtmltox-pdf-object.construct..settings.load.username') |
-          id('wkhtmltox-pdf-object.construct..settings.load.username')/following-sibling::*)"><xi:fallback/></xi:include>
+          id('wkhtmltox-pdf-object.construct..settings.load.username')/following-sibling::*)"/>
         </tbody>
        </tgroup>
       </table>

--- a/reference/xlswriter/xlsx-kernel.xml
+++ b/reference/xlswriter/xlsx-kernel.xml
@@ -33,12 +33,8 @@
 <!-- }}} -->
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.vtiful-kernel-excel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.vtiful-kernel-excel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.vtiful-kernel-excel')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.vtiful-kernel-excel')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/xmldiff/xmldiff.base.xml
+++ b/reference/xmldiff/xmldiff.base.xml
@@ -33,12 +33,8 @@
 <!-- }}} -->
     
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmldiff-base')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmldiff-base')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmldiff-base')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmldiff-base')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/xmlreader/xmlreader.xml
+++ b/reference/xmlreader/xmlreader.xml
@@ -233,9 +233,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmlreader')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XMLReader'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmlreader')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XMLReader'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/xmlreader/xmlreader/fromstring.xml
+++ b/reference/xmlreader/xmlreader/fromstring.xml
@@ -20,9 +20,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlreader.xml')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlreader.xml')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/xmlreader/xmlreader/fromuri.xml
+++ b/reference/xmlreader/xmlreader/fromuri.xml
@@ -20,9 +20,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlreader.open')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlreader.open')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/xmlwriter/xmlwriter.xml
+++ b/reference/xmlwriter/xmlwriter.xml
@@ -26,9 +26,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmlwriter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XMLWriter'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xmlwriter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XMLWriter'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/xmlwriter/xmlwriter/touri.xml
+++ b/reference/xmlwriter/xmlwriter/touri.xml
@@ -17,9 +17,7 @@
  </refsect1>
 
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlwriter.openuri')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xmlwriter.openuri')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/xsl/xsltprocessor.xml
+++ b/reference/xsl/xsltprocessor.xml
@@ -50,9 +50,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xsltprocessor')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XSLTProcessor'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.xsltprocessor')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='XSLTProcessor'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/xsl/xsltprocessor/transformtoxml.xml
+++ b/reference/xsl/xsltprocessor/transformtoxml.xml
@@ -17,9 +17,7 @@
   </para>
  </refsect1>
  <refsect1 role="parameters">
-  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xsltprocessor.transformtodoc')/db:refsect1[@role='parameters']/*)">
-   <xi:fallback/>
-  </xi:include>
+  <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('xsltprocessor.transformtodoc')/db:refsect1[@role='parameters']/*)"/>
  </refsect1>
 
  <xi:include xpointer="domxpath.query..errors" />

--- a/reference/zip/ziparchive.xml
+++ b/reference/zip/ziparchive.xml
@@ -730,9 +730,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ziparchive')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ZipArchive'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ziparchive')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ZipArchive'])"/>
    </classsynopsis>
 <!-- }}} -->
 

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -38,12 +38,8 @@
  
 <!-- {{{ Class methods -->
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zookeeper')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zookeeper')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zookeeper')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zookeeper')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 <!-- }}} -->
 
 <!-- {{{ Class constants -->

--- a/reference/zookeeper/zookeeperconfig.xml
+++ b/reference/zookeeper/zookeeperconfig.xml
@@ -37,9 +37,7 @@
 
 <!-- {{{ Class methods -->
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zookeeperconfig')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
-     <xi:fallback />
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zookeeperconfig')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
 <!-- }}} -->
 
    </classsynopsis>


### PR DESCRIPTION
Removes empty `<xi:fallback/>` across doc-en, turning
`<xi:include ...><xi:fallback/></xi:include>` into `<xi:include .../>`.

An empty fallback replaces a failed XInclude with nothing, hiding the failure
from the reporting `configure.php` already gives.

The two `<xi:fallback>` inside example CDATA (dom `xinclude` /
`getElementsByTagNameNS`) are kept, they document the feature itself.

Related:
- php/doc-en#5700 fixes the broken Imagick xpointers this removal exposed
- php/doc-base#326 lets such failures be recovered instead of hard-failing

`[skip-revcheck]`: no translated content affected.