### PR TITLE
sigmoidalcontrastimage.xml Amend parameter names

### DIFF
--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -24,7 +24,7 @@
    <parameter>beta</parameter> indicates where midtones fall in the resultant
    image, as a fraction of the quantum range: <literal>0.0</literal> is white,
    <literal>0.5</literal> is middle-gray, <literal>1.0</literal> is black
-   (multiply by <code>getQuantumRange()['quantumRangeLong']</code> to get the value to 
+   (multiply by <code>getQuantumRange()['quantumRangeLong']</code> to get the value to
    pass).
   </simpara>
   <simpara>
@@ -88,7 +88,7 @@
    &imagick.imagick.throws;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -108,7 +108,7 @@ function generateBlendImage($width, $height, $alpha = 10, $beta = 0.5)
     $quanta = $imagick->getQuantumRange();
     $imagick->sigmoidalContrastImage(true, $alpha, $beta * $quanta["quantumRangeLong"]);
 
-    return $imagick; 
+    return $imagick;
 }
 ]]>
    </programlisting>

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -18,10 +18,10 @@
   <para>
    Adjusts the contrast of an image with a non-linear sigmoidal contrast
    algorithm. Increase the contrast of the image using a sigmoidal transfer
-   function without saturating highlights or shadows. Contrast indicates
-   how much to increase the contrast (0 is none; 3 is typical; 20 is
-   pushing it); mid-point indicates where midtones fall in the resultant
-   image (0 is white; 50 is middle-gray; 100 is black). Set sharpen to
+   function without saturating highlights or shadows. <parameter>alpha</parameter> indicates
+   how much to increase the contrast: 0.00 is none; 3.00 is typical; 20.00 is pushing it.
+   <parameter>beta</parameter> indicates where midtones fall in the resultant
+   image: 0.00 is white; 0.50 is middle-gray; 1.00 is black. Set <parameter>sharpen</parameter> to
    &true; to increase the image contrast otherwise the contrast is reduced.
   </para>
   <para>
@@ -46,7 +46,7 @@
      <term><parameter>alpha</parameter></term>
      <listitem>
       <para>
-       The amount of contrast to apply. 1 is very little, 5 is a significant amount, 20 is extreme.
+       The amount of contrast to apply. 1.00 is very little, 5.00 is a significant amount, 20.00 is extreme.
       </para>
      </listitem>
     </varlistentry>
@@ -91,22 +91,21 @@
     <title>
      Create a gradient image using <function>Imagick::sigmoidalContrastImage</function>
      suitable for blending two images together smoothly, with the blending
