### PR TITLE
Update tables to fix mobile labels

### DIFF
--- a/reference/mysqli/summary.xml
+++ b/reference/mysqli/summary.xml
@@ -114,7 +114,7 @@
    </tbody>
   </tgroup>
  </table>
- 
+
  <table xml:id="mysqli.summary.classmethods">
   <title>Summary of <classname>mysqli</classname> methods</title>
   <tgroup cols="4">
@@ -424,8 +424,8 @@
   </tgroup>
  </table>
 
- <table xml:id="mysqli.summary.stmtmethods"> 
-  <title>Summary of <classname>mysqli_stmt</classname> methods</title>    
+ <table xml:id="mysqli.summary.stmtmethods">
+  <title>Summary of <classname>mysqli_stmt</classname> methods</title>
   <tgroup cols="4">
    <thead>
     <row>
@@ -593,7 +593,7 @@
    </tbody>
   </tgroup>
  </table>
- 
+
  <table xml:id="mysqli.summary.resultmethods">
   <title>Summary of <classname>mysqli_result</classname> methods</title>
   <tgroup cols="4">
@@ -705,7 +705,7 @@
    </tbody>
   </tgroup>
  </table>
- 
+
  <table xml:id="mysqli.summary.drivermethods">
   <title>Summary of <classname>mysqli_driver</classname> methods</title>
   <tgroup cols="4">

--- a/reference/mysqli/summary.xml
+++ b/reference/mysqli/summary.xml
@@ -4,13 +4,10 @@
 
  <title>The MySQLi Extension Function Summary</title>
 
- <table xml:id="mysqli.summary.classtable">
-  <title>Summary of <classname>mysqli</classname> methods</title>
+ <table xml:id="mysqli.summary.classproperties">
+  <title>Summary of <classname>mysqli</classname> properties</title>
   <tgroup cols="4">
    <thead>
-    <row>
-     <entry>mysqli Class</entry>
-    </row>
     <row>
      <entry>OOP Interface</entry>
      <entry>Procedural Interface</entry>
@@ -19,9 +16,6 @@
     </row>
    </thead>
    <tbody>
-    <row>
-     <entry><emphasis role="bold">Properties</emphasis></entry>
-    </row>
     <row>
      <entry><link linkend="mysqli.affected-rows">$mysqli::affected_rows</link></entry>
      <entry><function>mysqli_affected_rows</function></entry>
@@ -117,9 +111,22 @@
      <entry>N/A</entry>
      <entry>Returns the number of warnings from the last query for the given link</entry>
     </row>
+   </tbody>
+  </tgroup>
+ </table>
+ 
+ <table xml:id="mysqli.summary.classmethods">
+  <title>Summary of <classname>mysqli</classname> methods</title>
+  <tgroup cols="4">
+   <thead>
     <row>
-     <entry><emphasis role="bold">Methods</emphasis></entry>
+     <entry>OOP Interface</entry>
+     <entry>Procedural Interface</entry>
+     <entry>Alias (Do not use)</entry>
+     <entry>Description</entry>
     </row>
+   </thead>
+   <tbody>
     <row>
      <entry><methodname>mysqli::autocommit</methodname></entry>
      <entry><function>mysqli_autocommit</function></entry>
@@ -352,13 +359,10 @@
   </tgroup>
  </table>
 
- <table xml:id="mysqli.summary.methods">
-  <title>Summary of <classname>mysqli_stmt</classname> methods</title>
+ <table xml:id="mysqli.summary.stmtproperties">
+  <title>Summary of <classname>mysqli_stmt</classname> properties</title>
   <tgroup cols="4">
    <thead>
-    <row>
-     <entry>MySQL_STMT</entry>
-    </row>
     <row>
      <entry>OOP Interface</entry>
      <entry>Procedural Interface</entry>
@@ -367,9 +371,6 @@
     </row>
    </thead>
    <tbody>
-    <row>
-     <entry><emphasis role="bold">Properties</emphasis></entry>
-    </row>
     <row>
      <entry><link linkend="mysqli-stmt.affected-rows">$mysqli_stmt::affected_rows</link></entry>
      <entry><function>mysqli_stmt_affected_rows</function></entry>
@@ -419,9 +420,22 @@
      <entry>N/A</entry>
      <entry>Returns SQLSTATE error from previous operation</entry>
     </row>
+   </tbody>
+  </tgroup>
+ </table>
+
+ <table xml:id="mysqli.summary.stmtmethods"> 
+  <title>Summary of <classname>mysqli_stmt</classname> methods</title>    
+  <tgroup cols="4">
+   <thead>
     <row>
