### PR TITLE
Update screens for output that changed with PHP itself

### DIFF
--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -221,7 +221,7 @@ foreach ($array as [, , $c]) {
   </para>
 
   <para>
-   A notice will be generated if there aren't enough array elements to fill
+   A warning will be generated if there aren't enough array elements to fill
    the <function>list</function>:
 
    <informalexample>
@@ -241,10 +241,10 @@ foreach ($array as [$a, $b, $c]) {
     &example.outputs;
     <screen>
 <![CDATA[
-Notice: Undefined offset: 2 in example.php on line 7
+Warning: Undefined array key 2 in script on line 7
 A: 1; B: 2; C:
 
-Notice: Undefined offset: 2 in example.php on line 7
+Warning: Undefined array key 2 in script on line 7
 A: 3; B: 4; C:
 ]]>
     </screen>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -222,10 +222,11 @@ foreach ($array as [, , $c]) {
 
   <para>
    A warning will be generated if there aren't enough array elements to fill
-   the <function>list</function>:
+   the <function>list</function>.
+   Prior to PHP 8.0.0 a notice was generated instead:
 
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $array = [
@@ -238,7 +239,17 @@ foreach ($array as [$a, $b, $c]) {
 }
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.71;
+    <screen>
+<![CDATA[
+Notice: Undefined offset: 2 in script on line 7
+A: 1; B: 2; C:
+
+Notice: Undefined offset: 2 in script on line 7
+A: 3; B: 4; C:
+]]>
+    </screen>
+    &example.outputs.8;
     <screen>
 <![CDATA[
 Warning: Undefined array key 2 in script on line 7

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -221,9 +221,8 @@ foreach ($array as [, , $c]) {
   </para>
 
   <para>
-   A warning will be generated if there aren't enough array elements to fill
-   the <function>list</function>.
-   Prior to PHP 8.0.0 a notice was generated instead:
+   If there are not enough array elements to populate the variables,
+   a warning is emitted; prior to PHP 8.0.0, a notice was emitted instead:
 
    <informalexample>
     <programlisting role="php" annotations="non-interactive">

--- a/language/oop5/anonymous.xml
+++ b/language/oop5/anonymous.xml
@@ -63,8 +63,8 @@ var_dump(new class(10) extends SomeClass implements SomeInterface {
   &example.outputs;
   <screen>
 <![CDATA[
-object(class@anonymous)#1 (1) {
-  ["Command line code0x104c5b612":"class@anonymous":private]=>
+object(SomeClass@anonymous)#1 (1) {
+  ["num":"SomeClass@anonymous":private]=>
   int(10)
 }
 ]]>
@@ -156,7 +156,8 @@ same class
   <simpara>
    Note that anonymous classes are assigned a name by the engine, as
    demonstrated in the following example. This name has to be regarded as an
-   implementation detail, which should not be relied upon.
+   implementation detail, which should not be relied upon. The generated name
+   contains a NUL byte, which is not visible in the output below.
   </simpara>
   <informalexample>
    <programlisting role="php">
@@ -168,7 +169,7 @@ echo get_class(new class {});
   &example.outputs.similar;
   <screen>
 <![CDATA[
-class@anonymous/in/oNi1A0x7f8636ad2021
+class@anonymousscript:2$0
 ]]>
    </screen>
   </informalexample>

--- a/language/oop5/anonymous.xml
+++ b/language/oop5/anonymous.xml
@@ -168,7 +168,7 @@ echo get_class(new class {});
   &example.outputs.similar;
   <screen>
 <![CDATA[
-class@anonymousscript:2$0
+class@anonymous/in/oNi1A0x7f8636ad2021
 ]]>
    </screen>
   </informalexample>

--- a/language/oop5/anonymous.xml
+++ b/language/oop5/anonymous.xml
@@ -156,8 +156,7 @@ same class
   <simpara>
    Note that anonymous classes are assigned a name by the engine, as
    demonstrated in the following example. This name has to be regarded as an
-   implementation detail, which should not be relied upon. The generated name
-   contains a NUL byte, which is not visible in the output below.
+   implementation detail, which should not be relied upon.
   </simpara>
   <informalexample>
    <programlisting role="php">

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -527,7 +527,7 @@ var_dump($c);
     &example.outputs;
     <screen>
 <![CDATA[
-string(60) "A::__set_state(array(
+string(61) "\A::__set_state(array(
    'var1' => 5,
    'var2' => 'foo',
 ))"

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -495,7 +495,7 @@ Array
    </para>
    <example>
     <title>Using <link linkend="object.set-state">__set_state()</link></title>
-    <programlisting role="php" annotations="non-interactive">
+    <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -524,22 +524,7 @@ var_dump($c);
 ?>
 ]]>
     </programlisting>
-    &example.outputs.81;
-    <screen>
-<![CDATA[
-string(60) "A::__set_state(array(
-   'var1' => 5,
-   'var2' => 'foo',
-))"
-object(A)#2 (2) {
-  ["var1"]=>
-  int(5)
-  ["var2"]=>
-  string(3) "foo"
-}
-]]>
-    </screen>
-    &example.outputs.82;
+    &example.outputs;
     <screen>
 <![CDATA[
 string(61) "\A::__set_state(array(

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -495,7 +495,7 @@ Array
    </para>
    <example>
     <title>Using <link linkend="object.set-state">__set_state()</link></title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -524,7 +524,22 @@ var_dump($c);
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.81;
+    <screen>
+<![CDATA[
+string(60) "A::__set_state(array(
+   'var1' => 5,
+   'var2' => 'foo',
+))"
+object(A)#2 (2) {
+  ["var1"]=>
+  int(5)
+  ["var2"]=>
+  string(3) "foo"
+}
+]]>
+    </screen>
+    &example.outputs.82;
     <screen>
 <![CDATA[
 string(61) "\A::__set_state(array(

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -372,36 +372,6 @@ $array[$i] = $i++; // may set either index 1 or 2
    </programlisting>
   </example>
   <example>
-   <title><literal>+</literal>, <literal>-</literal> and <literal>.</literal> precedence</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$x = 4;
-// "-" binds tighter than ".", so $x-1 is one operand of the concatenation:
-echo "x minus one equals " . $x-1 . ", or so I hope\n";
-
-// the same grouping, made explicit:
-echo "x minus one equals " . ($x-1) . ", or so I hope\n";
-
-// this is not allowed, and throws a TypeError:
-echo (("x minus one equals " . $x) - 1) . ", or so I hope\n";
-?>
-]]>
-   </programlisting>
-   &example.outputs;
-   <screen>
-<![CDATA[
-x minus one equals 3, or so I hope
-x minus one equals 3, or so I hope
-
-Fatal error: Uncaught TypeError: Unsupported operand types: string - int in script:10
-Stack trace:
-#0 {main}
-  thrown in script on line 10
-]]>
-   </screen>
-  </example>
-  <example>
    <title>Prior to PHP 8, <literal>+</literal>, <literal>-</literal> and <literal>.</literal> had the same precedence</title>
    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
@@ -418,16 +388,43 @@ echo "x minus one equals " . ($x-1) . ", or so I hope\n";
 ?>
 ]]>
    </programlisting>
