### PR TITLE
Fix unresolved exception ZMQ entity references

### DIFF
--- a/reference/zmq/book.xml
+++ b/reference/zmq/book.xml
@@ -19,12 +19,22 @@
  </preface>
 
  &reference.zmq.setup;
- 
+
  &reference.zmq.zmq;
+ &reference.zmq.zmqexception;
+
  &reference.zmq.zmqcontext;
+ &reference.zmq.zmqcontextexception;
+
  &reference.zmq.zmqsocket;
+ &reference.zmq.zmqsocketexception;
+
  &reference.zmq.zmqpoll;
+ &reference.zmq.zmqpollexception;
+
  &reference.zmq.zmqdevice;
+ &reference.zmq.zmqdeviceexception;
+
 
 </book>
 

--- a/reference/zmq/zmqcontextexception.xml
+++ b/reference/zmq/zmqcontextexception.xml
@@ -29,7 +29,7 @@
      <ooclass>
       <classname>ZMQContextException</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>ZMQException</classname>
@@ -38,19 +38,16 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-    
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqcontextexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
+
 <!-- {{{ ZMQContextException properties -->
   <section xml:id="zmqcontextexception.props">
    &reftitle.properties;
@@ -85,8 +82,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqcontextexception;
 
 </reference>
 

--- a/reference/zmq/zmqdeviceexception.xml
+++ b/reference/zmq/zmqdeviceexception.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<reference xml:id="class.zmqdeviceexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.zmqdeviceexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The ZMQDeviceException class</title>
  <titleabbrev>ZMQDeviceException</titleabbrev>
@@ -29,7 +29,7 @@
      <ooclass>
       <classname>ZMQDeviceException</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>ZMQException</classname>
@@ -38,19 +38,16 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-    
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqdeviceexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
+
 <!-- {{{ ZMQDeviceException properties -->
   <section xml:id="zmqdeviceexception.props">
    &reftitle.properties;
@@ -85,8 +82,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqdeviceexception;
 
 </reference>
 

--- a/reference/zmq/zmqexception.xml
+++ b/reference/zmq/zmqexception.xml
@@ -29,7 +29,7 @@
      <ooclass>
       <classname>ZMQException</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>Exception</classname>
@@ -38,10 +38,7 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-    
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
@@ -50,7 +47,7 @@
 
   </section>
 
-  
+
 <!-- {{{ ZMQException properties -->
   <section xml:id="zmqexception.props">
    &reftitle.properties;
@@ -85,8 +82,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqexception;
 
 </reference>
 

--- a/reference/zmq/zmqpollexception.xml
+++ b/reference/zmq/zmqpollexception.xml
@@ -29,7 +29,7 @@
      <ooclass>
       <classname>ZMQPollException</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>ZMQException</classname>
@@ -38,19 +38,16 @@
 <!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
-    
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqpollexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
+
 <!-- {{{ ZMQPollException properties -->
   <section xml:id="zmqpollexception.props">
    &reftitle.properties;
@@ -85,8 +82,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqpollexception;
 
 </reference>
 

--- a/reference/zmq/zmqsocketexception.xml
+++ b/reference/zmq/zmqsocketexception.xml
@@ -29,7 +29,7 @@
      <ooclass>
       <classname>ZMQSocketException</classname>
      </ooclass>
-     
+
      <ooclass>
       <modifier>extends</modifier>
       <classname>ZMQException</classname>
@@ -39,18 +39,15 @@
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
 
 
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqsocketexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zmqexception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
 
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
+
 <!-- {{{ ZMQSocketException properties -->
   <section xml:id="zmqsocketexception.props">
    &reftitle.properties;
@@ -85,8 +82,6 @@
 
 
  </partintro>
-
- &reference.zmq.entities.zmqsocketexception;
 
 </reference>
 


### PR DESCRIPTION
A few more follow-up MRs to come. The main goal is to bring docbook-cs to a state where it reports no unresolved entities.
These errors are caused by incorrect or outdated references.

I have not verified whether the synopsis is correct; that is out of scope.