### PR TITLE
ext/pcre: document variable-length lookbehind and longer subpattern names (PHP 8.4)

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1510,6 +1510,10 @@
    also by name. There are two alternative syntaxes
    <literal>(?&lt;name&gt;pattern)</literal> and <literal>(?'name'pattern)</literal>.
   </para>
+  <simpara>
+   As of PHP 8.4.0, which bundles PCRE2 10.44, the maximum length of a
+   subpattern name is 128 characters; prior to PHP 8.4.0 it was 32 characters.
+  </simpara>
 
   <para>
    Sometimes it is necessary to have multiple matching, but alternating
@@ -1915,6 +1919,14 @@
    at the ends of strings; an example is given at the end
    of the section on once-only subpatterns.
   </para>
+  <simpara>
+   The fixed-length restriction described above applies prior to PHP 8.4.0.
+   As of PHP 8.4.0, which bundles PCRE2 10.44, a lookbehind assertion may match
+   strings of variable length: alternatives of differing lengths (such as
+   <literal>(?&lt;!dogs?|cats?)</literal>) and top-level branches that can match
+   more than one length (such as <literal>(?&lt;=ab(c|de))</literal>) are now
+   permitted, up to an implementation-defined maximum length.
+  </simpara>
   <para>
    Several assertions (of any sort) may occur in succession.
    For example,

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1512,7 +1512,7 @@
   </para>
   <simpara>
    As of PHP 8.4.0, which bundles PCRE2 10.44, the maximum length of a
-   subpattern name is 128 characters; prior to PHP 8.4.0 it was 32 characters.
+   subpattern name is 128 characters; previously it was 32 characters.
   </simpara>
 
   <para>

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1878,37 +1878,24 @@
    when the next three characters are "bar". A lookbehind
    assertion is needed to achieve this effect.
   </para>
-  <para>
+  <simpara>
    <emphasis>Lookbehind</emphasis> assertions start with (?&lt;= for positive assertions
    and (?&lt;! for negative assertions. For example,
 
    <literal>(?&lt;!foo)bar</literal>
 
    does find an occurrence of "bar" that is not preceded by
-   "foo". The contents of a lookbehind assertion are restricted
-   such that all the strings it matches must have a fixed
-   length. However, if there are several alternatives, they do
-   not all have to have the same fixed length. Thus
-
-   <literal>(?&lt;=bullock|donkey)</literal>
-
-   is permitted, but
+   "foo". A lookbehind assertion may match strings of variable
+   length, up to an implementation-defined maximum length.
+   Alternatives of differing lengths, such as
 
    <literal>(?&lt;!dogs?|cats?)</literal>
 
-   causes an error at compile time. Branches that match different
-   length strings are permitted only at the top level of
-   a lookbehind assertion. This is an extension compared with
-   Perl 5.005, which requires all branches to match the same
-   length of string. An assertion such as
+   and top-level branches that can match more than one length, such as
 
    <literal>(?&lt;=ab(c|de))</literal>
 
-   is not permitted, because its single top-level branch can
-   match two different lengths, but it is acceptable if rewritten
-   to use two top-level branches:
-
-   <literal>(?&lt;=abc|abde)</literal>
+   are permitted.
 
    The implementation of lookbehind assertions is, for each
    alternative, to temporarily move the current position back
@@ -1918,14 +1905,32 @@
    once-only subpatterns can be particularly useful for matching
    at the ends of strings; an example is given at the end
    of the section on once-only subpatterns.
-  </para>
+  </simpara>
   <simpara>
-   The fixed-length restriction described above applies prior to PHP 8.4.0.
-   As of PHP 8.4.0, which bundles PCRE2 10.44, a lookbehind assertion may match
-   strings of variable length: alternatives of differing lengths (such as
-   <literal>(?&lt;!dogs?|cats?)</literal>) and top-level branches that can match
-   more than one length (such as <literal>(?&lt;=ab(c|de))</literal>) are now
-   permitted, up to an implementation-defined maximum length.
+   Prior to PHP 8.4.0, which bundles PCRE2 10.44, the contents of a lookbehind
+   assertion were restricted such that all the strings it matched had to have a
+   fixed length. If there were several alternatives, they did not all have to
+   have the same fixed length, thus
+
+   <literal>(?&lt;=bullock|donkey)</literal>
+
+   was permitted, but
+
+   <literal>(?&lt;!dogs?|cats?)</literal>
+
+   caused an error at compile time. Branches that matched different
+   length strings were permitted only at the top level of
+   a lookbehind assertion. This was an extension compared with
+   Perl 5.005, which required all branches to match the same
+   length of string. An assertion such as
+
+   <literal>(?&lt;=ab(c|de))</literal>
+
+   was not permitted, because its single top-level branch could
+   match two different lengths, but it was acceptable if rewritten
+   to use two top-level branches:
+
+   <literal>(?&lt;=abc|abde)</literal>
   </simpara>
   <para>
    Several assertions (of any sort) may occur in succession.


### PR DESCRIPTION
Resolves the following issues:

https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826167
https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826180

**Sources**

- variable-length lookbehind and the 128-character subpattern name limit come from the PCRE2 10.44 bundled in PHP 8.4.0: php/php-src@d1f14a46095571b1b6363fa7f83c6a681d1d02de (`ext/pcre: update to PCRE2 v10.44`, php/php-src#14498)

Checked on `php:8.3-cli` (PCRE 10.42) and `php:8.4-cli` (PCRE 10.44):

- `(?<!dogs?|cats?)bar` and `(?<=ab(c|de))x` fail to compile on 8.3 and compile and match on 8.4
- the longest accepted subpattern name is 32 characters on 8.3 and 128 on 8.4
