### PR TITLE
ext/mysqli: Note MYSQLI_TYPE_VECTOR availability (PHP 8.4.0, MySQL 9)

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -806,9 +806,10 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
+     <simpara>
       Field is defined as <literal>VECTOR</literal>.
-     </para>
+      Available as of PHP 8.4.0, for MySQL 9.0 and later.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.mysqli-need-data">


### PR DESCRIPTION
PHP 8.4 added support for the VECTOR data type from MySQL 9 in mysqlnd, surfaced through the `MYSQLI_TYPE_VECTOR` constant. Adds the availability note to that constant's documentation.