### PR TITLE
ext/gmp: Document GMP-to-bool cast (8.4.0)

### DIFF
--- a/reference/gmp/gmp.xml
+++ b/reference/gmp/gmp.xml
@@ -55,6 +55,15 @@
         <classname>GMP</classname> is now marked <modifier>final</modifier>
        </entry>
       </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        A <classname>GMP</classname> object can now be cast to
+        <type>bool</type>; an object representing <literal>0</literal> is cast
+        to &false;, and any other value to &true;. Previously, casting to
+        <type>bool</type> emitted an <constant>E_RECOVERABLE_ERROR</constant>.
+       </entry>
+      </row>
      </tbody>
     </tgroup>
    </informaltable>


### PR DESCRIPTION
PHP 8.4 allows casting a `GMP` object to `bool` (0 becomes `false`, any other value `true`), instead of emitting an `E_RECOVERABLE_ERROR`. Adds a changelog entry to the GMP class page.