### PR TITLE
Add note to shell_exec that the backtick operator is deprecated

### DIFF
--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
   <para>
-   This function is identical to the <link linkend="language.operators.execution">backtick operator</link>.
+   This function is identical to the deprecated <link linkend="language.operators.execution">backtick operator</link>.
   </para>
   <note>
    <para>

--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -13,9 +13,9 @@
    <type class="union"><type>string</type><type>false</type><type>null</type></type><methodname>shell_exec</methodname>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    This function is identical to the deprecated <link linkend="language.operators.execution">backtick operator</link>.
-  </para>
+  </simpara>
   <note>
    <para>
     On Windows, the underlying pipe is opened in text mode which can cause the


### PR DESCRIPTION
See https://github.com/php/doc-en/pull/5017