### PR TITLE
ext/opcache: document the JIT default change and startup fatal error (PHP 8.4)

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1158,7 +1158,8 @@ function getA() { return A; }
      <member><literal>off</literal>:  Disabled, but can be enabled at runtime.</member>
      <member>
       <literal>tracing</literal>/<literal>on</literal>: Use tracing JIT.
-      Enabled by default and recommended for most users.
+      Recommended for most users. Prior to PHP 8.4.0, this was the default
+      value; as of PHP 8.4.0 the default is <literal>disable</literal>.
      </member>
      <member><literal>function</literal>: Use function JIT.</member>
     </simplelist>
@@ -1220,6 +1221,12 @@ function getA() { return A; }
      The <literal>"tracing"</literal> mode corresponds to <code>CRTO = 1254</code>,
      the <literal>"function"</literal> mode corresponds to <code>CRTO = 1205</code>.
     </para>
+    <note>
+     <simpara>
+      As of PHP 8.4.0, if the JIT is enabled, PHP exits with a fatal error
+      during startup when JIT initialization fails.
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="ini.opcache.jit-buffer-size">

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1223,7 +1223,7 @@ function getA() { return A; }
     </para>
     <note>
      <simpara>
-      As of PHP 8.4.0, if the JIT is enabled, PHP exits with a fatal error
+      As of PHP 8.4.0, if JIT is enabled, PHP exits with a fatal error
       during startup when JIT initialization fails.
      </simpara>
     </note>


### PR DESCRIPTION
Resolves the following issues:

https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826068
https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826076