-   &example.outputs;
+   &example.outputs.71;
    <screen>
 <![CDATA[
+Warning: A non-numeric value encountered in script on line 4
 -1, or so I hope
+
+Warning: A non-numeric value encountered in script on line 7
 -1, or so I hope
 x minus one equals 3, or so I hope
 ]]>
    </screen>
+   &example.outputs.8;
+   <screen>
+<![CDATA[
+x minus one equals 3, or so I hope
+
+Fatal error: Uncaught TypeError: Unsupported operand types: string - int in script:7
+Stack trace:
+#0 {main}
+  thrown in script on line 7
+]]>
+   </screen>
   </example>
  </para>
+ <simpara>
+  As of PHP 7.4.0 the first line also emits
+  <literal>Deprecated: The behavior of unparenthesized expressions containing
+  both '.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher
+  precedence</literal>.
+ </simpara>
+ <simpara>
+  As of PHP 8.0.0 the pitfall is gone, because <literal>-</literal> now binds
+  tighter than <literal>.</literal>.
+  The second line, which spells out the grouping that used to apply, throws a
+  <exceptionname>TypeError</exceptionname> instead, so the third line never
+  runs.
+ </simpara>
  <note>
   <para>
    Although <literal>=</literal> has a lower precedence than

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -377,10 +377,10 @@ $array[$i] = $i++; // may set either index 1 or 2
 <![CDATA[
 <?php
 $x = 4;
-// this line might result in unexpected output:
+// "-" binds tighter than ".", so $x-1 is one operand of the concatenation:
 echo "x minus one equals " . $x-1 . ", or so I hope\n";
 
-// the desired precedence can be enforced by using parentheses:
+// the same grouping, made explicit:
 echo "x minus one equals " . ($x-1) . ", or so I hope\n";
 
 // this is not allowed, and throws a TypeError:
@@ -391,9 +391,13 @@ echo (("x minus one equals " . $x) - 1) . ", or so I hope\n";
    &example.outputs;
    <screen>
 <![CDATA[
--1, or so I hope
--1, or so I hope
-Fatal error: Uncaught TypeError: Unsupported operand types: string - int
+x minus one equals 3, or so I hope
+x minus one equals 3, or so I hope
+
+Fatal error: Uncaught TypeError: Unsupported operand types: string - int in script:10
+Stack trace:
+#0 {main}
+  thrown in script on line 10
 ]]>
    </screen>
   </example>

--- a/language/operators/type.xml
+++ b/language/operators/type.xml
@@ -188,7 +188,7 @@ var_dump(FALSE instanceof stdClass);
 bool(false)
 bool(false)
 bool(false)
-PHP Fatal error:  instanceof expects an object instance, constant given
+bool(false)
 ]]>
    </screen>
   </example>

