### PR TITLE
Fix intl_get_error_message() example

### DIFF
--- a/reference/intl/functions/intl-get-error-message.xml
+++ b/reference/intl/functions/intl-get-error-message.xml
@@ -31,20 +31,30 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>intl_get_error_message</function> example</title>
-    <programlisting role="php">
+  <example>
+   <title><function>intl_get_error_message</function> example</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
-if( Collator::getAvailableLocales() === false ) {
-    show_error( intl_get_error_message() );
+
+$bundle = resourcebundle_create('en_US', __DIR__ . '/does-not-exist', false);
+
+if ($bundle === null) {
+    $errorCode = intl_get_error_code();
+
+    printf("Error name: %s\n", intl_error_name($errorCode));
+    printf("Error message: %s\n", intl_get_error_message());
 }
-?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
+  &example.outputs;
+  <screen>
+<![CDATA[
+Error name: U_MISSING_RESOURCE_ERROR
+Error message: resourcebundle_create(): Cannot load libICU resource bundle: U_MISSING_RESOURCE_ERROR
+]]>
+  </screen>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Applied the exact example as provided in #5558. Closes #5558