### PR TITLE
ext/pdo: PHP 8.4 changes across PDO, PDO_PGSQL and PDO_Firebird

### DIFF
--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -38,19 +38,14 @@
        One of the <literal>PDO::ATTR_*</literal> constants. The generic attributes that
        apply to database connections are as follows:
        <simplelist> 
-        <member><literal>PDO::ATTR_AUTOCOMMIT</literal></member>
         <member><literal>PDO::ATTR_CASE</literal></member>
-        <member><literal>PDO::ATTR_CLIENT_VERSION</literal></member>
-        <member><literal>PDO::ATTR_CONNECTION_STATUS</literal></member>
+        <member><literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal></member>
         <member><literal>PDO::ATTR_DRIVER_NAME</literal></member>
         <member><literal>PDO::ATTR_ERRMODE</literal></member>
         <member><literal>PDO::ATTR_ORACLE_NULLS</literal></member>
         <member><literal>PDO::ATTR_PERSISTENT</literal></member>
-        <member><literal>PDO::ATTR_PREFETCH</literal></member>
-        <member><literal>PDO::ATTR_SERVER_INFO</literal></member>
-        <member><literal>PDO::ATTR_SERVER_VERSION</literal></member>
+        <member><literal>PDO::ATTR_STATEMENT_CLASS</literal></member>
         <member><literal>PDO::ATTR_STRINGIFY_FETCHES</literal></member>
-        <member><literal>PDO::ATTR_TIMEOUT</literal></member>
        </simplelist> 
       </para>
       <simpara>

--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -49,6 +49,7 @@
         <member><literal>PDO::ATTR_PREFETCH</literal></member>
         <member><literal>PDO::ATTR_SERVER_INFO</literal></member>
         <member><literal>PDO::ATTR_SERVER_VERSION</literal></member>
+        <member><literal>PDO::ATTR_STRINGIFY_FETCHES</literal></member>
         <member><literal>PDO::ATTR_TIMEOUT</literal></member>
        </simplelist> 
       </para>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -56,12 +56,12 @@
   </para>
   <note>
    <simpara>
-    The parser used for emulated prepared statements and for
-    rewriting named or question mark style parameters supports the non standard
-    backslash escapes for single- and double quotes. That means that terminating
-    quotes immediately preceded by a backslash are not recognized as such, which
-    may result in wrong detection of parameters causing the prepared statement to
-    fail when it is executed. A work-around is to not use emulated prepares for
+    Before PHP 8.4.0, the parser used for emulated prepared statements and for
+    rewriting named or question mark style parameters supported the non standard
+    backslash escapes for single- and double quotes. That meant that terminating
+    quotes immediately preceded by a backslash were not recognized as such, which
+    could result in wrong detection of parameters causing the prepared statement to
+    fail when it was executed. A work-around was to not use emulated prepares for
     such SQL queries, and to avoid rewriting of parameters by using a parameter style
     which is natively supported by the driver.
    </simpara>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -71,6 +71,15 @@
     the <literal>??</literal> string will be translated to <literal>?</literal>
     when sending the query to the database.
   </para>
+  <simpara>
+   As of PHP 8.4.0, PDO uses driver-specific SQL parsers to locate parameter
+   markers, so that markers appearing inside string literals or comments are
+   not mistaken for placeholders. The default parser recognizes single- and
+   double-quoted string literals (with doubling as the escaping mechanism), as
+   well as two-dashes and non-nested C-style comments. Individual drivers may
+   provide a parser that recognizes additional syntax; refer to the
+   driver-specific documentation for details.
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -77,7 +77,7 @@
    not mistaken for placeholders. The default parser recognizes single- and
    double-quoted string literals, as
    well as two-dashes and non-nested C-style comments. Individual drivers may
-   provide a parser that recognizes additional syntax; refer to the
+   provide a parser that recognizes additional or different syntax; refer to the
    driver-specific documentation for details.
   </simpara>
  </refsect1>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -75,7 +75,7 @@
    As of PHP 8.4.0, PDO uses driver-specific SQL parsers to locate parameter
    markers, so that markers appearing inside string literals or comments are
    not mistaken for placeholders. The default parser recognizes single- and
-   double-quoted string literals (with doubling as the escaping mechanism), as
+   double-quoted string literals, as
    well as two-dashes and non-nested C-style comments. Individual drivers may
    provide a parser that recognizes additional syntax; refer to the
    driver-specific documentation for details.

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -24,6 +24,13 @@
       Get the name of the cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
      </simpara>
     </listitem>