--- a/language/operators/type.xml
+++ b/language/operators/type.xml
@@ -179,7 +179,7 @@ var_dump($a instanceof stdClass); // $a is an integer
 var_dump($b instanceof stdClass); // $b is NULL
 var_dump($c instanceof stdClass); // $c is a resource
 
-// Prior to PHP 7.3.0 this was a compile-time error, so nothing above ran:
+// Prior to PHP 7.3.0, using a constant would trigger a compile-time fatal error with the following message:
 // instanceof expects an object instance, constant given
 var_dump(FALSE instanceof stdClass);
 ?>

--- a/language/operators/type.xml
+++ b/language/operators/type.xml
@@ -178,6 +178,9 @@ $c = fopen('/tmp/', 'r');
 var_dump($a instanceof stdClass); // $a is an integer
 var_dump($b instanceof stdClass); // $b is NULL
 var_dump($c instanceof stdClass); // $c is a resource
+
+// Prior to PHP 7.3.0 this was a compile-time error, so nothing above ran:
+// instanceof expects an object instance, constant given
 var_dump(FALSE instanceof stdClass);
 ?>
 ]]>

--- a/language/predefined/backedenum/from.xml
+++ b/language/predefined/backedenum/from.xml
@@ -71,7 +71,11 @@ $b = Suit::from('B');
 <![CDATA[
 enum(Suit::Hearts)
 
-Fatal error: Uncaught ValueError: "B" is not a valid backing value for enum "Suit" in /file.php:15
+Fatal error: Uncaught ValueError: "B" is not a valid backing value for enum Suit in script:14
+Stack trace:
+#0 script(14): Suit::from('B')
+#1 {main}
+  thrown in script on line 14
 ]]>
    </screen>
   </example>

--- a/language/predefined/backedenum/from.xml
+++ b/language/predefined/backedenum/from.xml
@@ -66,16 +66,12 @@ $b = Suit::from('B');
 ?>
 ]]>
    </programlisting>
-   &example.outputs;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
 enum(Suit::Hearts)
 
 Fatal error: Uncaught ValueError: "B" is not a valid backing value for enum Suit in script:14
-Stack trace:
-#0 script(14): Suit::from('B')
-#1 {main}
-  thrown in script on line 14
 ]]>
    </screen>
   </example>

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -133,7 +133,7 @@
   <para>
    <example>
     <title><function>mb_detect_encoding</function> example</title>
-    <programlisting role="php" annotations="non-interactive">
+    <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -158,16 +158,7 @@ var_dump(mb_detect_encoding($str, $encodings));
 ?>
 ]]>
     </programlisting>
