### PR TITLE
apache2handler: document Apache 2.4 minimum requirement as of PHP 8.4.0

### DIFF
--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -60,6 +60,13 @@
   end of life and should not be used.
  </simpara>
 
+ <note>
+  <simpara>
+   As of PHP 8.4.0, the apache2handler SAPI requires at least Apache 2.4;
+   support for the End-of-Life Apache 2.0 and 2.2 has been removed.
+  </simpara>
+ </note>
+
  <orderedlist>
   <listitem>
    <simpara>


### PR DESCRIPTION
Document that PHP 8.4.0 dropped support for Apache 2.0 and 2.2, requiring Apache 2.4 as minimum.

https://github.com/orgs/php/projects/11/views/4