### PR TITLE
Fix incorrect claim that opcache_invalidate() skips the file cache

### DIFF
--- a/reference/opcache/functions/opcache-invalidate.xml
+++ b/reference/opcache/functions/opcache-invalidate.xml
@@ -17,7 +17,9 @@
    This function invalidates a particular script from the opcode cache. If
    <parameter>force</parameter> is unset or &false;, the script will only be
    invalidated if the modification time of the script is newer than the cached
-   opcodes. This function only invalidates in-memory cache and not file cache.
+   opcodes. If the <link linkend="ini.opcache.file-cache">opcache.file_cache</link>
+   directive is enabled, this function also invalidates the corresponding
+   file cache entry.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
## Summary
- `opcache_invalidate()`'s description states it "only invalidates in-memory cache and not file cache", which is incorrect.
- Since file cache support was added in 2015, `zend_accel_invalidate()` in `ext/opcache/ZendAccelerator.c` calls `zend_file_cache_invalidate()` whenever `opcache.file_cache` is enabled, which deletes the corresponding compiled file from the file cache (`zend_file_cache_unlink()` in `ext/opcache/zend_file_cache.c`).
- Updated the description to describe the actual behavior instead.

Closes #5696

## Test plan
- [ ] Validated the XML with `configure.php` (no local build environment set up here, would appreciate a CI check)