### PR TITLE
use simpara for simple  paragraphs

### DIFF
--- a/install/unix/commandline.xml
+++ b/install/unix/commandline.xml
@@ -2,14 +2,14 @@
 <!-- $Revision$ -->
   <sect1 xml:id="install.unix.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>CGI and command line setups</title>
-   <para>
+   <simpara>
     By default, PHP is built as both a <acronym>CLI</acronym> and
     <acronym>CGI</acronym> program, which can be used for CGI
     processing. If you are running a web server that PHP has module
     support for, you should generally go for that solution for
     performance reasons. However, the CGI version enables users to run
     different PHP-enabled pages under different user-ids.
-   </para>
+   </simpara>
    &warn.install.cgi;
    
    <sect2 xml:id="install.unix.commandline.testing">

--- a/install/unix/lighttpd-14.xml
+++ b/install/unix/lighttpd-14.xml
@@ -3,29 +3,29 @@
 <sect1 xml:id="install.unix.lighttpd-14" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Lighttpd 1.4 on Unix systems</title>
 
- <para>
+ <simpara>
   This section contains notes and hints specific to Lighttpd 1.4 installs
   of PHP on Unix systems.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Please use the <link xlink:href="&url.lighttpd.doc;">Lighttpd trac</link>
   to learn how to install Lighttpd properly before continuing.
- </para>
+ </simpara>
  
- <para>
+ <simpara>
   FastCGI is the preferred SAPI to connect PHP and Lighttpd. FastCGI is
   automagically enabled in php-cgi.
- </para>
+ </simpara>
  
  <sect2 xml:id="install.unix.lighttpd-14.lighttpd-spawn">
   <title>Letting Lighttpd spawn php processes</title>
 
-  <para>
+  <simpara>
    To configure Lighttpd to connect to PHP and spawn FastCGI processes, edit
    <filename>lighttpd.conf</filename>. Sockets are preferred to connect to FastCGI processes on
    the local system.
-  </para>
+  </simpara>
 
   <example>
    <title>Partial lighttpd.conf</title>
