### PR TITLE
Bulk PDO and mysqli grammar fixes

### DIFF
--- a/appendices/migration72/new-features.xml
+++ b/appendices/migration72/new-features.xml
@@ -156,13 +156,13 @@ $db->quote('über', PDO::PARAM_STR | PDO::PARAM_STR_NATL);
  <sect2 xml:id="migration72.new-features.additional-emulated-prepares-debugging-info">
   <title>Additional emulated prepares debugging information for <link linkend="book.pdo">PDO</link></title>
 
-  <para>
+  <simpara>
    The <function>PDOStatement::debugDumpParams</function> method has been
    updated to include the SQL being sent to the DB, where the full, raw query
-   (including the replaced placeholders with their bounded values) will be
+   (including the replaced placeholders with their bound values) will be
    shown. This has been added to aid with debugging emulated prepares (and so
    it will only be available when emulated prepares are turned on).
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration72.new-features.extended-ops-in-ldap">

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -266,7 +266,7 @@
     <function>mysqli_fetch_object</function> now raises a
     <classname>ValueError</classname> instead of an <classname>Exception</classname>
     when the <parameter>constructor_args</parameter> argument is non empty with
-    the class not having constructor.
+    the class not having a constructor.
    </simpara>
 
    <simpara>
@@ -300,7 +300,7 @@
     <function>pg_fetch_object</function> now raises a
     <classname>ValueError</classname> instead of an <classname>Exception</classname>
     when the <parameter>constructor_args</parameter> argument is non empty with
-    the class not having constructor.
+    the class not having a constructor.
    </simpara>
 
    <para>

--- a/reference/mysqli/book.xml
+++ b/reference/mysqli/book.xml
@@ -29,10 +29,10 @@
    xlink:href="&url.mysql.docs;">&url.mysql.docs;</link>.
   </para>
 
-  <para>
-   Parts of this documentation included from MySQL manual with
-   permissions of Oracle Corporation.
-  </para>
+  <simpara>
+   Parts of this documentation were included from the MySQL manual with
+   permission of Oracle Corporation.
+  </simpara>
   
   <para>
    Examples use either the <link xlink:href="&url.mysql.example;">world</link>

--- a/reference/mysqli/configure.xml
+++ b/reference/mysqli/configure.xml
@@ -35,14 +35,15 @@
    as your choice of client library for each extension.
   </para>
 
-  <para>
-   The MySQL Native Driver is the recommended client library option, as it
+  <simpara>
+   The MySQL Native Driver is the recommended client library option,
+   and as of PHP 8.2.0 the only option, as it
    results in improved performance and gives access to features not
    available when using the MySQL Client Library. Refer to
    <link linkend="mysqli.overview.mysqlnd">What is PHP's MySQL Native
    Driver?</link> for a brief overview of the advantages of MySQL Native
    Driver.
-  </para>
+  </simpara>
 
   <para>
    The <literal>/path/to/mysql_config</literal> represents the location of
@@ -64,7 +65,14 @@
     </thead>
     <tbody>
      <row>
-      <entry>5.4.x and above</entry>
+      <entry>8.2.0 and later</entry>
+      <entry>mysqlnd</entry>
+      <entry><option role="configure">--with-mysqli</option></entry>
+      <entry>libmysqlclient is not supported</entry>
+      <entry>mysqlnd is the only option</entry>
+     </row>
+     <row>
+      <entry>5.4.0 through 8.1.x</entry>
       <entry>mysqlnd</entry>
       <entry><option role="configure">--with-mysqli</option></entry>
       <entry><option role="configure">--with-mysqli=/path/to/mysql_config</option></entry>
@@ -87,15 +95,6 @@
     </tbody>
    </tgroup>
   </table>
-
-  <para>
-   Note that it is possible to freely mix MySQL extensions and client
-   libraries. For example, it is possible to enable the MySQL extension
-   to use the MySQL Client Library (libmysqlclient), while configuring the
-   <literal>mysqli</literal> extension to use the MySQL Native Driver.
-   However, all permutations of extension and client library are
-   possible.
-  </para>
 
  </section>
 

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -448,9 +448,9 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-      Field is part of an multi-index.
-     </para>
+     <simpara>
+      Field is part of a multi-index.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.mysqli-group-flag">

--- a/reference/mysqli/ini.xml
+++ b/reference/mysqli/ini.xml
@@ -147,10 +147,10 @@
     <type>int</type>
    </term>
    <listitem>
-    <para>
-     Maximum of persistent connections that can be made. Set to 
+    <simpara>
+     The maximum number of persistent connections that can be made. Set to
      0 for unlimited.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="ini.mysqli.max-links">
@@ -159,9 +159,9 @@
     <type>int</type>
    </term>
    <listitem>
-    <para>
-     The maximum number of MySQL connections per process.
-    </para>
+    <simpara>
+     The maximum number of connections per process.
+    </simpara>
    </listitem>
   </varlistentry>
    <varlistentry xml:id="ini.mysqli.default-port">

--- a/reference/mysqli/mysqli/change-user.xml
+++ b/reference/mysqli/mysqli/change-user.xml
@@ -31,12 +31,12 @@
    In comparison to <methodname>mysqli::connect</methodname>, this method will
    not disconnect the current connection if the new connection cannot be opened.
   </para>
-  <para>
-   In order to successfully change users a valid <parameter>username</parameter> and
-   <parameter>password</parameter> parameters must be provided and that user must have
+  <simpara>
+   In order to successfully change users, a valid <parameter>username</parameter> and
+   <parameter>password</parameter> must be provided, and that user must have
    sufficient permissions to access the desired database. If for any reason authorization
    fails, the current user authentication will remain.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -172,13 +172,13 @@ Default database:
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Using this command will always cause the current database connection to
-    behave as if was a completely new database connection, regardless of if
+    behave as if it was a completely new database connection, regardless of if
     the operation was completed successfully. This reset includes performing
     a rollback on any active transactions, closing all temporary tables, and
     unlocking all locked tables.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/dump-debug-info.xml
