### PR TITLE
Clarify forward_static_call docs

### DIFF
--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -3,8 +3,8 @@
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call_array</refname>
-  <refpurpose>Call a callback with parameters as an array, forwarding late
-   static binding when available</refpurpose>
+  <refpurpose>Call a callback with an array of parameters, preserving the 
+  current called class</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -3,7 +3,8 @@
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call_array</refname>
-  <refpurpose>Call a static method and pass the arguments as array</refpurpose>
+  <refpurpose>Call a callback with parameters as an array, forwarding late
+   static binding when available</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,10 +18,13 @@
    Calls a user defined function or method given by the <parameter>callback</parameter>
    parameter, with arguments passed as an array, similarly to
    <function>call_user_func_array</function>.
-   When called from within a method context, it uses the
-   <link linkend="language.oop5.late-static-bindings">late static binding</link>.
-   When called outside a class context, it behaves like
-   <function>call_user_func_array</function>, without late static binding.
+   When called from within a method context and calling a method callback,
+   it forwards the current
+   <link linkend="language.oop5.late-static-bindings">late static binding</link>,
+   so <literal>static::</literal> inside the method resolves to the current
+   called class. This is useful for static method callbacks that should behave
+   like forwarding calls such as <literal>parent::</literal> or
+   <literal>self::</literal>.
   </simpara>
   <note>
    <simpara>
@@ -49,14 +53,14 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       One parameter, gathering all the method parameter in one array.
-      </para>
+      <simpara>
+       The parameters to be passed to the callback, as an array.
+      </simpara>
       <note>
-       <para>
-        Note that the parameters for <function>forward_static_call_array</function> are
-        not passed by reference.
-       </para>
+       <simpara>
+        To pass a parameter by reference, the corresponding element in
+        <parameter>args</parameter> must be a reference.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -19,12 +19,11 @@
    parameter, with arguments passed as an array, similarly to
    <function>call_user_func_array</function>.
    When called from within a method context and calling a method callback,
-   it forwards the current
-   <link linkend="language.oop5.late-static-bindings">late static binding</link>,
-   so <literal>static::</literal> inside the method resolves to the current
-   called class. This is useful for static method callbacks that should behave
-   like forwarding calls such as <literal>parent::</literal> or
-   <literal>self::</literal>.
+   it makes a
+   <link linkend="language.oop5.late-static-bindings">forwarding call</link>,
+   so <literal>static::</literal> inside the method resolves to the same called
+   class as in the caller. This is useful for static method callbacks that
+   should behave like <literal>self::</literal> or <literal>parent::</literal>.
   </simpara>
   <note>
    <simpara>

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call_array</refname>
-  <refpurpose>Call a callback with an array of parameters, preserving the 
+  <refpurpose>Call a callback with an array of parameters, preserving the
   current called class</refpurpose>
  </refnamediv>
 

--- a/reference/funchand/functions/forward-static-call.xml
+++ b/reference/funchand/functions/forward-static-call.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.forward-static-call" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call</refname>
-  <refpurpose>Call a static method</refpurpose>
+  <refpurpose>Call a callback while preserving the current called class</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,13 +13,17 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Calls a user defined function or method given by the <parameter>callback</parameter>
    parameter, with the following arguments. This function must be called within a method
    context, it can't be used outside a class.
-   It uses the <link linkend="language.oop5.late-static-bindings">late static
-   binding</link>.
-  </para>
+   When calling a method callback, it forwards the current
+   <link linkend="language.oop5.late-static-bindings">late static binding</link>,
+   so <literal>static::</literal> inside the method resolves to the current
+   called class. This is useful for static method callbacks that should behave
+   like forwarding calls such as <literal>parent::</literal> or
+   <literal>self::</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -39,9 +43,9 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Zero or more parameters to be passed to the function.
-      </para>
+      <simpara>
+       Zero or more parameters to be passed to the callback.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/funchand/functions/forward-static-call.xml
+++ b/reference/funchand/functions/forward-static-call.xml
@@ -17,12 +17,11 @@
    Calls a user defined function or method given by the <parameter>callback</parameter>
    parameter, with the following arguments. This function must be called within a method
    context, it can't be used outside a class.
-   When calling a method callback, it forwards the current
-   <link linkend="language.oop5.late-static-bindings">late static binding</link>,
-   so <literal>static::</literal> inside the method resolves to the current
-   called class. This is useful for static method callbacks that should behave
-   like forwarding calls such as <literal>parent::</literal> or
-   <literal>self::</literal>.
+   When calling a method callback, it makes a
+   <link linkend="language.oop5.late-static-bindings">forwarding call</link>,
+   so <literal>static::</literal> inside the method resolves to the same called
+   class as in the caller. This is useful for static method callbacks that
+   should behave like <literal>self::</literal> or <literal>parent::</literal>.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
This PR replaces #5681 and has been rebased on the latest `master` after 846dfb87.

Commit 846dfb87 clarified that `forward_static_call_array()` does not require an active class scope and behaves like `call_user_func_array()` when called outside a class context.

This PR keeps that correction and focuses on the remaining parts not covered by that commit:

- clarifying that `forward_static_call()` is not limited to calling static methods, but preserves the current called class for method callbacks
- explaining how this relates to late static binding, where `static::` resolves to the current called class
- clarifying that this is useful for static method callbacks that should behave like forwarding calls such as `parent::` or `self::`
- updating the `forward_static_call_array()` parameter note to match `call_user_func_array()`: parameters can be passed by reference when the corresponding element in the `args` array is a reference