### PR TITLE
Fix reference to non-existent "example three"

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -40,12 +40,12 @@
     </example>
    </para>
 
-   <para>
+   <simpara>
     Short tags (the third line in the example above) are available by default but can be disabled
     either via the <link linkend="ini.short-open-tag">short_open_tag</link>
     &php.ini; configuration file directive, or are disabled by default if
     PHP is built with the <option>--disable-short-tags</option> configuration.
-   </para>
+   </simpara>
    <para>
     <note>
      <para>

--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -41,7 +41,7 @@
    </para>
 
    <para>
-    Short tags (example three) are available by default but can be disabled
+    Short tags (the third line in the example above) are available by default but can be disabled
     either via the <link linkend="ini.short-open-tag">short_open_tag</link>
     &php.ini; configuration file directive, or are disabled by default if
     PHP is built with the <option>--disable-short-tags</option> configuration.


### PR DESCRIPTION
## Summary
- The short tags paragraph in `language.basic-syntax.phptags` referred to "example three", but the page only has a single `<example>` block containing three manually numbered code snippets (1., 2., 3.), not three separate DocBook examples.
- Reworded the reference to point to the third line of that example instead, so it doesn't refer to a non-existent "example three".

Closes #5685