### PR TITLE
pcntl: fix the reference pages and document the 8.4 failure return

### DIFF
--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -641,17 +641,6 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry xml:id="constant.si-msggq">
-   <term>
-    <constant>SI_MSGGQ</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-
-    </simpara>
-   </listitem>
-  </varlistentry>
   <varlistentry xml:id="constant.si-asyncio">
    <term>
     <constant>SI_ASYNCIO</constant>

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -60,9 +60,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns &false;.
-  </para>
+  <simpara>
+   Returns &false; on failure. On success the function does not return, because
+   the current process image is replaced by the executed program.
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigprocmask.xml
+++ b/reference/pcntl/functions/pcntl-sigprocmask.xml
@@ -83,28 +83,29 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>signal</parameter>
-       is empty.
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>signals</parameter>
+       is empty, unless <parameter>mode</parameter> is
+       <constant>SIG_SETMASK</constant>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>TypeError</classname> is thrown if <parameter>signal</parameter>
+       A <exceptionname>TypeError</exceptionname> is thrown if <parameter>signals</parameter>
        value is not an <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>signal</parameter>
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>signals</parameter>
        value is invalid.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>mode</parameter>
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>mode</parameter>
        value is not <constant>SIG_BLOCK</constant>, <constant>SIG_UNBLOCK</constant> or
        <constant>SIG_SETMASK</constant>.
       </entry>
@@ -134,12 +135,10 @@ pcntl_sigprocmask(SIG_UNBLOCK, array(SIGHUP), $oldset);
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigwaitinfo</function></member>
-    <member><function>pcntl_sigtimedwait</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigwaitinfo</function></member>
+   <member><function>pcntl_sigtimedwait</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigtimedwait.xml
+++ b/reference/pcntl/functions/pcntl-sigtimedwait.xml
@@ -87,42 +87,49 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>signal</parameter>
+       On failure, &false; is now returned; previously
+       <literal>-1</literal> was returned in some cases.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>signals</parameter>
        is empty.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>TypeError</classname> is thrown if <parameter>signal</parameter>
+       A <exceptionname>TypeError</exceptionname> is thrown if <parameter>signals</parameter>
        value is not an <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>signal</parameter>
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>signals</parameter>
        value is invalid.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>seconds</parameter>
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>seconds</parameter>
        value is less than <literal>0</literal>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>nanoseconds</parameter>
-       value is less than <literal>0</literal>.
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>nanoseconds</parameter>
+       value is not between <literal>0</literal> and <literal>1e9</literal>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if both <parameter>seconds</parameter> and
+       A <exceptionname>ValueError</exceptionname> is thrown if both <parameter>seconds</parameter> and
        <parameter>nanoseconds</parameter> values are <literal>0</literal>.
       </entry>
      </row>
@@ -133,12 +140,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigprocmask</function></member>
-    <member><function>pcntl_sigwaitinfo</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigprocmask</function></member>
+   <member><function>pcntl_sigwaitinfo</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigwaitinfo.xml
+++ b/reference/pcntl/functions/pcntl-sigwaitinfo.xml
@@ -102,21 +102,28 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>signal</parameter>
+       On failure, &false; is now returned; previously
+       <literal>-1</literal> was returned in some cases.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>signals</parameter>
        is empty.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>TypeError</classname> is thrown if <parameter>signal</parameter>
+       A <exceptionname>TypeError</exceptionname> is thrown if <parameter>signals</parameter>
        value is not an <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       A <classname>ValueError</classname> is thrown if <parameter>signal</parameter>
+       A <exceptionname>ValueError</exceptionname> is thrown if <parameter>signals</parameter>
        value is invalid.
       </entry>
      </row>
@@ -151,12 +158,10 @@ pcntl_sigwaitinfo(array(SIGHUP), $info);
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigprocmask</function></member>
-    <member><function>pcntl_sigtimedwait</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigprocmask</function></member>
+   <member><function>pcntl_sigtimedwait</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-unshare.xml
+++ b/reference/pcntl/functions/pcntl-unshare.xml
@@ -47,20 +47,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns <literal>0</literal> on success, <literal>-1</literal> otherwise.
+  <simpara>
+   Returns &true; on success or &false; on failure.
    On failure it sets an error code, that can be retrieved with <function>pcntl_get_last_error</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><link linkend="pcntl.constants.clone">PCNTL Constants</link></member>
-    <member><function>pcntl_get_last_error</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><link linkend="pcntl.constants.clone">PCNTL Constants</link></member>
+   <member><function>pcntl_get_last_error</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/versions.xml
+++ b/reference/pcntl/versions.xml
@@ -7,12 +7,15 @@
  <function name="pcntl_errno" from="PHP 5 &gt;= 5.3.4, PHP 7, PHP 8"/>
  <function name="pcntl_exec" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_fork" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pcntl_forkx" from="PHP 8 &gt;= 8.2.0"/>
+ <function name="pcntl_getcpu" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_getcpuaffinity" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_getqos_class" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_getpriority" from="PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_get_last_error" from="PHP 5 &gt;= 5.3.4, PHP 7, PHP 8"/>
  <function name="pcntl_rfork" from="PHP 8 &gt;= 8.1.0"/>
  <function name="pcntl_setcpuaffinity" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="pcntl_setns" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_setpriority" from="PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_setqos_class" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_signal" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
@@ -27,6 +30,7 @@
  <function name="pcntl_waitpid" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_waitid" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pcntl_wexitstatus" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
+ <function name="pcntl_wifcontinued" from="PHP 7, PHP 8"/>
  <function name="pcntl_wifexited" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_wifsignaled" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>
  <function name="pcntl_wifstopped" from="PHP 4 &gt;= 4.1.0, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Fixes several inaccuracies on the pcntl reference pages and documents the PHP 8.4.0 failure return.

- `pcntl_exec()` returns `false` only on failure; on success the process image is replaced and the function does not return. `pcntl_unshare()` returns a `bool`, not `0`/`-1`.
- `pcntl_sigprocmask()`, `pcntl_sigtimedwait()`, `pcntl_sigwaitinfo()`: the changelog rows named a `signal` parameter that does not exist (it is `signals`), and used `<classname>` for thrown exceptions.
- Added the 8.4.0 failure-return row to `pcntl_sigtimedwait()` and `pcntl_sigwaitinfo()`; an empty `signals` does not throw when `mode` is `SIG_SETMASK`; `nanoseconds` must be between `0` and `1e9`, not merely non-negative.
- `versions.xml`: `pcntl_forkx` (8.2.0), `pcntl_getcpu` (8.4.0), `pcntl_setns` (8.4.0) and `pcntl_wifcontinued` (7.0.0) were missing.
- `constants.xml`: `SI_MSGGQ` does not exist in php-src; the constant is `SI_MESGQ`, documented just above.
- The `seealso` simplelists move out of their `<para>`.

**Sources**

- UPGRADING for PHP 8.4, PCNTL sections: failure return ("now always return false on failure. In some case previously it could return the value -1"), thrown exceptions including the `SIG_SETMASK` exception, and the new functions.
- `ext/pcntl/pcntl.stub.php` for signatures, parameter names and per-tag availability; `SI_MESGQ` in `pcntl_arginfo.h`, no `SI_MSGGQ` anywhere.
- Behaviour checked on `php:8.4-cli` with pcntl built in: `pcntl_sigprocmask(SIG_SETMASK, [])` returns `true` without throwing, and `pcntl_sigtimedwait([SIGTERM], $i, 0, 2e9)` throws `ValueError: Argument #4 ($nanoseconds) must be between 0 and 1e9`.
