### PR TITLE
Print minutes as minutes in the date_sun_info() length of day example

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -276,13 +276,13 @@ $si = date_sun_info(strtotime('2022-08-26'), 50.45, 30.52);
 $diff = $si['sunset'] - $si['sunrise'];
 echo "Length of day: ",
     floor($diff / 3600), "h ",
-    floor(($diff % 3600) / 60), "s\n";
+    floor(($diff % 3600) / 60), "m\n";
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Length of day: 13h 53s
+Length of day: 13h 53m
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
The example divides the remainder of the hours by 60, so the second figure is minutes, not seconds: the day is 13:53:15 long. #5718 corrected the value in this screen without touching the unit.
