### PR TITLE
ext/odbc: document the row default value change to null in fetch_object/array/into (PHP 8.4)

### DIFF
--- a/reference/uodbc/functions/odbc-fetch-array.xml
+++ b/reference/uodbc/functions/odbc-fetch-array.xml
@@ -65,7 +65,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> is now nullable.
+       <parameter>row</parameter> is now nullable, and its default value
+       changed from <literal>-1</literal> to &null;, consistent with
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-array.xml
+++ b/reference/uodbc/functions/odbc-fetch-array.xml
@@ -34,7 +34,10 @@
      <term><parameter>row</parameter></term>
      <listitem>
       <para>
-       Optionally choose which row number to retrieve.
+       The 1-based number of the row to retrieve. If omitted or &null;, the
+       next row of the result set is fetched, as
+       <function>odbc_fetch_row</function> does. If the driver does not
+       support fetching rows by number, this parameter is ignored.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/uodbc/functions/odbc-fetch-array.xml
+++ b/reference/uodbc/functions/odbc-fetch-array.xml
@@ -33,12 +33,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The 1-based number of the row to retrieve. If omitted or &null;, the
        next row of the result set is fetched, as
        <function>odbc_fetch_row</function> does. If the driver does not
        support fetching rows by number, this parameter is ignored.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/uodbc/functions/odbc-fetch-into.xml
+++ b/reference/uodbc/functions/odbc-fetch-into.xml
@@ -77,7 +77,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> is now nullable.
+       <parameter>row</parameter> is now nullable, and its default value
+       changed from <literal>0</literal> to &null;, consistent with
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-into.xml
+++ b/reference/uodbc/functions/odbc-fetch-into.xml
@@ -45,12 +45,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The 1-based number of the row to fetch. If omitted or &null;, the
        next row of the result set is fetched, as
        <function>odbc_fetch_row</function> does. If the driver does not
        support fetching rows by number, this parameter is ignored.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/uodbc/functions/odbc-fetch-into.xml
+++ b/reference/uodbc/functions/odbc-fetch-into.xml
@@ -46,7 +46,10 @@
      <term><parameter>row</parameter></term>
      <listitem>
       <para>
-       The row number.
+       The 1-based number of the row to fetch. If omitted or &null;, the
+       next row of the result set is fetched, as
+       <function>odbc_fetch_row</function> does. If the driver does not
+       support fetching rows by number, this parameter is ignored.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/uodbc/functions/odbc-fetch-object.xml
+++ b/reference/uodbc/functions/odbc-fetch-object.xml
@@ -65,7 +65,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> is now nullable.
+       <parameter>row</parameter> is now nullable, and its default value
+       changed from <literal>-1</literal> to &null;, consistent with
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-object.xml
+++ b/reference/uodbc/functions/odbc-fetch-object.xml
@@ -34,7 +34,10 @@
      <term><parameter>row</parameter></term>
      <listitem>
       <para>
-       Optionally choose which row number to retrieve.
+       The 1-based number of the row to retrieve. If omitted or &null;, the
+       next row of the result set is fetched, as
+       <function>odbc_fetch_row</function> does. If the driver does not
+       support fetching rows by number, this parameter is ignored.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/uodbc/functions/odbc-fetch-object.xml
+++ b/reference/uodbc/functions/odbc-fetch-object.xml
@@ -33,12 +33,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The 1-based number of the row to retrieve. If omitted or &null;, the
        next row of the result set is fetched, as
        <function>odbc_fetch_row</function> does. If the driver does not
        support fetching rows by number, this parameter is ignored.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
The changelog rows of `odbc_fetch_object()`, `odbc_fetch_array()` and `odbc_fetch_into()` state only that `row` became nullable in PHP 8.4.0. They omit the accompanying change of default value, which is the part that changes behaviour for existing calls: the previous defaults `-1` and `0` were row positions, whereas `null` means "fetch the next row", the semantics `odbc_fetch_row()` already had.

**Sources**

`ext/odbc/odbc.stub.php`, comparing the `php-8.3.0` and `php-8.4.0` tags:

```
8.3.0  odbc_fetch_object($statement, int $row = -1): stdClass|false
8.3.0  odbc_fetch_array($statement, int $row = -1): array|false
8.3.0  odbc_fetch_into($statement, &$array, int $row = 0): int|false
8.3.0  odbc_fetch_row($statement, ?int $row = null): bool

8.4.0  odbc_fetch_object($statement, ?int $row = null): stdClass|false
8.4.0  odbc_fetch_array($statement, ?int $row = null): array|false
8.4.0  odbc_fetch_into($statement, &$array, ?int $row = null): int|false
8.4.0  odbc_fetch_row(Odbc\Result $statement, ?int $row = null): bool
```
