### PR TITLE
strtr.xml Fix the confusing example, CS

### DIFF
--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -119,9 +119,15 @@ $original = "He1Lo, w0rld!";
 
 // With three arguments, strtr() performs byte-by-byte translation.
 $result = strtr($original, "1L0", "llo");
-echo $result, PHP_EOL;
+echo $result;
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello, world!
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -158,10 +164,25 @@ hello all, I said hi
 <![CDATA[
 <?php
 
-echo strtr("baab", "ab", "01"), "\n";
+/**
+ * Single-byte
+ */
+$singlebyte_string = "baab";
+echo strtr($singlebyte_string, "ab", "01"), PHP_EOL; // Byte-by-byte translation
 
 $replace_pairs = ["ab" => "01"];
-echo strtr("baab", $replace_pairs);
+echo strtr($singlebyte_string, $replace_pairs), PHP_EOL; // Substring translation
+
+/**
+ * Multi-byte
+ */
+$multibyte_string = "Ä"; // In UTF-8, encoded as two bytes: "\xC3\x84"
+
+$result = strtr($multibyte_string, 'Ä', 'A');
+echo bin2hex($result), PHP_EOL; // "4184", where "c3" becomes "41" ("A"), while "84" is kept and breaks UTF-8
+
+$replace_pairs = ['Ä' => 'A'];
+echo strtr($multibyte_string, $replace_pairs); // A correct multibyte substring translation
 ]]>
     </programlisting>
     &example.outputs;
@@ -169,6 +190,8 @@ echo strtr("baab", $replace_pairs);
 <![CDATA[
 1001
 ba01
+4184
+A
 ]]>
     </screen>
   </example>

--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -164,22 +164,18 @@ hello all, I said hi
 <![CDATA[
 <?php
 
-/**
- * Single-byte
- */
+// Single-byte characters
 $singlebyte_string = "baab";
-echo strtr($singlebyte_string, "ab", "01"), PHP_EOL; // Byte-by-byte translation
+echo strtr($singlebyte_string, "ab", "01"), "\n"; // Byte-by-byte translation
 
 $replace_pairs = ["ab" => "01"];
-echo strtr($singlebyte_string, $replace_pairs), PHP_EOL; // Substring translation
+echo strtr($singlebyte_string, $replace_pairs), "\n"; // Substring translation
 
-/**
- * Multi-byte
- */
+// Multi-byte characters
 $multibyte_string = "Ä"; // In UTF-8, encoded as two bytes: "\xC3\x84"
 
 $result = strtr($multibyte_string, 'Ä', 'A');
-echo bin2hex($result), PHP_EOL; // "4184", where "c3" becomes "41" ("A"), while "84" is kept and breaks UTF-8
+echo bin2hex($result), "\n"; // "4184", where "c3" becomes "41" ("A"), while "84" is kept and breaks UTF-8
 
 $replace_pairs = ['Ä' => 'A'];
 echo strtr($multibyte_string, $replace_pairs); // A correct multibyte substring translation

--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -114,13 +114,12 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$addr = "The river å";
 
-// In this form, strtr() does byte-by-byte translation
-// Therefore, we are assuming a single-byte encoding here:
-$addr = strtr($addr, "äåö", "aao");
-echo $addr, PHP_EOL;
-?>
+$original = "He1Lo, w0rld!";
+
+// With three arguments, strtr() performs byte-by-byte translation.
+$result = strtr($original, "1L0", "llo");
+echo $result, PHP_EOL;
 ]]>
     </programlisting>
    </example>
@@ -136,9 +135,9 @@ echo $addr, PHP_EOL;
     <programlisting role="php">
 <![CDATA[
 <?php
-$trans = array("h" => "-", "hello" => "hi", "hi" => "hello");
-echo strtr("hi all, I said hello", $trans);
-?>
+
+$replace_pairs = ["h" => "-", "hello" => "hi", "hi" => "hello"];
+echo strtr("hi all, I said hello", $replace_pairs);
 ]]>
     </programlisting>
     &example.outputs;
@@ -158,11 +157,11 @@ hello all, I said hi
     <programlisting role="php">
 <![CDATA[
 <?php
-echo strtr("baab", "ab", "01"),"\n";
 
-$trans = array("ab" => "01");
-echo strtr("baab", $trans);
-?>
+echo strtr("baab", "ab", "01"), "\n";
+
+$replace_pairs = ["ab" => "01"];
+echo strtr("baab", $replace_pairs);
 ]]>
     </programlisting>
     &example.outputs;


### PR DESCRIPTION
The first example — with multi-byte characters — seems confusing. The function replaces only the first byte of a multi-byte character `å`, and the output shows a black diamond with a question mark (U+FFFD).

Instead of a real example, the page actually offers pseudocode, which an unprepared reader has to slog through to finally understand the substitution algorithm: ä → a, å → a, ö → o. I don't know why 🤷‍♂️