### PR TITLE
Fixed typo

### DIFF
--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -88,7 +88,7 @@
  </simpara>
 
  <simpara>
-  After the configuration script was been run, PHP can be built using
+  After the configuration script has been run, PHP can be built using
   the <command>make</command> command.
   The <link linkend="faq.installation">Installation section of the
   frequently asked questions</link> has further information about how


### PR DESCRIPTION
There was a grammatical issue in the previous version. Changed 'was been run' to 'has been run'.