### PR TITLE
Fix typos and update stale references in debian.xml

### DIFF
--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -35,8 +35,8 @@
     </programlisting>
    </example>
    <simpara>
-    APT will automatically install the PHP module for Apache 2 and all of its
-    dependencies, and then activate it.  Apache should be restarted in order for
+APT will automatically install the PHP module for Apache httpd 2 and all of its
+dependencies, and then activate it.  Apache httpd should be restarted in order for
     the changes to take place. For example:
    </simpara>
    <example xml:id="install.unix.debian.apt.example2">

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -27,7 +27,7 @@
     <command>apt update</command>.
    </simpara>
    <example xml:id="install.unix.debian.apt.example">
-    <title>Debian Install Example with Apache 2</title>
+    <title>Debian Install Example with Apache httpd 2</title>
     <programlisting role="shell">
 <![CDATA[
 # apt install php-common libapache2-mod-php php-cli

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -87,8 +87,9 @@ dependencies, and then activate it.  Apache httpd should be restarted in order f
    <simpara>
     APT will automatically add the appropriate lines to the
     different &php.ini; related files like 
-    <filename>/etc/php/8.x/php.ini</filename>,
-    <filename>/etc/php/8.x/conf.d/*.ini</filename>, etc. and depending on
+    <filename>/etc/php/8.x/apache2/php.ini</filename>,
+    <filename>/etc/php/8.x/cli/php.ini</filename>,
+    <filename>/etc/php/8.x/mods-available/*.ini</filename>, etc. and depending on
     the extension will add entries similar to <literal>extension=foo.so</literal>.
     However, restarting the web server is required before these
     changes take effect.

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -18,7 +18,7 @@
   <title>Using APT</title>
    <simpara>
     First, note that other related packages may be desired like
-    <literal>libapache-mod-php</literal> to integrate with Apache 2, and
+    <literal>libapache2-mod-php</literal> to integrate with Apache httpd 2, and
     <literal>php-pear</literal> for PEAR.
    </simpara>
    <simpara>
@@ -37,14 +37,13 @@
    <simpara>
     APT will automatically install the PHP module for Apache 2 and all of its
     dependencies, and then activate it.  Apache should be restarted in order for
-    the changes take place. For example:
+    the changes to take place. For example:
    </simpara>
    <example xml:id="install.unix.debian.apt.example2">
-    <title>Stopping and starting Apache once PHP is installed</title>
+    <title>Restarting Apache httpd once PHP is installed</title>
     <programlisting role="shell">
 <![CDATA[
-# /etc/init.d/apache2 stop
-# /etc/init.d/apache2 start
+# systemctl restart apache2
 ]]>
     </programlisting>
    </example>
@@ -88,10 +87,10 @@
    <simpara>
     APT will automatically add the appropriate lines to the
     different &php.ini; related files like 
-    <filename>/etc/php/7.4/php.ini</filename>,
-    <filename>/etc/php/7.4/conf.d/*.ini</filename>, etc. and depending on
+    <filename>/etc/php/8.x/php.ini</filename>,
+    <filename>/etc/php/8.x/conf.d/*.ini</filename>, etc. and depending on
     the extension will add entries similar to <literal>extension=foo.so</literal>.
-    However, restarting the web server (like Apache) is required before these
+    However, restarting the web server is required before these
     changes take effect.
    </simpara>
  </sect2>
@@ -137,3 +136,4 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
+


### PR DESCRIPTION
Updated obsolete init.d example to systemctl, corrected package name, and replaced EOL PHP 7.4 path references with current 8.x.