-     defined by $contrast and $the midpoint
+     defined by $alpha and $beta
     </title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-function generateBlendImage($width, $height, $contrast = 10, $midpoint = 0.5) {
+function generateBlendImage($width, $height, $alpha = 10, $beta = 0.5)
+{
     $imagick = new Imagick();
     $imagick->newPseudoImage($width, $height, 'gradient:black-white');
     $quanta = $imagick->getQuantumRange();
-    $imagick->sigmoidalContrastImage(true, $contrast, $midpoint * $quanta["quantumRangeLong"]);
+    $imagick->sigmoidalContrastImage(true, $alpha, $beta * $quanta["quantumRangeLong"]);
 
     return $imagick; 
 }
-
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -26,7 +26,7 @@
   </simpara>
   <para>
    See also <link xlink:href="&url.imagemagick.usage.color_mods.sigmoidal;">ImageMagick
-   v6 Examples - Image Transformations — Sigmoidal Non-linearity Contrast</link>
+    Examples -- Color Modifications — Sigmoidal Non-linearity Contrast</link>
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -38,7 +38,7 @@
      <term><parameter>sharpen</parameter></term>
      <listitem>
       <para>
-       If true increase the contrast, if false decrease the contrast.
+       If &true; increase the contrast, if &false; decrease the contrast.
       </para>
      </listitem>
     </varlistentry>
@@ -54,7 +54,8 @@
      <term><parameter>beta</parameter></term>
      <listitem>
       <simpara>
-       Where the midpoint of the gradient will be. This value should be in the range 0 to 1 - multiplied by the quantum value for ImageMagick.
+       Where the midpoint of the gradient will be. This value should be in the range <literal>0.00</literal>
+       to <literal>1.00</literal> - multiplied by the quantum value for ImageMagick.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -15,7 +15,7 @@
    <methodparam><type>float</type><parameter>beta</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Adjusts the contrast of an image with a non-linear sigmoidal contrast
    algorithm. Increase the contrast of the image using a sigmoidal transfer
    function without saturating highlights or shadows. <parameter>alpha</parameter> indicates
@@ -23,7 +23,7 @@
    <parameter>beta</parameter> indicates where midtones fall in the resultant
    image: 0.00 is white; 0.50 is middle-gray; 1.00 is black. Set <parameter>sharpen</parameter> to
    &true; to increase the image contrast otherwise the contrast is reduced.
-  </para>
+  </simpara>
   <para>
    See also <link xlink:href="&url.imagemagick.usage.color_mods.sigmoidal;">ImageMagick
    v6 Examples - Image Transformations — Sigmoidal Non-linearity Contrast</link>
@@ -45,9 +45,9 @@
     <varlistentry>
      <term><parameter>alpha</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The amount of contrast to apply. 1.00 is very little, 5.00 is a significant amount, 20.00 is extreme.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -22,9 +22,10 @@
    how much to increase the contrast: <literal>0.00</literal> is none; <literal>3.00</literal> is
    typical; <literal>20.00</literal> is pushing it.
    <parameter>beta</parameter> indicates where midtones fall in the resultant
-   image: <literal>0.00</literal> is white; <literal>0.50</literal> is
-   middle-gray; <literal>1.00</literal> is black. Set <parameter>sharpen</parameter> to
-   &true; to increase the image contrast otherwise the contrast is reduced.
+   image, as a fraction of the quantum range: <literal>0.0</literal> is white,
+   <literal>0.5</literal> is middle-gray, <literal>1.0</literal> is black
+   (multiply by <code>getQuantumRange()['quantumRangeLong']</code> to get the value to 
+   pass).
   </simpara>
   <simpara>
    See also <link xlink:href="&url.imagemagick.usage.color_mods.sigmoidal;">ImageMagick

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -94,7 +94,7 @@
    <title>
     Create a gradient image using <function>Imagick::sigmoidalContrastImage</function>
     suitable for blending two images together smoothly, with the blending
-    defined by $alpha and $beta
+    defined by <parameter>alpha</parameter> and <parameter>beta</parameter>
    </title>
    <programlisting role="php">
 <![CDATA[

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -39,9 +39,9 @@
     <varlistentry>
      <term><parameter>sharpen</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        If &true; increase the contrast, if &false; decrease the contrast.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -65,9 +65,9 @@
     <varlistentry>
      <term><parameter>channel</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Which color channels the contrast will be applied to.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -90,14 +90,13 @@
  
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>
-     Create a gradient image using <function>Imagick::sigmoidalContrastImage</function>
-     suitable for blending two images together smoothly, with the blending
-     defined by $alpha and $beta
-    </title>
-    <programlisting role="php">
+  <example>
+   <title>
+    Create a gradient image using <function>Imagick::sigmoidalContrastImage</function>
+    suitable for blending two images together smoothly, with the blending
+    defined by $alpha and $beta
+   </title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -111,9 +110,8 @@ function generateBlendImage($width, $height, $alpha = 10, $beta = 0.5)
     return $imagick; 
 }
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
 </refentry>

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -19,15 +19,17 @@
    Adjusts the contrast of an image with a non-linear sigmoidal contrast
    algorithm. Increase the contrast of the image using a sigmoidal transfer
    function without saturating highlights or shadows. <parameter>alpha</parameter> indicates
-   how much to increase the contrast: 0.00 is none; 3.00 is typical; 20.00 is pushing it.
+   how much to increase the contrast: <literal>0.00</literal> is none; <literal>3.00</literal> is
+   typical; <literal>20.00</literal> is pushing it.
    <parameter>beta</parameter> indicates where midtones fall in the resultant
-   image: 0.00 is white; 0.50 is middle-gray; 1.00 is black. Set <parameter>sharpen</parameter> to
+   image: <literal>0.00</literal> is white; <literal>0.50</literal> is
+   middle-gray; <literal>1.00</literal> is black. Set <parameter>sharpen</parameter> to
    &true; to increase the image contrast otherwise the contrast is reduced.
   </simpara>
-  <para>
+  <simpara>
    See also <link xlink:href="&url.imagemagick.usage.color_mods.sigmoidal;">ImageMagick
-    Examples -- Color Modifications — Sigmoidal Non-linearity Contrast</link>
-  </para>
+    Examples -- Color Modifications — Sigmoidal Non-linearity Contrast</link>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -46,7 +48,8 @@
      <term><parameter>alpha</parameter></term>
      <listitem>
       <simpara>
-       The amount of contrast to apply. 1.00 is very little, 5.00 is a significant amount, 20.00 is extreme.
+       The amount of contrast to apply. <literal>1.00</literal> is very little, <literal>5.00</literal>
+       is a significant amount, <literal>20.00</literal> is extreme.
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Integer values in the description are confusing, whereas numbers in the x.xx format seem to be perceived more easily, and the type remains consistent