### PR TITLE
uri: Fix Uri\WhatWg\Url screens that ignore URL normalization

### DIFF
--- a/reference/uri/uri/whatwg/url/getport.xml
+++ b/reference/uri/uri/whatwg/url/getport.xml
@@ -35,16 +35,20 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$url = new \Uri\WhatWg\Url("https://example.com:443");
+$url = new \Uri\WhatWg\Url("https://example.com:8080");
+var_dump($url->getPort());
 
-echo $url->getPort();
+// 443 is the default port for https, so it is not stored.
+$url = new \Uri\WhatWg\Url("https://example.com:443");
+var_dump($url->getPort());
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-443
+int(8080)
+NULL
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -79,7 +79,7 @@ if ($url !== null) {
    &example.outputs;
    <screen>
 <![CDATA[
-Valid URL: https://example.com
+Valid URL: https://example.com/
 ]]>
    </screen>
   </example>

--- a/reference/uri/uri/whatwg/url/withport.xml
+++ b/reference/uri/uri/whatwg/url/withport.xml
@@ -50,16 +50,21 @@
 <![CDATA[
 <?php
 $url = new \Uri\WhatWg\Url("https://example.com:8080");
-$url = $url->withPort(443);
 
-echo $url->getPort();
+// 443 is the default port for https, so it is not stored.
+$url = $url->withPort(443);
+var_dump($url->getPort());
+
+$url = $url->withPort(8443);
+var_dump($url->getPort());
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-443
+NULL
+int(8443)
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
Third batch from the audit behind #5718: screens that do not match what their example prints.

`Uri\WhatWg\Url::getPort()` and `withPort()` echoed a port that WHATWG normalization removes, so both printed nothing while the screens claimed 443. They use `var_dump()` now, and show a port that survives normalization and one that does not. `Url::parse()` gains the `/` that normalization adds to an empty path.

Three more screens were here and have been dropped. Two had wrong values that nothing in the examples depends on, and the third is now #5740.

Press Run code on these pages and the output that appears is what this PR puts in the `<screen>`:

- https://www.php.net/manual/en/uri-whatwg-url.getport.php
- https://www.php.net/manual/en/uri-whatwg-url.withport.php
- https://www.php.net/manual/en/uri-whatwg-url.parse.php
