### PR TITLE
Clean up fgetcsv example

### DIFF
--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -88,7 +88,7 @@
        It must be a single byte character or the empty string.
        The empty string (<literal>""</literal>) disables the proprietary escape mechanism.
       </para>
-      <warning xml:id="function.fgetcsv.warn.escape.parameter">
+      <warning xml:id="function.fgetcsv..warn.escape.parameter">
        <simpara>
         In the input stream, the <parameter>enclosure</parameter> character
         can always be escaped by doubling it inside a quoted string,

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -88,7 +88,7 @@
        It must be a single byte character or the empty string.
        The empty string (<literal>""</literal>) disables the proprietary escape mechanism.
       </para>
-      <warning xml:id="function.fgetcsv..warn.escape.parameter">
+      <warning xml:id="function.fgetcsv.warn.escape.parameter">
        <simpara>
         In the input stream, the <parameter>enclosure</parameter> character
         can always be escaped by doubling it inside a quoted string,

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -200,19 +200,26 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$row = 1;
-if (($handle = fopen("test.csv", "r")) !== FALSE) {
-    while (($data = fgetcsv($handle, 1000, ",")) !== FALSE) {
-        $num = count($data);
-        echo "<p> $num fields in line $row: <br /></p>\n";
-        $row++;
-        for ($c=0; $c < $num; $c++) {
-            echo $data[$c] . "<br />\n";
+
+if (($handle = fopen("test.csv", "r")) !== false) {
+    $row = 1;
+
+    while (($fields = fgetcsv($handle, 1000, ",", "\"", "\\")) !== false) {
+        $num = count($fields);
+
+        echo "\n<p>$num fields in line $row:</p>\n<ol>";
+
+        for ($c = 0; $c < $num; $c++) {
+            echo "\n\t<li>", $fields[$c], "</li>";
         }
+
+        echo "\n</ol>";
+
+        $row++;
     }
+
     fclose($handle);
 }
-?>
 ]]>
     </programlisting>
    </example>

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -53,7 +53,7 @@
        <methodname>SplFileObject::setCsvControl</methodname>.
        An empty string (<literal>""</literal>) disables the proprietary escape mechanism.
       </para>
-      <xi:include xpointer="function.fgetcsv..warn.escape.parameter"/>
+      <xi:include xpointer="function.fgetcsv.warn.escape.parameter"/>
       <warning>
        <simpara>
         As of PHP 8.4.0, depending on the default value of

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -53,7 +53,7 @@
        <methodname>SplFileObject::setCsvControl</methodname>.
        An empty string (<literal>""</literal>) disables the proprietary escape mechanism.
       </para>
-      <xi:include xpointer="function.fgetcsv.warn.escape.parameter"/>
+      <xi:include xpointer="function.fgetcsv..warn.escape.parameter"/>
       <warning>
        <simpara>
         As of PHP 8.4.0, depending on the default value of


### PR DESCRIPTION
Some naming fixes, add explicit `$enclosure` and `$escape`, transform output to ordered list, code style