+++ b/reference/mysqli/mysqli/dump-debug-info.xml
@@ -19,11 +19,11 @@
    <type>bool</type><methodname>mysqli_dump_debug_info</methodname>
    <methodparam><type>mysqli</type><parameter>mysql</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   This function is designed to be executed by an user with the SUPER
+  <simpara>
+   This function is designed to be executed by a user with the SUPER
    privilege and is used to dump debugging information into the log for the
    MySQL Server relating to the connection.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/errno.xml
+++ b/reference/mysqli/mysqli/errno.xml
@@ -33,10 +33,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   An error code value for the last call, if it failed. zero means no error
-   occurred.
-  </para>
+  <simpara>
+   An error code value for the last call, if it failed.
+   <literal>0</literal> means no error occurred.
+  </simpara>
  </refsect1>
  
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli/init.xml
+++ b/reference/mysqli/mysqli/init.xml
@@ -25,11 +25,11 @@
    <function>mysqli_options</function> and <function>mysqli_real_connect</function>.
   </para>
   <note>
-   <para>
-    Any subsequent calls to any mysqli function (except <function>mysqli_options</function>
+   <simpara>
+    Any subsequent call to any mysqli function (except <function>mysqli_options</function>
     and <function>mysqli_ssl_set</function>)
-    will fail until <function>mysqli_real_connect</function> was called.
-   </para>
+    will fail until <function>mysqli_real_connect</function> is called.
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/multi-query.xml
+++ b/reference/mysqli/mysqli/multi-query.xml
@@ -28,7 +28,7 @@
    Queries are sent in a single call to the database and processed sequentially.
    <methodname>mysqli_multi_query</methodname> waits for the first query to
    complete before returning control to PHP. In the meantime, the MySQL server
-   will continue processing the remaining queries asynchronously of PHP and make
+   will continue processing the remaining queries asynchronously from PHP and make
    the results available for fetching.
   </para>
   <para>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -75,7 +75,7 @@
           </row>
           <row>
            <entry><constant>MYSQLI_INIT_COMMAND</constant></entry>
-           <entry>Command to execute after when connecting to MySQL server</entry>
+           <entry>Command to execute after establishing a connection to the MySQL server</entry>
           </row>
           <row>
            <entry><constant>MYSQLI_SET_CHARSET_NAME</constant></entry>

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -80,8 +80,8 @@
       <entry>
        Both <methodname>mysqli::ping</methodname> and
        <function>mysqli_ping</function> are now deprecated.
-       The <literal>reconnect</literal> feature has not been available
-       as of PHP 8.2.0, making this function obsolete.
+       As of PHP 8.2.0, the <literal>reconnect</literal> feature is no longer
+       available, making this function obsolete.
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli/poll.xml
+++ b/reference/mysqli/mysqli/poll.xml
@@ -54,18 +54,18 @@
     <varlistentry>
      <term><parameter>error</parameter></term>
      <listitem>
-      <para>
-      List of connections on which an error occurred, for example, query
-      failure or lost connection.
-      </para>
+      <simpara>
+       List of connections on which an error occurred, for example, query
+       failure or lost connection.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>reject</parameter></term>
      <listitem>
       <simpara>
-      List of connections rejected because no pending asynchronous query exists
-      to poll.
+       List of connections rejected because no pending asynchronous query exists
+       to poll.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/mysqli/mysqli/poll.xml
+++ b/reference/mysqli/mysqli/poll.xml
@@ -63,10 +63,10 @@
     <varlistentry>
      <term><parameter>reject</parameter></term>
      <listitem>
-      <para>
-      List of connections rejected because no asynchronous query
-      has been run on for which the function could poll results.
-      </para>
+      <simpara>
+      List of connections rejected because no pending asynchronous query exists
+      to poll.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mysqli/mysqli/rollback.xml
+++ b/reference/mysqli/mysqli/rollback.xml
@@ -22,9 +22,9 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Rollbacks the current transaction for the database.
-  </para>
+  <simpara>
+   Rolls back the current transaction for the database.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/select-db.xml
+++ b/reference/mysqli/mysqli/select-db.xml
@@ -25,11 +25,11 @@
    the database connection.
   </para>
   <note>
-   <para>
+   <simpara>
     This function should only be used to change the default database for the
-    connection. You can select the default database with 4th parameter in 
+    connection. You can select the default database with the 4th parameter in
     <function>mysqli_connect</function>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/sqlstate.xml
+++ b/reference/mysqli/mysqli/sqlstate.xml
@@ -23,10 +23,10 @@
    <link xlink:href="&url.mysql.docs.error;">&url.mysql.docs.error;</link>.
   </para>
   <note>
-   <para>
-    Note that not all MySQL errors are yet mapped to SQLSTATE's.
+   <simpara>
+    Note that not all MySQL errors are yet mapped to SQLSTATEs.
     The value <literal>HY000</literal> (general error) is used for unmapped errors.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/stmt-init.xml
+++ b/reference/mysqli/mysqli/stmt-init.xml
@@ -24,10 +24,10 @@
    <function>mysqli_stmt_prepare</function>.
   </para>
   <note>
-   <para>
-    Any subsequent calls to any mysqli_stmt function
-    will fail until <function>mysqli_stmt_prepare</function> was called.
-   </para>
+   <simpara>
+    Any subsequent call to any <classname>mysqli_stmt</classname> method
+    will fail until <function>mysqli_stmt_prepare</function> is called.
+   </simpara>
   </note>
  </refsect1>
 
@@ -42,9 +42,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns an object.
-  </para>
+  <simpara>
+   Returns a <classname>mysqli_stmt</classname> object.
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mysqli/mysqli/use-result.xml
+++ b/reference/mysqli/mysqli/use-result.xml
@@ -31,9 +31,9 @@
    from failing.
   </para>
   <note>
-   <para>
+   <simpara>
     The <function>mysqli_use_result</function> function does not transfer
-    the entire result set from the database and hence cannot be used functions
+    the entire result set from the database and hence cannot be used with functions
     such as <function>mysqli_data_seek</function> to move to a particular
     row within the set. To use this functionality, the result set must be
     stored using <function>mysqli_store_result</function>. One should not
@@ -41,7 +41,7 @@
     the client side is performed, since this will tie up the server and
     prevent other threads from updating any tables from which the data is
     being fetched.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -9,11 +9,11 @@
 <!-- {{{ ClassName intro -->
   <section xml:id="mysqli-driver.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     The <classname>mysqli_driver</classname> class is an instance of the monostate
-    pattern, i.e. there is only one driver which can be accessed though an arbitrary
+    pattern, i.e. there is only one driver which can be accessed through an arbitrary
     amount of <classname>mysqli_driver</classname> instances.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
  

--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -89,7 +89,7 @@
       <entry>length</entry>
       <entry>
        The width of the field in bytes. For string columns,
-       the length value varies on the connection character set. For example,
+       the length value depends on the connection character set. For example,
        if the character set is <literal>latin1</literal>, a single-byte character set,
        the length value for a <literal>SELECT 'abc'</literal> query is 3.
        If the character set is <literal>utf8mb4</literal>, a multibyte character

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -84,10 +84,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    A <classname>ValueError</classname> is thrown when
-   the <parameter>constructor_args</parameter> is non-empty with the class not having constructor.
-  </para>
+   the <parameter>constructor_args</parameter> is non-empty with the class not having a constructor.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -105,7 +105,7 @@
       <entry>8.3.0</entry>
       <entry>
        Now throws a <classname>ValueError</classname> exception when
-       the <parameter>constructor_args</parameter> is non-empty with the class not having constructor;
+       the <parameter>constructor_args</parameter> is non-empty with the class not having a constructor;
        previously an <classname>Exception</classname> was thrown.
       </entry>
      </row>

--- a/reference/mysqli/mysqli_result/num-rows.xml
+++ b/reference/mysqli/mysqli_result/num-rows.xml
@@ -95,11 +95,11 @@ Result set has 239 rows.
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     In contrast to the <function>mysqli_stmt_num_rows</function> function,
-    this function doesn't have object-oriented method variant.
+    this function doesn't have an object-oriented method variant.
     In the object-oriented style, use the getter property.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_sql_exception/getsqlstate.xml
+++ b/reference/mysqli/mysqli_sql_exception/getsqlstate.xml
@@ -19,10 +19,10 @@
    <link xlink:href="&url.mysql.docs.error;">&url.mysql.docs.error;</link>.
   </para>
   <note>
-   <para>
-    Note that not all MySQL errors are yet mapped to SQLSTATE's.
+   <simpara>
+    Note that not all MySQL errors are yet mapped to SQLSTATEs.
     The value <literal>HY000</literal> (general error) is used for unmapped errors.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/affected-rows.xml
+++ b/reference/mysqli/mysqli_stmt/affected-rows.xml
@@ -18,12 +18,12 @@
    <type class="union"><type>int</type><type>string</type></type><methodname>mysqli_stmt_affected_rows</methodname>
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Returns the number of rows affected by <literal>INSERT</literal>,
-   <literal>UPDATE</literal>, or <literal>DELETE</literal> query. 
+  <simpara>
+   Returns the number of rows affected by the <literal>INSERT</literal>,
+   <literal>UPDATE</literal>, or <literal>DELETE</literal> query.
    Works like <function>mysqli_stmt_num_rows</function> for
    <literal>SELECT</literal> statements.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -48,10 +48,10 @@
    <function>mysqli_stmt_store_result</function>.
   </para>
   <note>
-   <para>
-    If the number of affected rows is greater than maximum PHP int value, the
+   <simpara>
+    If the number of affected rows is greater than the maximum PHP int value, the
     number of affected rows will be returned as a string value.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/bind-result.xml
+++ b/reference/mysqli/mysqli_stmt/bind-result.xml
@@ -49,11 +49,11 @@
    </para>
   </note>
   <tip>
-   <para>
-    This function is useful for simple results. To retrieve iterable result
+   <simpara>
+    This function is useful for simple results. To retrieve an iterable result
     set, or fetch each row as an array or object,
     use <function>mysqli_stmt_get_result</function>.
-   </para>
+   </simpara>
   </tip>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -21,7 +21,7 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>params</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Executes previously prepared statement. The statement must be successfully 
+   Executes a previously prepared statement. The statement must be successfully
    prepared prior to execution, using either
    the <function>mysqli_prepare</function> or
    <function>mysqli_stmt_prepare</function> function, or by passing the second

--- a/reference/mysqli/mysqli_stmt/reset.xml
+++ b/reference/mysqli/mysqli_stmt/reset.xml
@@ -19,9 +19,9 @@
    <type>bool</type><methodname>mysqli_stmt_reset</methodname>
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Resets a prepared statement on client and server to state after prepare.
-  </para>
+  <simpara>
+   Resets a prepared statement on client and server to the state after prepare.
+  </simpara>
   <para>
     It resets the statement on the server, data sent using <function>mysqli_stmt_send_long_data</function>, 
     unbuffered result sets and current errors. It does not clear bindings or stored result sets. 

--- a/reference/mysqli/mysqli_stmt/send-long-data.xml
+++ b/reference/mysqli/mysqli_stmt/send-long-data.xml
@@ -22,12 +22,12 @@
    <methodparam><type>int</type><parameter>param_num</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Allows to send parameter data to the server in pieces (or chunks), e.g. if the
+  <simpara>
+   Allows sending parameter data to the server in pieces (or chunks), e.g. if the
    size of a blob exceeds the size of <literal>max_allowed_packet</literal>.
    This function can be called multiple times to send the parts of a character or
    binary data value for a column, which must be one of the TEXT or BLOB datatypes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli_stmt/sqlstate.xml
+++ b/reference/mysqli/mysqli_stmt/sqlstate.xml
@@ -133,10 +133,10 @@ Error: 42S02.
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
-    Note that not all MySQL errors are yet mapped to SQLSTATE's.
+   <simpara>
+    Note that not all MySQL errors are yet mapped to SQLSTATEs.
     The value <literal>HY000</literal> (general error) is used for unmapped errors.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/overview.xml
+++ b/reference/mysqli/overview.xml
@@ -80,12 +80,12 @@
     the MySQL server.
   </para>
 
-  <para>
+  <simpara>
     Sometimes people use the terms connector and driver interchangeably,
-    this can be confusing. In the MySQL-related documentation the term 
+    which can be confusing. In the MySQL-related documentation the term
     <quote>driver</quote> is reserved for software that provides
     the database-specific part of a connector package.
-  </para>
+  </simpara>
 
   <para>
     <emphasis role="bold">What is an Extension?</emphasis>
@@ -307,15 +307,15 @@
     <literal>libmysqlclient</literal> for PHP applications.
   </para>
 
-  <para>
-    Both, the <literal>mysqli</literal> extension and the PDO MySQL driver can
+  <simpara>
+    Both the <literal>mysqli</literal> extension and the PDO MySQL driver can
     each be individually configured to use either
     <literal>libmysqlclient</literal> or <literal>mysqlnd</literal>. As
     <literal>mysqlnd</literal> is designed specifically to be utilised
     in the PHP system it has numerous memory and speed enhancements over
     <literal>libmysqlclient</literal>. You are strongly encouraged to take
     advantage of these improvements.
-  </para>
+  </simpara>
 
   <para>
     The MySQL Native Driver is implemented using the PHP extension

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -231,11 +231,11 @@ mysqli.default_socket=/tmp/mysql.sock
    name. If not given or empty, then the socket (pipe name) defaults to
    <literal>\\.\pipe\MySQL</literal>.
   </para>
-  <para>
-   If neither a Unix domain socket based not a Windows named pipe based connection
+  <simpara>
+   If neither a Unix domain socket-based nor a Windows named pipe-based connection
    is to be established and the port parameter value is unset, the library
    will default to port <literal>3306</literal>.
-  </para>
+  </simpara>
   <para>
    The <link linkend="mysqlnd.overview">mysqlnd</link> library and the
    MySQL Client Library (libmysqlclient) implement the same logic for determining defaults.
@@ -287,15 +287,15 @@ mysqli.default_socket=/tmp/mysql.sock
    per PHP process can be restricted with <link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link>.
    Please note that the web server may spawn many PHP processes.
   </para>
-  <para>
-   A common complain about persistent connections is that their state is
+  <simpara>
+   A common complaint about persistent connections is that their state is
    not reset before reuse. For example, open and unfinished transactions are not
    automatically rolled back. But also, authorization changes which happened
    in the time between putting the connection into the pool and reusing it
    are not reflected. This may be seen as an unwanted side-effect. On the contrary,
    the name <literal>persistent</literal> may be understood as a promise
    that the state is persisted.
-  </para>
+  </simpara>
   <para>
    The mysqli extension supports both interpretations of a persistent connection:
    state persisted, and state reset before reuse. The default is reset.
@@ -949,9 +949,9 @@ array(2) {
   <para>
    <emphasis role="bold">Client-side prepared statement emulation</emphasis>
   </para>
-  <para>
-   The API does not include emulation for client-side prepared statement emulation.
-  </para>
+  <simpara>
+   The API does not include support for client-side prepared statement emulation.
+  </simpara>
   <para>
    <emphasis role="bold">See also</emphasis>
   </para>
@@ -1063,12 +1063,12 @@ Hi!
     </screen>
    </example>
   </para>
-  <para>
+  <simpara>
    Application and framework developers may be able to provide a more convenient
-   API using a mix of session variables and databased catalog inspection.
+   API using a mix of session variables and database catalog inspection.
    However, please note the possible performance impact of a custom
    solution based on catalog inspection.
-  </para>
+  </simpara>
   <para>
    <emphasis role="bold">Handling result sets</emphasis>
   </para>

--- a/reference/mysqli/summary.xml
+++ b/reference/mysqli/summary.xml
@@ -203,7 +203,7 @@
      <entry><methodname>mysqli::get_warnings</methodname></entry>
      <entry><function>mysqli_get_warnings</function></entry>
      <entry>N/A</entry>
-     <entry>NOT DOCUMENTED</entry>
+     <entry>Get result of SHOW WARNINGS</entry>
     </row>
     <row>
      <entry><methodname>mysqli::init</methodname></entry>
@@ -393,7 +393,7 @@
      <entry><link linkend="mysqli-stmt.field-count">$mysqli_stmt::field_count</link></entry>
      <entry><function>mysqli_stmt_field_count</function></entry>
      <entry>N/A</entry>
-     <entry>Returns the number of field in the given statement - not documented</entry>
+     <entry>Returns the number of fields in the statement</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.insert-id">$mysqli_stmt::insert_id</link></entry>
@@ -405,19 +405,19 @@
      <entry><link linkend="mysqli-stmt.num-rows">$mysqli_stmt::num_rows</link></entry>
      <entry><function>mysqli_stmt_num_rows</function></entry>
      <entry>N/A</entry>
-     <entry>Return the number of rows in statements result set</entry>
+     <entry>Returns the number of rows in statement's result set</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.param-count">$mysqli_stmt::param_count</link></entry>
      <entry><function>mysqli_stmt_param_count</function></entry>
      <entry>N/A</entry>
-     <entry>Returns the number of parameter for the given statement</entry>
+     <entry>Returns the number of parameters for the statement</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.sqlstate">$mysqli_stmt::sqlstate</link></entry>
      <entry><function>mysqli_stmt_sqlstate</function></entry>
      <entry>N/A</entry>
-     <entry>Returns SQLSTATE error from previous statement operation</entry>
+     <entry>Returns SQLSTATE error from previous operation</entry>
     </row>
     <row>
      <entry><emphasis role="bold">Methods</emphasis></entry>
@@ -426,7 +426,7 @@
      <entry><methodname>mysqli_stmt::attr_get</methodname></entry>
      <entry><function>mysqli_stmt_attr_get</function></entry>
      <entry>N/A</entry>
-     <entry>Used to get the current value of a statement attribute</entry>
+     <entry>Used to get the current value of a statement's attribute</entry>
     </row>
     <row>
      <entry><methodname>mysqli_stmt::attr_set</methodname></entry>

--- a/reference/mysqlinfo/set.xml
+++ b/reference/mysqlinfo/set.xml
@@ -127,7 +127,7 @@
 
    <simpara>
     Sometimes people use the terms connector and driver interchangeably,
-    this can be confusing. In the MySQL-related documentation the term
+    which can be confusing. In the MySQL-related documentation the term
     <quote>driver</quote> is reserved for software that provides
     the database-specific part of a connector package.
    </simpara>

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -9,14 +9,14 @@
  <procedure xml:id="pdo.install.unix51up">
   <title>Installing PDO on Unix systems</title>
   <step>
-   <para>
+   <simpara>
     PDO and the <link linkend="ref.pdo-sqlite">PDO_SQLITE</link> driver
-    is enabled by default. You may need
+    are enabled by default. You may need
     to enable the PDO driver for your database of choice; consult the
     documentation for
     <link linkend="pdo.drivers">database-specific PDO drivers</link>
     to find out more about that.
-   </para>
+   </simpara>
    <note>
     <para>
      When building PDO as a shared extension (<emphasis>not

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -114,13 +114,13 @@ $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass, array(
    </programlisting>
   </example>
  </para>
- <para>
+ <simpara>
   The value of the <constant>PDO::ATTR_PERSISTENT</constant> option is converted
   to &boolean; (enable/disable persistent connections), unless it is a non-numeric
-  &string;, in which case it allows to use multiple persistent connection pools.
+  &string;, in which case it allows the use of multiple persistent connection pools.
   This is useful if different connections use incompatible settings, for instance,
   different values of <constant>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</constant>.
- </para>
+ </simpara>
  <note>
   <para>
    If you wish to use persistent connections, you must set

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -425,7 +425,10 @@
     </term>
     <listitem>
      <simpara>
-      Sets the class name of which statements are returned as.
+      Sets the class name and constructor arguments for the extension of the
+      <classname>PDOStatement</classname> object. The first
+      element of the array is the class name, and the second element is an
+      array of constructor arguments.
      </simpara>
     </listitem>
    </varlistentry>
@@ -518,8 +521,9 @@
     </term>
     <listitem>
      <simpara>
-      Sets the default string parameter type, this can be one of <constant>PDO::PARAM_STR_NATL</constant>
-      and <constant>PDO::PARAM_STR_CHAR</constant>.
+      Sets the default string parameter type, which can be either
+      <constant>PDO::PARAM_STR_NATL</constant>
+      or <constant>PDO::PARAM_STR_CHAR</constant>.
      </simpara>
      <simpara>
       Available as of PHP 7.2.0.

--- a/reference/pdo/ini.xml
+++ b/reference/pdo/ini.xml
@@ -39,7 +39,7 @@
    </term>
    <listitem>
     <para>
-     Defines DSN alias. See <methodname>PDO::__construct</methodname> for
+     Defines a DSN alias. See <methodname>PDO::__construct</methodname> for
      thorough explanation.
     </para>
    </listitem>

--- a/reference/pdo/pdo/connect.xml
+++ b/reference/pdo/pdo/connect.xml
@@ -17,7 +17,7 @@
   <simpara>
    Creates an instance of a <classname>PDO</classname> subclass for the
    database being connected to, if it exists,
-   otherwise return a generic <classname>PDO</classname> instance.
+   otherwise returns a generic <classname>PDO</classname> instance.
   </simpara>
  </refsect1>
 

--- a/reference/pdo/pdo/errorcode.xml
+++ b/reference/pdo/pdo/errorcode.xml
@@ -23,17 +23,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns an SQLSTATE, a five characters alphanumeric identifier defined in
+  <simpara>
+   Returns an SQLSTATE, a five-character alphanumeric identifier defined in
    the ANSI SQL-92 standard.  Briefly, an SQLSTATE consists of a
-   two characters class value followed by a three characters subclass value. A
+   two-character class value followed by a three-character subclass value. A
    class value of 01 indicates a warning and is accompanied by a return code
    of SQL_SUCCESS_WITH_INFO. Class values other than '01', except for the
    class 'IM', indicate an error.  The class 'IM' is specific to warnings
    and errors that derive from the implementation of PDO (or perhaps ODBC,
    if you're using the ODBC driver) itself.  The subclass value '000' in any
    class indicates that there is no subclass for that SQLSTATE.
-  </para>
+  </simpara>
   <para>
    <methodname>PDO::errorCode</methodname> only retrieves error codes for operations
    performed directly on the database handle. If you create a PDOStatement

--- a/reference/pdo/pdo/errorinfo.xml
+++ b/reference/pdo/pdo/errorinfo.xml
@@ -38,7 +38,7 @@
      <tbody>
       <row>
        <entry>0</entry>
-       <entry>SQLSTATE error code (a five characters alphanumeric identifier defined
+       <entry>SQLSTATE error code (a five-character alphanumeric identifier defined
                in the ANSI SQL standard).</entry>
       </row>
       <row>

--- a/reference/pdo/pdo/getavailabledrivers.xml
+++ b/reference/pdo/pdo/getavailabledrivers.xml
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <para>
    This function returns all currently available PDO drivers which can be used
-   in <parameter>DSN</parameter> parameter of
+   in the <parameter>DSN</parameter> parameter of
    <methodname>PDO::__construct</methodname>.
   </para>
 

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -32,12 +32,12 @@
    statement, unless emulation mode is on.
   </para>
   <note>
-   <para>
+   <simpara>
     Parameter markers can represent a complete data literal only.
-    Neither part of literal, nor keyword, nor identifier, nor whatever arbitrary query 
-    part can be bound using parameters. For example, you cannot bind multiple values 
+    Neither part of a literal, nor keyword, nor identifier, nor whatever arbitrary query
+    part can be bound using parameters. For example, you cannot bind multiple values
     to a single parameter in the IN() clause of an SQL statement.
-   </para>
+   </simpara>
   </note>
   <para>
    Calling <methodname>PDO::prepare</methodname> and
@@ -113,10 +113,10 @@
    <classname>PDOException</classname> (depending on <link linkend="pdo.error-handling">error handling</link>).
   </para>
   <note>
-   <para>
-    Emulated prepared statements does not communicate with the database server
+   <simpara>
+    Emulated prepared statements do not communicate with the database server
     so <methodname>PDO::prepare</methodname> does not check the statement.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -60,7 +60,7 @@
      <term><parameter>type</parameter></term>
       <listitem>
        <simpara>
-        Provides a hint to  the type of data for drivers that have alternate quoting
+        Provides a hint as to the type of data for drivers that have alternate quoting
         styles. For example <constant>PDO_PARAM_LOB</constant> will tell the driver to
         escape binary data.
        </simpara>

--- a/reference/pdo/pdorow.xml
+++ b/reference/pdo/pdorow.xml
@@ -16,13 +16,13 @@
    <para>
     Objects of this class cannot be instantiated and are not serializable.
    </para>
-   <para>
+   <simpara>
     The <classname>PDORow</classname> object allows access
     to the returned data as if both <constant>PDO::FETCH_OBJ</constant>
-    and <constant>PDO::FETCH_BOTH</constant> mode was used.
+    and <constant>PDO::FETCH_BOTH</constant> mode were used.
     This means that the returned data can be accessed as object properties,
     and as an array both indexed by the column name and a column offset number.
-   </para>
+   </simpara>
    <caution>
     <simpara>
      Accessing an undefined property returns &null;

--- a/reference/pdo/pdostatement/debugdumpparams.xml
+++ b/reference/pdo/pdostatement/debugdumpparams.xml
@@ -63,7 +63,7 @@
        <entry>
         <methodname>PDOStatement::debugDumpParams</methodname> now returns the SQL sent to
         the database, including the full, raw query (including the replaced placeholders with
-        their bounded values). Note, that this will only be available if emulated prepared
+        their bound values). Note, that this will only be available if emulated prepared
         statements are turned on.
        </entry>
       </row>

--- a/reference/pdo/pdostatement/errorinfo.xml
+++ b/reference/pdo/pdostatement/errorinfo.xml
@@ -37,7 +37,7 @@
      <tbody>
       <row>
        <entry>0</entry>
-       <entry>SQLSTATE error code (a five characters alphanumeric identifier defined
+       <entry>SQLSTATE error code (a five-character alphanumeric identifier defined
                in the ANSI SQL standard).</entry>
       </row>
       <row>

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -172,7 +172,7 @@ $sth->execute($params);
   &reftitle.notes;
   <note>
    <simpara>
-    Some drivers require <link linkend="pdostatement.closecursor">the cursor to
+    Some drivers require the <link linkend="pdostatement.closecursor">cursor to
     be closed</link> before executing the next statement.
    </simpara>
   </note>

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -171,10 +171,10 @@ $sth->execute($params);
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
-    Some drivers require to <link linkend="pdostatement.closecursor">close
-    cursor</link> before executing next statement.
-   </para>
+   <simpara>
+    Some drivers require <link linkend="pdostatement.closecursor">the cursor to
+    be closed</link> before executing the next statement.
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -36,69 +36,89 @@
        defaulting to value of <literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal>
        (which defaults to <literal>PDO::FETCH_BOTH</literal>).
        <itemizedlist>
-        <listitem><para>
-         <literal>PDO::FETCH_ASSOC</literal>: returns an array indexed by column
-         name as returned in your result set
-        </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_BOTH</literal> (default): returns an array indexed by
-         both column name and 0-indexed column number as returned in your
-         result set
-        </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_BOUND</literal>: returns &true; and assigns the
-         values of the columns in your result set to the PHP variables to which
-         they were bound with the <methodname>PDOStatement::bindColumn</methodname>
-         method
-        </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_CLASS</literal>: returns a new instance of the
-         requested class. The object is initialized by mapping the columns of
-         the result set to properties in the class. This occurs before the
-         constructor is called, allowing properties to be populated regardless
-         of their visibility or whether they are marked as <literal>readonly</literal>.
-         If a property does not exist in the class, the magic <link linkend="object.set">__set()</link>
-         method will be invoked if it exists; otherwise, a dynamic public
-         property will be created. However, when <constant>PDO::FETCH_PROPS_LATE</constant>
-         is also given, the constructor is called <emphasis>before</emphasis>
-         the properties are populated. If <parameter>mode</parameter> includes
-         <constant>PDO::FETCH_CLASSTYPE</constant> (e.g.
-         <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), the name
-         of the class is determined from the value of the first column.
-        </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_INTO</literal>: updates an existing instance
-         of the requested class, mapping the columns of the result set to
-         named properties in the class
-        </para></listitem>
-        <listitem><simpara>
-         <literal>PDO::FETCH_LAZY</literal>: combines
-         <literal>PDO::FETCH_BOTH</literal> and <literal>PDO::FETCH_OBJ</literal>,
-         and returns a <classname>PDORow</classname> object
-         which creates the object property names as they are accessed.
-        </simpara></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_NAMED</literal>: returns an array with the same
-         form as <literal>PDO::FETCH_ASSOC</literal>, except that if there are
-         multiple columns with the same name, the value referred to by that
-         key will be an array of all the values in the row that had that
-         column name
-        </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_NUM</literal>: returns an array indexed by column
-         number as returned in your result set, starting at column 0
-        </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_OBJ</literal>: returns an anonymous object with
-         property names that correspond to the column names returned in your
-         result set
-        </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_PROPS_LATE</literal>: when used with
-         <literal>PDO::FETCH_CLASS</literal>, the constructor of the class is
-         called before the properties are assigned from the respective column
-         values.
-        </para></listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_ASSOC</literal>: returns an array indexed by column
+          name as returned in your result set
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_BOTH</literal> (default): returns an array indexed by
+          both column name and 0-indexed column number as returned in your
+          result set
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_BOUND</literal>: returns &true; and assigns the
+          values of the columns in your result set to the PHP variables to which
+          they were bound with the <methodname>PDOStatement::bindColumn</methodname>
+          method
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_CLASS</literal>: returns a new instance of the
+          requested class. The object is initialized by mapping the columns of
+          the result set to properties in the class. This occurs before the
+          constructor is called, allowing properties to be populated regardless
+          of their visibility or whether they are marked as <literal>readonly</literal>.
+          If a property does not exist in the class, the magic <link linkend="object.set">__set()</link>
+          method will be invoked if it exists; otherwise, a dynamic public
+          property will be created. However, when <constant>PDO::FETCH_PROPS_LATE</constant>
+          is also given, the constructor is called <emphasis>before</emphasis>
+          the properties are populated. If <parameter>mode</parameter> includes
+          <constant>PDO::FETCH_CLASSTYPE</constant> (e.g.
+          <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), the name
+          of the class is determined from the value of the first column.
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_INTO</literal>: updates an existing instance
+          of the requested class, mapping the columns of the result set to
+          named properties in the class
+         </para>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_LAZY</literal>: combines
+          <literal>PDO::FETCH_BOTH</literal> and <literal>PDO::FETCH_OBJ</literal>,
+          and returns a <classname>PDORow</classname> object
+          which creates the object property names as they are accessed.
+         </simpara>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_NAMED</literal>: returns an array with the same
+          form as <literal>PDO::FETCH_ASSOC</literal>, except that if there are
+          multiple columns with the same name, the value referred to by that
+          key will be an array of all the values in the row that had that
+          column name
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_NUM</literal>: returns an array indexed by column
+          number as returned in your result set, starting at column 0
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_OBJ</literal>: returns an anonymous object with
+          property names that correspond to the column names returned in your
+          result set
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          <literal>PDO::FETCH_PROPS_LATE</literal>: when used with
+          <literal>PDO::FETCH_CLASS</literal>, the constructor of the class is
+          called before the properties are assigned from the respective column
+          values.
+         </para>
+        </listitem>
        </itemizedlist>
       </para>
      </listitem>

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -37,28 +37,28 @@
        (which defaults to <literal>PDO::FETCH_BOTH</literal>).
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_ASSOC</literal>: returns an array indexed by column
           name as returned in your result set
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_BOTH</literal> (default): returns an array indexed by
           both column name and 0-indexed column number as returned in your
           result set
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_BOUND</literal>: returns &true; and assigns the
           values of the columns in your result set to the PHP variables to which
           they were bound with the <methodname>PDOStatement::bindColumn</methodname>
           method
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_CLASS</literal>: returns a new instance of the
           requested class. The object is initialized by mapping the columns of
           the result set to properties in the class. This occurs before the
@@ -72,14 +72,14 @@
           <constant>PDO::FETCH_CLASSTYPE</constant> (e.g.
           <literal>PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE</literal>), the name
           of the class is determined from the value of the first column.
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_INTO</literal>: updates an existing instance
           of the requested class, mapping the columns of the result set to
           named properties in the class
-         </para>
+         </simpara>
         </listitem>
         <listitem>
          <simpara>
@@ -90,34 +90,34 @@
          </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_NAMED</literal>: returns an array with the same
           form as <literal>PDO::FETCH_ASSOC</literal>, except that if there are
           multiple columns with the same name, the value referred to by that
           key will be an array of all the values in the row that had that
           column name
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_NUM</literal>: returns an array indexed by column
           number as returned in your result set, starting at column 0
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_OBJ</literal>: returns an anonymous object with
           property names that correspond to the column names returned in your
           result set
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <literal>PDO::FETCH_PROPS_LATE</literal>: when used with
           <literal>PDO::FETCH_CLASS</literal>, the constructor of the class is
           called before the properties are assigned from the respective column
           values.
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -71,12 +71,12 @@
          of the requested class, mapping the columns of the result set to
          named properties in the class
         </para></listitem>
-        <listitem><para>
+        <listitem><simpara>
          <literal>PDO::FETCH_LAZY</literal>: combines
          <literal>PDO::FETCH_BOTH</literal> and <literal>PDO::FETCH_OBJ</literal>,
-         and is returning a <classname>PDORow</classname> object
-         which is creating the object property names as they are accessed.
-        </para></listitem>
+         and returns a <classname>PDORow</classname> object
+         which creates the object property names as they are accessed.
+        </simpara></listitem>
         <listitem><para>
          <literal>PDO::FETCH_NAMED</literal>: returns an array with the same
          form as <literal>PDO::FETCH_ASSOC</literal>, except that if there are

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -74,7 +74,7 @@
      </listitem>
     </varlistentry>
    </variablelist>
-   The following are dynamic parameters that are depending on the fetch mode.
+   The following are dynamic parameters that depend on the fetch mode.
    They can't be used with named parameters.
    <variablelist>
     <varlistentry>

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -17,10 +17,10 @@
   <para>
    Gets an attribute of the statement. Currently, no generic attributes exist but only driver specific:
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem><simpara><literal>PDO::ATTR_CURSOR_NAME</literal>
      (Firebird and ODBC specific):
-     Get the name of cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
-    </para></listitem>
+     Get the name of the cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
+    </simpara></listitem>
    </itemizedlist>
    Note that driver specific attributes <emphasis>must not</emphasis> be used
    with other drivers.

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -17,10 +17,13 @@
   <para>
    Gets an attribute of the statement. Currently, no generic attributes exist but only driver specific:
    <itemizedlist>
-    <listitem><simpara><literal>PDO::ATTR_CURSOR_NAME</literal>
-     (Firebird and ODBC specific):
-     Get the name of the cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
-    </simpara></listitem>
+    <listitem>
+     <simpara>
+      <literal>PDO::ATTR_CURSOR_NAME</literal>
+      (Firebird and ODBC specific):
+      Get the name of the cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
+     </simpara>
+    </listitem>
    </itemizedlist>
    Note that driver specific attributes <emphasis>must not</emphasis> be used
    with other drivers.

--- a/reference/pdo/pdostatement/rowcount.xml
+++ b/reference/pdo/pdostatement/rowcount.xml
@@ -28,11 +28,11 @@
    on for portable applications.
   </para>
     <note>
-     <para>
-      This method returns "0" (zero) with PostgreSQL driver when setting the
+     <simpara>
+      This method returns "0" (zero) with the PostgreSQL driver when setting the
       <constant>PDO::ATTR_CURSOR</constant> statement attribute to
       <constant>PDO::CURSOR_SCROLL</constant>.
-     </para>
+     </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -18,10 +18,13 @@
   <para>
    Sets an attribute on the statement. Currently, no generic attributes are set but only driver specific:
    <itemizedlist>
-    <listitem><simpara><literal>PDO::ATTR_CURSOR_NAME</literal>
-     (Firebird and ODBC specific):
-     Set the name of the cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
-    </simpara></listitem>
+    <listitem>
+     <simpara>
+      <literal>PDO::ATTR_CURSOR_NAME</literal>
+      (Firebird and ODBC specific):
+      Set the name of the cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
+     </simpara>
+    </listitem>
    </itemizedlist>
    Note that driver specific attributes <emphasis>must not</emphasis> be used
    with other drivers.

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -18,10 +18,10 @@
   <para>
    Sets an attribute on the statement. Currently, no generic attributes are set but only driver specific:
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem><simpara><literal>PDO::ATTR_CURSOR_NAME</literal>
      (Firebird and ODBC specific):
-     Set the name of cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
-    </para></listitem>
+     Set the name of the cursor for <literal>UPDATE ... WHERE CURRENT OF</literal>.
+    </simpara></listitem>
    </itemizedlist>
    Note that driver specific attributes <emphasis>must not</emphasis> be used
    with other drivers.

--- a/reference/pgsql/functions/pg-fetch-object.xml
+++ b/reference/pgsql/functions/pg-fetch-object.xml
@@ -87,10 +87,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    A <classname>ValueError</classname> is thrown when
-   the <parameter>constructor_args</parameter> is non-empty with the class not having constructor.
-  </para>
+   the <parameter>constructor_args</parameter> is non-empty with the class not having a constructor.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -108,7 +108,7 @@
       <entry>8.3.0</entry>
       <entry>
        Now throws a <classname>ValueError</classname> exception when
-       the <parameter>constructor_args</parameter> is non-empty with the class not having constructor;
+       the <parameter>constructor_args</parameter> is non-empty with the class not having a constructor;
        previously an <classname>Exception</classname> was thrown.
       </entry>
      </row>

--- a/reference/tidy/tidy/parsefile.xml
+++ b/reference/tidy/tidy/parsefile.xml
@@ -90,7 +90,7 @@
    <methodname>tidy::parseFile</methodname> returns &true; on success.
    <function>tidy_parse_file</function> returns a new <classname>tidy</classname>
    instance on success.
-   Both, the method and the function return &false; on failure.
+   Both the method and the function return &false; on failure.
   </para>
  </refsect1>
 

--- a/reference/tidy/tidy/parsestring.xml
+++ b/reference/tidy/tidy/parsestring.xml
@@ -77,7 +77,7 @@
    <methodname>tidy::parseString</methodname> returns &true; on success.
    <function>tidy_parse_string</function> returns a new <classname>tidy</classname>
    instance on success.
-   Both, the method and the function return &false; on failure.
+   Both the method and the function return &false; on failure.
   </para>
  </refsect1>
 


### PR DESCRIPTION
I tried to fix all grammar issues and typos that failed AI check. Most of the changes are superficial with only a few demanding a bigger rewrite. In particular, reference/mysqli/configure.xml was changed to reflect the up-to-date status. 
