### PR TITLE
GH Actions: fail "setup-php" if requested tooling/extensions could not be installed

### DIFF
--- a/.github/workflows/docbook-cs.yaml
+++ b/.github/workflows/docbook-cs.yaml
@@ -74,6 +74,8 @@ jobs:
           php-version: "8.5"
           extensions: "dom, libxml, simplexml"
           tools: composer, cs2pr
+        env:
+          fail-fast: true
 
       - name: "Build documentation"
         run: |


### PR DESCRIPTION

Setup-PHP will normally "gracefully" show a warning and not fail the build when an extension or tool failed to install.

In most cases, this is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be run/tested.

This commit changes this behaviour to fail the build at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional