### PR TITLE
Update LuaSandbox installation method

### DIFF
--- a/reference/luasandbox/setup.xml
+++ b/reference/luasandbox/setup.xml
@@ -25,23 +25,35 @@
 
  <section xml:id="luasandbox.installation">
   &reftitle.install;
-  <simpara>
-   &pecl.moved;
-  </simpara>
-  <simpara>
-   &pecl.info;
-   <link xlink:href="&url.pecl.package;luasandbox">&url.pecl.package;luasandbox</link>.
-  </simpara>
+
   <para>
    If the operating system is Debian 10 or later, or Ubuntu 18.04 or later, then
    LuaSandbox should typically be installed from the package
    <literal>php-luasandbox</literal>:
-   <screen>
+
+   <programlisting role="shell">
 <![CDATA[
 sudo apt-get install php-luasandbox
 ]]>
-   </screen>
+   </programlisting>
   </para>
+
+  <para>
+   To install LuaSandbox using <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.pie;">PIE</link>,
+   run the following command:
+   <programlisting role="shell">
+<![CDATA[
+pie install wikimedia/luasandbox
+]]>
+   </programlisting>
+  </para>
+
+  <note>
+   <simpara>
+    Old releases can be found in the <link xlink:href="&url.pecl.package;luasandbox">LuaSandbox PECL package</link>.
+   </simpara>
+  </note>
+
  </section>
 
 </chapter>


### PR DESCRIPTION
New releases will be in PIE and Debian.

MongoDB seemed to be the nearest analogy, but what we need to say here is a lot simpler, so I pared it down to a single section. I used `programlisting` for the shell commands, as in MongoDB.