+    <listitem>
+     <simpara>
+      <constant>Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</constant>
+      (PostgreSQL specific, available as of PHP 8.4.0):
+      Get the amount of memory, in bytes, allocated to the query result.
+     </simpara>
+    </listitem>
    </itemizedlist>
    Note that driver specific attributes <emphasis>must not</emphasis> be used
    with other drivers.

--- a/reference/pdo_firebird/configure.xml
+++ b/reference/pdo_firebird/configure.xml
@@ -12,6 +12,11 @@ $ ./configure --with-pdo-firebird
 ]]>
   </screen>
  </para>
+ <simpara>
+  As of PHP 8.4.0, this extension uses some Firebird C++ APIs and therefore
+  requires a C++ compiler to be built, and must be built against fbclient 3.0
+  or higher.
+ </simpara>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_firebird/configure.xml
+++ b/reference/pdo_firebird/configure.xml
@@ -13,7 +13,7 @@ $ ./configure --with-pdo-firebird
   </screen>
  </para>
  <simpara>
-  As of PHP 8.4.0, this extension uses some Firebird C++ APIs and therefore
+  As of PHP 8.4.0, this extension uses Firebird C++ APIs and therefore
   requires a C++ compiler, and must be built against fbclient 3.0
   or higher.
  </simpara>

--- a/reference/pdo_firebird/configure.xml
+++ b/reference/pdo_firebird/configure.xml
@@ -14,7 +14,7 @@ $ ./configure --with-pdo-firebird
  </para>
  <simpara>
   As of PHP 8.4.0, this extension uses some Firebird C++ APIs and therefore
-  requires a C++ compiler to be built, and must be built against fbclient 3.0
+  requires a C++ compiler, and must be built against fbclient 3.0
   or higher.
  </simpara>
 </section>

--- a/reference/pdo_pgsql/configure.xml
+++ b/reference/pdo_pgsql/configure.xml
@@ -12,6 +12,10 @@ $ ./configure --with-pdo-pgsql
 ]]>
   </screen>
  </para>
+ <simpara>
+  This extension requires libpq (the PostgreSQL C client library).
+  As of PHP 8.4.0, libpq 10.0 or later is required.
+ </simpara>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -44,6 +44,14 @@
      </listitem>
     </itemizedlist>
    </para>
+   <note>
+    <simpara>
+     Because this parser recognizes dollar-quoted string literals, question
+     marks inside them are not treated as parameter placeholders and do not
+     need to be escaped. As of PHP 8.4.0, escaping question marks as
+     <literal>??</literal> inside a dollar-quoted string is deprecated.
+    </simpara>
+   </note>
   </section>
   <!-- }}} -->
 

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -121,6 +121,15 @@
      </variablelist>
      <note>
       <simpara>
+       As of PHP 8.4.0, credentials specified in the DSN
+       (<literal>user</literal> and <literal>password</literal>) take priority
+       over the corresponding arguments passed to the
+       <classname>PDO</classname> constructor. In earlier versions, the
+       PDO constructor arguments took precedence.
+      </simpara>
+     </note>
+     <note>
+      <simpara>
        All semicolons in the DSN string are replaced by spaces, because PostgreSQL
        expects this format. This implies that semicolons in any of the components
        (e.g. <literal>password</literal> or <literal>dbname</literal>) are not


### PR DESCRIPTION
Documents the PHP 8.4 changes across the PDO family.

PDO core
- Default SQL parser that recognises quoted literals and comments.
- PDO::ATTR_STRINGIFY_FETCHES is now retrievable via PDO::getAttribute().
- Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE is now retrievable via PDOStatement::getAttribute().

PDO_PGSQL
- Requires libpq 10.0+.
- DSN credentials now take priority over constructor arguments.
- Using ?? inside a dollar-quoted string is deprecated.

PDO_Firebird
- Now requires a C++ compiler and fbclient 3.0+ to build.

Sources
- PDO::ATTR_STRINGIFY_FETCHES retrievable via PDO::getAttribute(): https://github.com/php/php-src/commit/866aa12bcd31348a9e230303ce19f2383cadf71c
- PDO_PGSQL DSN credentials take priority over constructor arguments: https://github.com/php/php-src/commit/b5c287e4b4c4dd225efeed7012a718a631bcccea
- PDO_PGSQL ?? inside dollar-quoted strings deprecated: https://github.com/php/php-src/commit/53d7c1747421c1ccd85ca46fcac0c9a62113985a