### PR TITLE
mysqlnd: document wait-timeout error code change 2006 -> 4031 (8.4.0)

### DIFF
--- a/reference/mysqli/mysqli/query.xml
+++ b/reference/mysqli/mysqli/query.xml
@@ -131,6 +131,33 @@
   &mysqli.conditionalexception;
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        When connecting to MySQL 8.0.24 or later, the error code reported
+        for a server wait timeout is now <literal>4031</literal>
+        (<literal>ER_CLIENT_INTERACTION_TIMEOUT</literal>) instead of
+        <literal>2006</literal> (<literal>CR_SERVER_GONE_ERROR</literal>).
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>


### PR DESCRIPTION
Document that as of PHP 8.4.0, the error code for MySQL server wait timeouts changed from 2006 (CR_SERVER_GONE_ERROR) to 4031 (ER_CLIENT_INTERACTION_TIMEOUT) for MySQL 8.0.24+.

https://github.com/orgs/php/projects/11/views/4