@@ -68,22 +68,22 @@ fastcgi.server = ( ".php" =>
  <sect2 xml:id="install.unix.lighttpd-14.spawn-fcgi">
   <title>Spawning with spawn-fcgi</title>  
 
-  <para>
+  <simpara>
    Lighttpd provides a program called spawn-fcgi to make the process of
    spawning FastCGI processes easier.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="install.unix.lighttpd-14.spawn-php">
   <title>Spawning php-cgi</title>
 
-  <para>
+  <simpara>
    It is possible to spawn processes without spawn-fcgi, though a bit of
    heavy-lifting is required. Setting the <envar>PHP_FCGI_CHILDREN</envar> environment var
    controls how many children PHP will spawn to handle incoming requests.
    Setting <envar>PHP_FCGI_MAX_REQUESTS</envar> will determine how long (in requests) each
    child will live. Here's a simple bash script to help spawn php responders.
-  </para>
+  </simpara>
      
   <example>
    <title>Spawning FastCGI Responders</title>
@@ -119,10 +119,10 @@ echo $! > "$PHP_PID"
  <sect2 xml:id="install.unix.lighttpd-14.remote-fcgi">
   <title>Connecting to remote FCGI instances</title>
 
-  <para>
+  <simpara>
    FastCGI instances can be spawned on multiple remote machines in order to
    scale applications.
-  </para>
+  </simpara>
    
   <example>
    <title>Connecting to remote php-fastcgi instances</title>

--- a/install/unix/litespeed.xml
+++ b/install/unix/litespeed.xml
@@ -3,51 +3,51 @@
 <sect1 xml:id="install.unix.litespeed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>LiteSpeed Web Server/OpenLiteSpeed Web Server on Unix systems</title>
 
- <para>
+ <simpara>
   LiteSpeed PHP is an optimized compilation of PHP built to work with LiteSpeed
   products through the LiteSpeed SAPI. LSPHP runs as its own process and has 
   its own standalone binary, which can be used as a simple command line binary to execute 
   PHP scripts from the command line.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   The LSAPI is a highly optimized API that allows communication between 
   LiteSpeed and third party web engines. Its protocol is similar to FCGI, but is 
   more efficient.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   This documentation will cover installing and configuring PHP with LSAPI 
   for a LiteSpeed Web Server and OpenLiteSpeed Web Server.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   This guide will assume that either LSWS or OLS is installed with their 
   default paths and flags. The default installation directory for both web 
   servers is /usr/local/lsws and both can be run from the bin subdirectory.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Please note that throughout this documentation, version numbers have been 
   replaced with an <literal>x</literal> to ensure this documentation stays correct in the future, 
   please replace these, as necessary, with the corresponding version numbers.
- </para>
+ </simpara>
 
  <orderedlist>
   <listitem>
-   <para>
+   <simpara>
     To obtain and install either LiteSpeed Web Server or OpenLiteSpeed Web Server, visit the
     LiteSpeed Web Server documentation
     <link xlink:href="&url.litespeed.lsws;">install page</link>
     or OpenLiteSpeed documentation 
     <link xlink:href="&url.litespeed.install;">install page</link>.
-   </para>
+   </simpara>
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Obtain and unpack the php source:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.litespeed.extract.php">
     <screen>
@@ -63,12 +63,12 @@ cd php-x.x.x
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Configure and build PHP. This is where PHP can be customized with various options,
     such as which extensions will be enabled. Run ./configure --help for a list of available 
     options. In the example, we'll use the default recommended configuration options for 
     LiteSpeed Web Server:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.litespeed.build.php">
     <screen>
@@ -82,14 +82,14 @@ sudo make install
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Checking The LSPHP Installation
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     One of the simplest ways to check whether the installation of PHP was successful
     is to run the following code:
-   </para>
+   </simpara>
 
    <informalexample>
     <screen>
@@ -100,9 +100,9 @@ cd /usr/local/lsws/fcgi-bin/
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     This should return information about the new PHP build:
-   </para>
+   </simpara>
 
    <informalexample>
     <screen>
@@ -114,45 +114,45 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Notice the <literal>litespeed</literal> in parenthesis. This means that the PHP binary has been 
     built with LSAPI support.
-   </para>
+   </simpara>
   </listitem>
  </orderedlist>
 
- <para>
+ <simpara>
   Following the steps above, LiteSpeed / OpenLiteSpeed Web Server should 
   now be running with support for PHP as an SAPI extension. There are many more
   configuration options available for LSWS / OLS and PHP. For more information,
   check out the LiteSpeed documentation about 
   <link xlink:href="&url.litespeed.php;">PHP</link>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Using LSPHP from the command line:
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   LSPHP(LSAPI + PHP) command line mode is used to process PHP scripts running 
   on a remote server that does not necessarily have a web server running. It is used 
   to process PHP scripts residing on a local web server (separate). This setup is 
   suitable for service scalability as PHP processing is offloaded to a remote server.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Start lsphp from the command line on a remote server:
   LSPHP is an executable and can be started manually and bound to IPv4, IPv6, or 
   Unix domain socket addresses with the command line option -b socket_address
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Examples:
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Have LSPHP bind to port 3000 on all IPv4 and IPv6 addresses:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -162,9 +162,9 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Have LSPHP bind to port 3000 on all IPv4 addresses:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -174,9 +174,9 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Have LSPHP bind to address 192.168.0.2:3000:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -186,9 +186,9 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Have LSPHP accept requests on Unix domain socket <literal>/tmp/lsphp_manual.sock</literal>:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -198,9 +198,9 @@ Zend Engine v2.6.0, Copyright (c) 1998-2015 Zend Technologies
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Environment variables can be added before the LSPHP executable:
- </para>
+ </simpara>
 
  <informalexample>
   <screen>
@@ -210,41 +210,41 @@ PHP_LSAPI_MAX_REQUESTS=500 PHP_LSAPI_CHILDREN=35 /path/to/lsphp -b IP_address:po
   </screen>
  </informalexample>
 
- <para>
+ <simpara>
   Currently LiteSpeed PHP can be used with LiteSpeed Web Server, 
   OpenLiteSpeed Web Server, and Apache mod_lsapi. For steps on 
   server-side configuration, visit the documentation pages for 
   <link xlink:href="&url.litespeed.web.server;">LiteSpeed Web Server</link> 
   and <link xlink:href="&url.litespeed.open;">OpenLiteSpeed</link>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   LSPHP can be installed in several other ways as well.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   CentOS:
   On CentOS, LSPHP can be installed from the LiteSpeed Repository or the Remi 
   Repository  using <link xlink:href="&url.litespeed.packages;">RPM</link>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Debian:
   On Debian, LSPHP can be installed from the LiteSpeed Repository using 
   <link xlink:href="&url.litespeed.packages;">apt</link>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   cPanel:
   Visit the respective <link xlink:href="&url.litespeed.cpanel;">documentation page</link> 
   about how to install LSPHP with cPanel and LSWS/OLS using EasyApache 4.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Plesk:
   Plesk can be used with LSPHP on CentOS, CloudLinux, Debian, and Ubuntu, 
   for more details on this, visit the respective <link xlink:href="&url.litespeed.plesk;">documentation page</link>
- </para>
+ </simpara>
 </sect1>
 
 <!-- Keep this comment at the end of the file

--- a/install/unix/nginx.xml
+++ b/install/unix/nginx.xml
@@ -3,46 +3,46 @@
 <sect1 xml:id="install.unix.nginx" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nginx 1.4.x on Unix systems</title>
 
- <para>
+ <simpara>
   This documentation will cover installing and configuring PHP with
   PHP-FPM for a Nginx 1.4.x HTTP server.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   This guide will assume that you have built Nginx from source and therefore
   all binaries and configuration files are located at
   <literal>/usr/local/nginx</literal>. If this is not the case and you have
   obtained Nginx through other means then please refer to the
   <link xlink:href="&url.nginx;">Nginx Wiki</link> in order to translate
   this manual to your setup.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   This guide will cover the basics of configuring an Nginx server to
   process PHP applications and serve them on port 80, it is recommended
   that you study the Nginx and PHP-FPM documentation if you wish to
   optimise your setup past the scope of this documentation.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Please note that throughout this documentation version numbers have been
   replaced with an 'x' to ensure this documentation stays correct in the future,
   please replace these as necessary with the corresponding version numbers.
- </para>
+ </simpara>
 
  <orderedlist>
   <listitem>
-   <para>
+   <simpara>
     It is recommended that you visit the Nginx Wiki
     <link xlink:href="&url.nginx.wiki.install;">install</link> page 
     in order to obtain and install Nginx on your system.
-   </para>
+   </simpara>
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Obtain and unpack the PHP source:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.extract.php">
     <screen>
@@ -54,12 +54,12 @@ tar zxf php-x.x.x
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Configure and build PHP.  This is where you customize PHP
     with various options, like which extensions will be enabled. Run
     ./configure --help for a list of available options.  In our example
     we'll do a simple configure with PHP-FPM and MySQLi support.
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.build.php">
     <screen>
@@ -74,9 +74,9 @@ sudo make install
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Obtain and move configuration files to their correct locations
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.php">
     <screen>
@@ -90,19 +90,19 @@ cp sapi/fpm/php-fpm /usr/local/bin
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     It is important that we prevent Nginx from passing requests to the
     PHP-FPM backend if the file does not exist, allowing us to prevent
     arbitrarily script injection.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     We can fix this by setting the
     <link linkend="ini.cgi.fix-pathinfo">cgi.fix_pathinfo</link>
     directive to <literal>0</literal> within our php.ini file.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Load up php.ini:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.ini">
     <screen>
@@ -112,9 +112,9 @@ vim /usr/local/php/php.ini
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Locate <literal>cgi.fix_pathinfo=</literal> and modify it as follows:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.pathinfo">
     <screen>
@@ -126,10 +126,10 @@ cgi.fix_pathinfo=0
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     php-fpm.conf must be modified to specify that php-fpm must run as the user
     www-data and the group www-data before we can start the service:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.modify.phpfpm">
     <screen>
@@ -139,9 +139,9 @@ vim /usr/local/etc/php-fpm.d/www.conf
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Find and modify the following: 
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.modify.phpfpm.usergroup">
     <screen>
@@ -155,9 +155,9 @@ group = www-data
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     The php-fpm service can now be started:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.start.phpfpm">
     <screen>
@@ -167,16 +167,16 @@ group = www-data
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     This guide will not configure php-fpm any further, if you are interested
     in further configuring php-fpm then please consult the documentation.
-   </para>
+   </simpara>
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Nginx must now be configured to support the processing of PHP applications:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.nginx">
     <programlisting>
@@ -186,10 +186,10 @@ vim /usr/local/nginx/conf/nginx.conf
     </programlisting>
    </informalexample>
 
-   <para>
+   <simpara>
     Modify the default location block to be aware it must attempt
     to serve .php files:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.nginx.location">
     <programlisting role="nginx-conf">
@@ -202,11 +202,11 @@ location / {
     </programlisting>
    </informalexample>
 
-   <para>
+   <simpara>
     The next step is to ensure that .php files are passed to the
     PHP-FPM backend. Below the commented default PHP location block,
     enter the following:
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.configure.nginx.php">
     <programlisting role="nginx-conf">
@@ -222,9 +222,9 @@ location ~* \.php$ {
     </programlisting>
    </informalexample>
 
-   <para>
+   <simpara>
     Restart Nginx.
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.restart.nginx">
     <screen>
@@ -237,9 +237,9 @@ sudo /usr/local/nginx/sbin/nginx
   </listitem>
 
   <listitem>
-   <para>
+   <simpara>
     Create a test file
-   </para>
+   </simpara>
 
    <informalexample xml:id="install.unix.nginx.test.nginx.php">
     <screen>
@@ -250,19 +250,19 @@ echo "<?php phpinfo(); ?>" >> /usr/local/nginx/html/index.php
     </screen>
    </informalexample>
 
-   <para>
+   <simpara>
     Now navigate to http://localhost. The phpinfo() should now be shown.
-   </para>
+   </simpara>
   </listitem>
  </orderedlist>
 
- <para>
+ <simpara>
   Following the steps above you will have a running Nginx web server with
   support for PHP as an <literal>FPM</literal> <literal>SAPI</literal> module.  Of course there are
   many more configuration options available for Nginx and PHP.  For more
   information type <command>./configure --help</command> in the corresponding
   source tree.
- </para>
+ </simpara>
 
 </sect1>
 

--- a/install/unix/openbsd.xml
+++ b/install/unix/openbsd.xml
@@ -2,10 +2,10 @@
 <!-- $Revision$ -->
 <sect1 xml:id="install.unix.openbsd" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installing from packages or ports on OpenBSD</title>
- <para>
+ <simpara>
  This section contains notes and hints specific to installing
  PHP on <link xlink:href="&url.openbsd;">OpenBSD</link>.
- </para>
+ </simpara>
  <sect2 xml:id="install.unix.openbsd.packages">
   <title>Using Binary Packages</title>
    <simpara>

--- a/install/unix/solaris.xml
+++ b/install/unix/solaris.xml
@@ -2,18 +2,18 @@
 <!-- $Revision$ -->
 <sect1 xml:id="install.unix.solaris" xmlns="http://docbook.org/ns/docbook">
  <title><productname>Solaris</productname> specific installation tips</title>
- <para>
+ <simpara>
   This section contains notes and hints specific to installing
   PHP on <productname>Solaris</productname> systems.
- </para>
+ </simpara>
  <sect2 xml:id="install.unix.solaris.required">
   <title>Required software</title>
-  <para>
+  <simpara>
    <productname>Solaris</productname> installs often lack C compilers and their related tools.
    Read <link linkend="faq.installation.needgnu">this FAQ</link> 
    for information on why using GNU versions for some of these
    tools is necessary.
-  </para>
+  </simpara>
   <para>
    For unpacking the PHP distribution you need
    <itemizedlist>


### PR DESCRIPTION
Documentatio CI enforces the use of simpara rather than para for paragraphs containing only inline
content. Converted 62 instances of para to simpara across install/unix/ where no block-level elements (examples, lists, etc.) are nested within to simplify future patches.