### PR TITLE
ext/session: Add PHP 8.4 deprecation notices for session directives

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -116,13 +116,13 @@
      <entry><link linkend="ini.session.use-only-cookies">session.use_only_cookies</link></entry>
      <entry>"1"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry></entry>
+     <entry>Disabling this setting is deprecated as of PHP 8.4.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.referer-check">session.referer_check</link></entry>
      <entry>""</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry></entry>
+     <entry>Setting a non-empty value is deprecated as of PHP 8.4.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.cache-limiter">session.cache_limiter</link></entry>
@@ -140,19 +140,25 @@
      <entry><link linkend="ini.session.use-trans-sid">session.use_trans_sid</link></entry>
      <entry>"0"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry></entry>
+     <entry>Enabling this setting is deprecated as of PHP 8.4.0.</entry>
     </row>
     <row>
      <entry><link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link></entry>
      <entry>"a=href,area=href,frame=src,form="</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry>Available as of PHP 7.1.0.</entry>
+     <entry>
+      Available as of PHP 7.1.0.
+      Changing this setting is deprecated as of PHP 8.4.0.
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link></entry>
      <entry><literal>$_SERVER['HTTP_HOST']</literal></entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry>Available as of PHP 7.1.0.</entry>
+     <entry>
+      Available as of PHP 7.1.0.
+      Setting a non-empty value is deprecated as of PHP 8.4.0.
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
@@ -456,6 +462,12 @@
      found, the embedded session id will be marked as invalid.
      Defaults to the empty string.
     </simpara>
+    <warning>
+     <simpara>
+      Setting <literal>session.referer_check</literal> to a non-empty value
+      is deprecated as of PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
 
@@ -570,6 +582,12 @@
      IDs in URLs.
      Defaults to <literal>1</literal> (enabled).
     </simpara>
+    <warning>
+     <simpara>
+      Disabling <literal>session.use_only_cookies</literal> is deprecated
+      as of PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
 
@@ -729,6 +747,12 @@
      sid support is enabled or not. Defaults to
      <literal>0</literal> (disabled).
     </simpara>
+    <warning>
+     <simpara>
+      Enabling <literal>session.use_trans_sid</literal> is deprecated
+      as of PHP 8.4.0.
+     </simpara>
+    </warning>
     <note>
      <simpara>
       URL based session management has additional security risks
@@ -758,12 +782,18 @@
      <literal>session.trans_sid_tags</literal> specifies which HTML tags
      are rewritten to include session id when transparent sid support
      is enabled. Defaults to
-     <literal>a=href,area=href,frame=src,input=src,form=</literal>
+     <literal>a=href,area=href,frame=src,form=</literal>
     </simpara>
     <simpara>
      <literal>form</literal> is special tag. <literal>&lt;input hidden="session_id" name="session_name"&gt;</literal>
      is added as form variable.
     </simpara>
+    <warning>
+     <simpara>
+      Changing <literal>session.trans_sid_tags</literal> from its default
+      value is deprecated as of PHP 8.4.0.
+     </simpara>
+    </warning>
     <note>
      <simpara>
       Before PHP 7.1.0, <link linkend="ini.url-rewriter.tags">url_rewriter.tags</link>
@@ -787,6 +817,12 @@
      Multiple hosts can be specified by ",", no space is allowed
      between hosts. e.g. <literal>php.net,wiki.php.net,bugs.php.net</literal>
     </simpara>
+    <warning>
+     <simpara>
+      Setting <literal>session.trans_sid_hosts</literal> to a non-empty
+      value is deprecated as of PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
 


### PR DESCRIPTION
Resolves the following issues:

https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826594
https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826601
https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826615
https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826643
https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826651