### PR TITLE
Fix Traversable description

### DIFF
--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -63,19 +63,19 @@
   <section role="notes">
    &reftitle.notes;
    <note>
-    <para>
+    <simpara>
      Internal (built-in) classes that implement this interface can be used in
      a &foreach; construct and do not need to implement
      <interfacename>IteratorAggregate</interfacename> or
      <interfacename>Iterator</interfacename>.
-    </para>
+    </simpara>
    </note>
    <note>
-    <para>
+    <simpara>
      Prior to PHP 8.0.0, this internal engine interface couldn't be directly implemented
      in PHP scripts — not even by abstract classes. Either <interfacename>IteratorAggregate</interfacename>
      or <interfacename>Iterator</interfacename> must be used instead.
-    </para>
+    </simpara>
    </note>
   </section>
 

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -47,7 +47,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>7.4.0</entry>
+       <entry>8.0.0</entry>
        <entry>
         The <interfacename>Traversable</interfacename> interface can now be implemented
         by abstract classes. Extending classes must implement
@@ -72,8 +72,8 @@
    </note>
    <note>
     <para>
-     Prior to PHP 7.4.0, this internal engine interface couldn't be implemented
-     in PHP scripts. Either <interfacename>IteratorAggregate</interfacename>
+     Prior to PHP 8.0.0, this internal engine interface couldn't be directly implemented
+     in PHP scripts — not even by abstract classes. Either <interfacename>IteratorAggregate</interfacename>
      or <interfacename>Iterator</interfacename> must be used instead.
     </para>
    </note>


### PR DESCRIPTION
Following by:

https://bugs.php.net/bug.php?id=62609

and

https://github.com/php/php-src/commit/e9ae581f024e06878b2b1991b7daed6318c811a7

It seems the `implements Traversable` construct for abstract classes was introduced only as of PHP 8.0.0, not in 7.4.0.

The following example works only as of PHP 8.0.0. Prior to 8.0.0, including [7.4.0, 7.4.33], it generates:

> Fatal error: Class AbstractTraversable must implement interface Traversable as part of either Iterator or IteratorAggregate:

```php
<?php

abstract class AbstractTraversable implements Traversable {}

class NonAbstractTraversable extends AbstractTraversable implements IteratorAggregate
{
    public function getIterator()
    {
        yield from ['foo', 'bar',];
    }
}

foreach (new NonAbstractTraversable() as $value) {
    echo $value, "\n";
}
```

