### PR TITLE
Add note that mssql_query() example uses a removed extension

### DIFF
--- a/security/database.xml
+++ b/security/database.xml
@@ -331,6 +331,16 @@ $result = mssql_query($query);
      account with which to access this machine.
     </para>
     <note>
+     <simpara>
+      The <function>mssql_query</function> function belonged to the
+      <literal>mssql</literal> extension, which was
+      <link linkend="migration70.removed-exts-sapis">removed in PHP 7.0.0</link>.
+      It is used here only to illustrate the attack; current code connecting
+      to MSSQL Server should use the <link linkend="book.sqlsrv">sqlsrv</link> or
+      <link linkend="ref.pdo-sqlsrv">pdo_sqlsrv</link> extensions instead.
+     </simpara>
+    </note>
+    <note>
      <para>
       Some examples above are tied to a specific database server, but it
       does not mean that a similar attack is impossible against other products.


### PR DESCRIPTION
I noticed that the example uses a long-gone extension, but I don't want to rewrite it now, so I just ask Claude to write a note. In future, it should probably be rewritten to avoid using extensions that no longer exist. 