-     <entry><emphasis role="bold">Methods</emphasis></entry>
+     <entry>OOP Interface</entry>
+     <entry>Procedural Interface</entry>
+     <entry>Alias (Do not use)</entry>
+     <entry>Description</entry>
     </row>
+   </thead>
+   <tbody>
     <row>
      <entry><methodname>mysqli_stmt::attr_get</methodname></entry>
      <entry><function>mysqli_stmt_attr_get</function></entry>
@@ -540,13 +554,10 @@
   </tgroup>
  </table>
 
- <table xml:id="mysqli.summary.resultmethods">
-  <title>Summary of <classname>mysqli_result</classname> methods</title>
+ <table xml:id="mysqli.summary.resultproperties">
+  <title>Summary of <classname>mysqli_result</classname> properties</title>
   <tgroup cols="4">
    <thead>
-    <row>
-     <entry>mysqli_result</entry>
-    </row>
     <row>
      <entry>OOP Interface</entry>
      <entry>Procedural Interface</entry>
@@ -555,9 +566,6 @@
     </row>
    </thead>
    <tbody>
-    <row>
-     <entry><emphasis role="bold">Properties</emphasis></entry>
-    </row>
     <row>
      <entry><link linkend="mysqli-result.current-field">$mysqli_result::current_field</link></entry>
      <entry><function>mysqli_field_tell</function></entry>
@@ -582,9 +590,22 @@
      <entry>N/A</entry>
      <entry>Gets the number of rows in a result</entry>
     </row>
+   </tbody>
+  </tgroup>
+ </table>
+ 
+ <table xml:id="mysqli.summary.resultmethods">
+  <title>Summary of <classname>mysqli_result</classname> methods</title>
+  <tgroup cols="4">
+   <thead>
     <row>
-     <entry><emphasis role="bold">Methods</emphasis></entry>
+     <entry>OOP Interface</entry>
+     <entry>Procedural Interface</entry>
+     <entry>Alias (Do not use)</entry>
+     <entry>Description</entry>
     </row>
+   </thead>
+   <tbody>
     <row>
      <entry><methodname>mysqli_result::data_seek</methodname></entry>
      <entry><function>mysqli_data_seek</function></entry>
@@ -663,13 +684,10 @@
   </tgroup>
  </table>
 
- <table xml:id="mysqli.summary.drivermethods">
-  <title>Summary of <classname>mysqli_driver</classname> methods</title>
+ <table xml:id="mysqli.summary.driverproperties">
+  <title>Summary of <classname>mysqli_driver</classname> properties</title>
   <tgroup cols="4">
    <thead>
-    <row>
-     <entry>MySQL_Driver</entry>
-    </row>
     <row>
      <entry>OOP Interface</entry>
      <entry>Procedural Interface</entry>
@@ -679,17 +697,27 @@
    </thead>
    <tbody>
     <row>
-     <entry><emphasis role="bold">Properties</emphasis></entry>
-    </row>
-    <row>
      <entry><link linkend="mysqli-driver.report-mode">$mysqli_driver::mysqli_report</link></entry>
      <entry><function>mysqli_report</function></entry>
      <entry>N/A</entry>
      <entry>Sets mysqli error reporting mode</entry>
     </row>
+   </tbody>
+  </tgroup>
+ </table>
+ 
+ <table xml:id="mysqli.summary.drivermethods">
+  <title>Summary of <classname>mysqli_driver</classname> methods</title>
+  <tgroup cols="4">
+   <thead>
     <row>
-     <entry><emphasis role="bold">Methods</emphasis></entry>
+     <entry>OOP Interface</entry>
+     <entry>Procedural Interface</entry>
+     <entry>Alias (Do not use)</entry>
+     <entry>Description</entry>
     </row>
+   </thead>
+   <tbody>
     <row>
      <entry><methodname>mysqli_driver::embedded_server_end</methodname></entry>
      <entry><function>mysqli_embedded_server_end</function></entry>


### PR DESCRIPTION
Moved "properties" and "methods" to table titles from table entries, splitting tables at these points; removed class names from table entries; and updated table id's to match new tables. This fixes the following issue: On mobile, table is collapsed and table head entries are used as :before label elements for table body entries, in a cycling fashion (see web-php/public/js/common.js line 835-851). Table had class names as head entries and "methods" and "properties" as body entries, resulting in incorrect labels for body entries.