### PR TITLE
ext/simplexml: document that get methods and casts no longer implicitly rewind (PHP 8.4)

### DIFF
--- a/reference/simplexml/simplexmlelement.xml
+++ b/reference/simplexml/simplexmlelement.xml
@@ -57,6 +57,18 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Get methods (such as
+        <methodname>SimpleXMLElement::asXML</methodname> or
+        <methodname>SimpleXMLElement::getName</methodname>) and casting a
+        <classname>SimpleXMLElement</classname> to a &string; no longer
+        implicitly rewind the iterator.
+        The iterator must now be rewound explicitly, using
+        <methodname>SimpleXMLElement::rewind</methodname>, where needed.
+       </entry>
+      </row>
+      <row>
        <entry>8.0.0</entry>
        <entry>
         <classname>SimpleXMLElement</classname> implements

--- a/reference/simplexml/simplexmlelement/rewind.xml
+++ b/reference/simplexml/simplexmlelement/rewind.xml
@@ -22,6 +22,17 @@
   <para>
    This method rewinds the <classname>SimpleXMLElement</classname> to the first element.
   </para>
+
+  <note>
+   <simpara>
+    As of PHP 8.4.0, calling get methods (such as
+    <methodname>SimpleXMLElement::asXML</methodname> or
+    <methodname>SimpleXMLElement::getName</methodname>) or casting a
+    <classname>SimpleXMLElement</classname> to a &string; no longer
+    implicitly rewinds the iterator. Where required, the iterator must be
+    rewound explicitly by calling this method.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Resolves the following issue:

https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826662
