### PR TITLE
Fix naming, paths, and add php-fpm to install example in dnf.xml

### DIFF
--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -28,7 +28,7 @@
    <title>DNF Install Example</title>
    <programlisting role="shell">
 <![CDATA[
-# dnf install php php-common
+# dnf install php php-common php-fpm
 ]]>
    </programlisting>
   </example>
@@ -38,7 +38,7 @@
    For example:
   </simpara>
   <example xml:id="install.unix.dnf.example2">
-   <title>Restarting Apache once PHP is installed</title>
+   <title>Restarting Apache httpd once PHP is installed</title>
    <programlisting role="shell">
 <![CDATA[
 # sudo systemctl restart httpd
@@ -86,10 +86,9 @@
   <simpara>
    DNF will automatically add the appropriate lines to the
    different &php.ini; related files like
-   <filename>/etc/php/8.3/php.ini</filename>,
-   <filename>/etc/php/8.3/conf.d/*.ini</filename>, etc. and depending on
+   <filename>/etc/php.d/*.ini</filename>, etc. and depending on
    the extension will add entries similar to <literal>extension=foo.so</literal>.
-   However, restarting the web server (like Apache) is required before these
+   However, restarting the web server and PHP-FPM is required before these
    changes take effect.
   </simpara>
  </sect2>
@@ -114,3 +113,4 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
+

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -86,6 +86,7 @@
   <simpara>
    DNF will automatically add the appropriate lines to the
    different &php.ini; related files like
+   <filename>/etc/php.ini</filename>,
    <filename>/etc/php.d/*.ini</filename>, etc. and depending on
    the extension will add entries similar to <literal>extension=foo.so</literal>.
    However, restarting the web server and PHP-FPM is required before these


### PR DESCRIPTION
Use "Apache httpd" per project naming convention. Replace incorrect Debian-style /etc/php/8.3/ paths with the actual DNF-based distro layout (/etc/php.d/). Add php-fpm to the install example since it is the default SAPI on these systems. Note PHP-FPM as the service to restart.