### PR TITLE
Built-in webserver: Clarify "not supported on Windows" note

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1732,7 +1732,7 @@ php >
    number of desired workers before starting the server.
   </simpara>
   <note>
-   <simpara>This feature is not supported on Windows.</simpara>
+   <simpara>Multiple workers are not supported on Windows.</simpara>
   </note>
   <note>
    <simpara>


### PR DESCRIPTION
Related: https://www.reddit.com/r/PHPhelp/comments/1v483w4/simple_alternative_to_wampserver/

Some users are seeing the "Not supported on Windows" note and thinking it applies to the webserver feature as a whole, rather than just multiple workers.