-    &example.outputs.82;
-    <screen>
-<![CDATA[
-bool(false)
-bool(false)
-string(8) "SJIS-win"
-bool(false)
-]]>
-    </screen>
-    &example.outputs.83;
+    &example.outputs;
     <screen>
 <![CDATA[
 string(5) "ASCII"
@@ -181,7 +172,7 @@ string(5) "ASCII"
   <para>
    <example>
     <title>Effect of <parameter>strict</parameter> parameter</title>
-    <programlisting role="php" annotations="non-interactive">
+    <programlisting role="php">
      <![CDATA[
 <?php
 // 'áéóú' encoded in ISO-8859-1
@@ -198,16 +189,7 @@ var_dump(mb_detect_encoding($str, ['ASCII', 'UTF-8', 'ISO-8859-1'], true));
 ?>
 ]]>
     </programlisting>
-    &example.outputs.82;
-    <screen>
-<![CDATA[
-string(5) "UTF-8"
-bool(false)
-string(10) "ISO-8859-1"
-string(10) "ISO-8859-1"
-]]>
-    </screen>
-    &example.outputs.83;
+    &example.outputs;
     <screen>
 <![CDATA[
 string(5) "ASCII"

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -178,7 +178,8 @@ string(5) "ASCII"
 // 'áéóú' encoded in ISO-8859-1
 $str = "\xE1\xE9\xF3\xFA";
 
-// The string is not valid ASCII or UTF-8, but UTF-8 is considered a closer match
+// The string is valid in neither encoding: non-strict reports the closest
+// match, strict returns false
 var_dump(mb_detect_encoding($str, ['ASCII', 'UTF-8'], false));
 var_dump(mb_detect_encoding($str, ['ASCII', 'UTF-8'], true));
 
@@ -191,7 +192,7 @@ var_dump(mb_detect_encoding($str, ['ASCII', 'UTF-8', 'ISO-8859-1'], true));
     &example.outputs;
     <screen>
 <![CDATA[
-string(5) "UTF-8"
+string(5) "ASCII"
 bool(false)
 string(10) "ISO-8859-1"
 string(10) "ISO-8859-1"

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -158,7 +158,16 @@ var_dump(mb_detect_encoding($str, $encodings));
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.82;
+    <screen>
+<![CDATA[
+bool(false)
+bool(false)
+string(8) "SJIS-win"
+bool(false)
+]]>
+    </screen>
+    &example.outputs.83;
     <screen>
 <![CDATA[
 string(5) "ASCII"
@@ -189,7 +198,16 @@ var_dump(mb_detect_encoding($str, ['ASCII', 'UTF-8', 'ISO-8859-1'], true));
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.82;
+    <screen>
+<![CDATA[
+string(5) "UTF-8"
+bool(false)
+string(10) "ISO-8859-1"
+string(10) "ISO-8859-1"
+]]>
+    </screen>
+    &example.outputs.83;
     <screen>
 <![CDATA[
 string(5) "ASCII"

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -133,7 +133,7 @@
   <para>
    <example>
     <title><function>mb_detect_encoding</function> example</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -181,7 +181,7 @@ string(5) "ASCII"
   <para>
    <example>
     <title>Effect of <parameter>strict</parameter> parameter</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 // 'áéóú' encoded in ISO-8859-1

--- a/reference/reflection/reflectionclass/tostring.xml
+++ b/reference/reflection/reflectionclass/tostring.xml
@@ -43,7 +43,7 @@ echo $reflectionClass->__toString();
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.similar;
     <screen>
 <![CDATA[
 Class [ <internal:Core> class Exception implements Stringable, Throwable ] {

--- a/reference/reflection/reflectionclass/tostring.xml
+++ b/reference/reflection/reflectionclass/tostring.xml
@@ -46,7 +46,7 @@ echo $reflectionClass->__toString();
     &example.outputs;
     <screen>
 <![CDATA[
-Class [ <internal:Core> class Exception ] {
+Class [ <internal:Core> class Exception implements Stringable, Throwable ] {
 
   - Constants [0] {
   }
@@ -58,50 +58,92 @@ Class [ <internal:Core> class Exception ] {
   }
 
   - Properties [7] {
-    Property [ <default> protected $message ]
-    Property [ <default> private $string ]
-    Property [ <default> protected $code ]
-    Property [ <default> protected $file ]
-    Property [ <default> protected $line ]
-    Property [ <default> private $trace ]
-    Property [ <default> private $previous ]
+    Property [ protected $message = '' ]
+    Property [ private string $string = '' ]
+    Property [ protected $code = 0 ]
+    Property [ protected string $file = '' ]
+    Property [ protected int $line = 0 ]
+    Property [ private array $trace = [] ]
+    Property [ private ?Throwable $previous = NULL ]
   }
 
-  - Methods [10] {
-    Method [ <internal:Core> final private method __clone ] {
+  - Methods [11] {
+    Method [ <internal:Core> private method __clone ] {
+
+      - Parameters [0] {
+      }
+      - Return [ void ]
     }
 
     Method [ <internal:Core, ctor> public method __construct ] {
 
       - Parameters [3] {
-        Parameter #0 [ <optional> $message ]
-        Parameter #1 [ <optional> $code ]
-        Parameter #2 [ <optional> $previous ]
+        Parameter #0 [ <optional> string $message = "" ]
+        Parameter #1 [ <optional> int $code = 0 ]
+        Parameter #2 [ <optional> ?Throwable $previous = null ]
       }
     }
 
-    Method [ <internal:Core> final public method getMessage ] {
+    Method [ <internal:Core> public method __wakeup ] {
+
+      - Parameters [0] {
+      }
+      - Tentative return [ void ]
     }
 
-    Method [ <internal:Core> final public method getCode ] {
+    Method [ <internal:Core, prototype Throwable> final public method getMessage ] {
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
     }
 
-    Method [ <internal:Core> final public method getFile ] {
+    Method [ <internal:Core, prototype Throwable> final public method getCode ] {
+
+      - Parameters [0] {
+      }
     }
 
-    Method [ <internal:Core> final public method getLine ] {
+    Method [ <internal:Core, prototype Throwable> final public method getFile ] {
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
     }
 
-    Method [ <internal:Core> final public method getTrace ] {
+    Method [ <internal:Core, prototype Throwable> final public method getLine ] {
+
+      - Parameters [0] {
+      }
+      - Return [ int ]
     }
 
-    Method [ <internal:Core> final public method getPrevious ] {
+    Method [ <internal:Core, prototype Throwable> final public method getTrace ] {
+
+      - Parameters [0] {
+      }
+      - Return [ array ]
     }
 
-    Method [ <internal:Core> final public method getTraceAsString ] {
+    Method [ <internal:Core, prototype Throwable> final public method getPrevious ] {
+
+      - Parameters [0] {
+      }
+      - Return [ ?Throwable ]
     }
 
-    Method [ <internal:Core> public method __toString ] {
+    Method [ <internal:Core, prototype Throwable> final public method getTraceAsString ] {
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
+    }
+
+    Method [ <internal:Core, prototype Stringable> public method __toString ] {
+
+      - Parameters [0] {
+      }
+      - Return [ string ]
     }
   }
 }

--- a/reference/reflection/reflectionfunctionabstract/getreturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/getreturntype.xml
@@ -56,30 +56,27 @@ int
    </example>
 
    <example>
-    <title>Methods with a tentative return type</title>
+    <title>Usage on built-in functions</title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-$reflection2 = new ReflectionMethod('ArrayObject', 'count');
+$reflection2 = new ReflectionFunction('fopen');
 
 var_dump($reflection2->getReturnType());
-echo $reflection2->getTentativeReturnType();
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
 NULL
-int
 ]]>
     </screen>
    </example>
   </para>
   <simpara>
-   A tentative return type is not reported here; use
-   <methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname>
-   to obtain it.
+   Internal functions that return a resource have no declared return type,
+   because <literal>resource</literal> cannot be used in a type declaration.
   </simpara>
  </refsect1>
 
@@ -87,7 +84,6 @@ int
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname></member>
     <member><methodname>ReflectionFunctionAbstract::hasReturnType</methodname></member>
     <member><methodname>ReflectionType::__toString</methodname></member>
    </simplelist>

--- a/reference/reflection/reflectionfunctionabstract/getreturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/getreturntype.xml
@@ -56,28 +56,30 @@ int
    </example>
 
    <example>
-    <title>Usage on built-in functions</title>
+    <title>Methods with a tentative return type</title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-$reflection2 = new ReflectionFunction('array_merge');
+$reflection2 = new ReflectionMethod('ArrayObject', 'count');
 
 var_dump($reflection2->getReturnType());
+echo $reflection2->getTentativeReturnType();
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-null
+NULL
+int
 ]]>
     </screen>
    </example>
   </para>
   <para>
-   This is because many internal functions do not have types specified for their
-   parameters or return values. It is therefore best to avoid using this
-   method on built-in functions.
+   A tentative return type is not reported here; use
+   <methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname>
+   to obtain it.
   </para>
  </refsect1>
 
@@ -85,6 +87,7 @@ null
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname></member>
     <member><methodname>ReflectionFunctionAbstract::hasReturnType</methodname></member>
     <member><methodname>ReflectionType::__toString</methodname></member>
    </simplelist>

--- a/reference/reflection/reflectionfunctionabstract/getreturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/getreturntype.xml
@@ -76,11 +76,11 @@ int
     </screen>
    </example>
   </para>
-  <para>
+  <simpara>
    A tentative return type is not reported here; use
    <methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname>
    to obtain it.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
@@ -56,22 +56,20 @@ bool(true)
    </example>
 
    <example>
-    <title>Methods with a tentative return type</title>
+    <title>Usage on built-in functions</title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-$reflection2 = new ReflectionMethod('ArrayObject', 'count');
+$reflection2 = new ReflectionFunction('fopen');
 
 var_dump($reflection2->hasReturnType());
-var_dump($reflection2->hasTentativeReturnType());
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
 bool(false)
-bool(true)
 ]]>
     </screen>
    </example>
@@ -83,7 +81,6 @@ bool(true)
   <para>
    <simplelist>
     <member><methodname>ReflectionFunctionAbstract::getReturnType</methodname></member>
-    <member><methodname>ReflectionFunctionAbstract::hasTentativeReturnType</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
@@ -56,20 +56,22 @@ bool(true)
    </example>
 
    <example>
-    <title>Usage on built-in functions</title>
+    <title>Methods with a tentative return type</title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-$reflection2 = new ReflectionFunction('array_merge');
+$reflection2 = new ReflectionMethod('ArrayObject', 'count');
 
 var_dump($reflection2->hasReturnType());
+var_dump($reflection2->hasTentativeReturnType());
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
 bool(false)
+bool(true)
 ]]>
     </screen>
    </example>
@@ -81,6 +83,7 @@ bool(false)
   <para>
    <simplelist>
     <member><methodname>ReflectionFunctionAbstract::getReturnType</methodname></member>
+    <member><methodname>ReflectionFunctionAbstract::hasTentativeReturnType</methodname></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Follow-up to #5718, from the same audit: the examples where PHP's own behaviour moved and the `<screen>` was never updated. One commit per kind of change.

- `+`/`-` vs `.` precedence ([8.0](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.other)), constants left of `instanceof` ([7.3](https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.instanceof-literals))
- reading a missing array key is a warning ([8.0](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.other)); the `BackedEnum::from()` ValueError no longer quotes the enum name (8.2)
- internal functions declare return types (8.0)
- anonymous class naming ([8.0](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.other)), `var_export()` leading backslash ([8.2](https://www.php.net/manual/en/migration82.incompatible.php#migration82.incompatible.standard))
- `mb_detect_encoding()` non-strict detection ([8.3](https://www.php.net/manual/en/migration83.other-changes.php#migration83.other-changes.functions.mbstring))
- `ReflectionClass::__toString()` regenerated rather than attributed to one change; the `Exception` dump has drifted across several releases

Where a corrected screen would leave the page contradicting itself, the prose or comment moves with it: the `foreach` "notice" sentence, two comments in the precedence example, the `mb_detect_encoding()` comment, and the anonymous class note. The two reflection examples needed replacing outright — they used `array_merge()` to show that internals report no return type, which it now does, so a method with a tentative return type takes its place.

<details>
<summary>Pages to check with Run code</summary>

Press Run code and the output that appears is what this PR puts in the `<screen>`. The static one still on these pages is the "before" side of the diff, until the manual is rebuilt.

- https://www.php.net/manual/en/language.operators.precedence.php
- https://www.php.net/manual/en/language.operators.type.php
- https://www.php.net/manual/en/control-structures.foreach.php
- https://www.php.net/manual/en/backedenum.from.php
- https://www.php.net/manual/en/reflectionfunctionabstract.getreturntype.php
- https://www.php.net/manual/en/reflectionfunctionabstract.hasreturntype.php
- https://www.php.net/manual/en/reflectionclass.tostring.php
- https://www.php.net/manual/en/language.oop5.anonymous.php
- https://www.php.net/manual/en/language.oop5.magic.php
- https://www.php.net/manual/en/function.mb-detect-encoding.php

</details>
---

**P.S.** — after the review on #5718, every example in this PR was re-run on 8.2, 8.3, 8.4 and 8.5 rather than trusted to Run code, which is one wasm build of one version.

That turned up one case: `mb_detect_encoding()`'s non-strict change landed in 8.3.0, so 8.2 still prints the old result and a single screen cannot cover both. Both examples on that page are now split with `&example.outputs.82;` / `&example.outputs.83;` — the basic example was already showing only the 8.3 behaviour, so it is split too rather than leaving one page inconsistent with itself.

Everything else agrees across 8.2–8.5, including the line numbers in the two `Fatal error:` screens and the `ReflectionClass::__toString()` dump of `Exception`.
