### PR TITLE
cli: document built-in server index file lookup behavior (8.4.0)

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1656,6 +1656,15 @@ php >
     the URI. Otherwise a 404 response code is returned.
   </para>
 
+  <note>
+   <simpara>
+    As of PHP 8.4.0, this index file lookup is performed even when the
+    requested path looks like a file, i.e. its last path component contains a
+    period, but cannot be located. Previously, such requests skipped the
+    lookup and immediately returned a 404 response.
+   </simpara>
+  </note>
+
   <para>
     If a PHP file is given on the command line when the web server is
     started it is treated as a "router" script.  The script is run at


### PR DESCRIPTION
Document the PHP 8.4.0 change where the built-in server recursively traverses parent directories to find an index file when the requested file-like path cannot be located.

https://github.com/orgs/php/projects/11/views/4