### PR TITLE
Set the timezone in the date_sun_info() example

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -175,6 +175,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+date_default_timezone_set('Asia/Jerusalem');
 $sun_info = date_sun_info(strtotime("2006-12-12"), 31.7667, 35.2333);
 foreach ($sun_info as $key => $val) {
     echo "$key: " . date("H:i:s", $val) . "\n";
@@ -184,15 +185,15 @@ foreach ($sun_info as $key => $val) {
     &example.outputs;
     <screen>
 <![CDATA[
-sunrise: 05:52:11
-sunset: 15:41:21
-transit: 10:46:46
-civil_twilight_begin: 05:24:08
-civil_twilight_end: 16:09:24
-nautical_twilight_begin: 04:52:25
-nautical_twilight_end: 16:41:06
-astronomical_twilight_begin: 04:21:32
-astronomical_twilight_end: 17:12:00
+sunrise: 06:29:21
+sunset: 16:36:00
+transit: 11:32:41
+civil_twilight_begin: 06:02:36
+civil_twilight_end: 17:02:45
+nautical_twilight_begin: 05:32:14
+nautical_twilight_end: 17:33:08
+astronomical_twilight_begin: 05:02:31
+astronomical_twilight_end: 18:02:51
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Split out of #5721, from the audit behind #5718.

The `date_sun_info()` example formatted its timestamps with `date()`, so the times it printed depended on whatever timezone the reader had configured. The coordinates are in Jerusalem, and the example now sets that zone.

Press Run code here and the output that appears is what this PR puts in the `<screen>`: https://www.php.net/manual/en/function.date-sun-info.php
