### PR TITLE
ext/sodium: document the 8.4 aarch64 support for AES-256-GCM

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4496,6 +4496,29 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
    </simpara>
 '>
 
+<!-- Sodium -->
+<!ENTITY sodium.changelog.aes256gcm-aarch64 '
+  <informaltable xmlns="http://docbook.org/ns/docbook">
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       This function is now also defined on aarch64.
+       Previously it was only defined on x86 and x86_64.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+'>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/sodium/constants.xml
+++ b/reference/sodium/constants.xml
@@ -169,6 +169,8 @@
    </term>
    <listitem>
     <simpara>
+     Only defined on platforms where AES-256-GCM support is compiled in.
+     Defined on aarch64 as of PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -179,6 +181,8 @@
    </term>
    <listitem>
     <simpara>
+     Only defined on platforms where AES-256-GCM support is compiled in.
+     Defined on aarch64 as of PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -189,6 +193,8 @@
    </term>
    <listitem>
     <simpara>
+     Only defined on platforms where AES-256-GCM support is compiled in.
+     Defined on aarch64 as of PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -199,6 +205,8 @@
    </term>
    <listitem>
     <simpara>
+     Only defined on platforms where AES-256-GCM support is compiled in.
+     Defined on aarch64 as of PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-decrypt.xml
@@ -69,6 +69,11 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
+ </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
@@ -68,6 +68,11 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
+ </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-is-available.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-is-available.xml
@@ -30,6 +30,31 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       This function may now return &true; on aarch64 CPUs with the ARM
+       cryptographic extensions.
+       Previously, hardware-accelerated AES-256-GCM was only detected on x86
+       and x86_64, and this function always returned &false; on aarch64.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-keygen.xml
@@ -31,6 +31,11 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
+ </refsect1>
+
 
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Before PHP 8.4 the `HAVE_AESGCM` guard in `ext/sodium/libsodium.c` covered x86 and x86_64 only. PHP 8.4 extends it to `__aarch64__` and `_M_ARM64`, which changes two distinct things on aarch64:

* `sodium_crypto_aead_aes256gcm_is_available()` may now return `true`; before 8.4 it was compiled as a plain `RETURN_FALSE`.
* `sodium_crypto_aead_aes256gcm_encrypt()`, `..._decrypt()`, `..._keygen()` and the four `SODIUM_CRYPTO_AEAD_AES256GCM_*` constants are now defined at all; before 8.4 calling one raised `Error: Call to undefined function`.

`sodium_crypto_aead_aes256gcm_is_available()` sits outside the guard and has always existed, so it is the one member of the family whose availability did not change. This adds a changelog entry to all four function pages and fills in the four constant descriptions, which were empty. The table shared by the encrypt, decrypt and keygen pages is declared once as `sodium.changelog.aes256gcm-aarch64` in `language-snippets.ent`; translations that lack the entity fall back to the English one.

Verified on emulated aarch64: 8.3 returns `false` with the other functions undefined, 8.4 returns `true` with them defined. With libsodium 1.0.18, 8.4 defines them but still returns `false`, hence *may* in the wording.

## Sources

* Guard extended to aarch64: [php/php-src#12867](https://github.com/php/php-src/pull/12867), commit [`1816403d84`](https://github.com/php/php-src/commit/1816403d84dde991e354442ca074fc1cde8a61ff). The pull request title mentions AEGIS only; the aarch64 change rides along in the same commit ("Also don't prevent usage of AES-GCM on aarch64").
* `UPGRADING` and `NEWS` for PHP 8.4.
* Not backported: `git tag --contains 1816403d84` yields `php-8.4.0RC1` and `php-8.4.0` only.

Tracker: [PHP 8.4 Documentation Tracker](https://github.com/orgs/php/projects/11/views/1?pane=issue&itemId=199826753).
