### PR TITLE
language: document the PHP 8.4 comparison and readonly clone BC breaks

### DIFF
--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -361,6 +361,14 @@ var_dump($test2->prop); // NULL
      </programlisting>
     </example>
    </para>
+   <note>
+    <simpara>
+     As of PHP 8.4.0, indirect modification of a readonly property within
+     <link linkend="object.clone">__clone()</link>, such as acquiring a
+     reference to it (<code>$ref = &amp;$this->prop</code>), is no longer
+     allowed. This was already forbidden during readonly initialization.
+    </simpara>
+   </note>
   </sect2>
 
   <sect2 xml:id="language.oop5.properties.dynamic-properties">

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -334,7 +334,7 @@ function standard_array_compare($op1, $op2)
   <simpara>
    Encountering recursion during comparison, for example when comparing an
    array or object that contains a reference to itself, throws an
-   <exceptionname>Error</exceptionname> as of PHP 8.4.0; prior to PHP 8.4.0,
+   <exceptionname>Error</exceptionname> as of PHP 8.4.0; previously,
    it resulted in a fatal error.
   </simpara>
  </note>

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -330,6 +330,15 @@ function standard_array_compare($op1, $op2)
   </simpara>
  </note>
 
+ <note>
+  <simpara>
+   Encountering recursion during comparison, for example when comparing an
+   array or object that contains a reference to itself, throws an
+   <exceptionname>Error</exceptionname> as of PHP 8.4.0; prior to PHP 8.4.0,
+   it resulted in a fatal error.
+  </simpara>
+ </note>
+
  <sect2 xml:id="language.operators.comparison.incomparable">
   <title>Incomparable Values</title>
   <simpara>


### PR DESCRIPTION
Documents the two remaining PHP 8.4 core language BC breaks:

* Indirect modification of a readonly property within `__clone()` is no longer allowed, for example acquiring a reference to it. Added as a note to the readonly properties section, right after the PHP 8.3 clone reinitialization paragraph.
* Encountering recursion during comparison now throws an `Error` instead of raising a fatal error. Added as a note to the comparison operators page.

Tracker: both items are on the [PHP 8.4 Documentation Tracker](https://github.com/orgs/php/projects/11), listed as "(BC Break) Indirect Modification of readonly Properties" and "(BC Break) Recursion during comparison".

Sources:

* Indirect modification of readonly properties within `__clone()`: [UPGRADING for PHP 8.4](https://github.com/php/php-src/blob/php-8.4.0/UPGRADING#L28-L31), php-src [#15012](https://github.com/php/php-src/pull/15012) (commit `46ee0fb`), test `Zend/tests/readonly_props/readonly_clone_error7.phpt`.
* Recursion during comparison: [UPGRADING for PHP 8.4](https://github.com/php/php-src/blob/php-8.4.0/UPGRADING#L26-L27), php-src [#14989](https://github.com/php/php-src/pull/14989) (commit `82479e8`), implementation in `Zend/zend_hash.c` and `Zend/zend_object_handlers.c`, test `Zend/tests/recursive_array_comparison.phpt`.

Verified on `php:8.3-cli` and `php:8.4-cli`:

```php
class A {
    public readonly array $p;
    public function __construct(array $p) { $this->p = $p; }
    public function __clone(): void { $r = &$this->p; $r[] = 1; }
}
clone new A([0]);
// 8.3: succeeds, the property is modified
// 8.4: Error: Cannot indirectly modify readonly property A::$p

$a = [&$a];
var_dump($a === [[]]);
// 8.3: Fatal error: Nesting level too deep - recursive dependency?
// 8.4: Error: Nesting level too deep - recursive dependency? (catchable)
```

The comparison note deliberately says "encountering recursion during comparison" rather than referring to a maximum nesting level: the check is a recursion guard, and a single self-referencing value compared against a plain one is enough to trigger it. Comparing a value with itself (`$a === $a`) still returns `true`.
