### PR TITLE
How to flush cookies as of PHP8

### DIFF
--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -19,11 +19,11 @@
   </methodsynopsis>
   &note.resource-migration-8.0-dead-function;
    <note>
-    <para>
+    <simpara>
      If cookies need to be written before the <parameter>handle</parameter>
      is destroyed, call <function>curl_setopt</function> with
      <constant>CURLOPT_COOKIELIST</constant> set to <literal>"FLUSH"</literal>.
-    </para>
+    </simpara>
    </note>
 
   <para>

--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -19,13 +19,12 @@
   </methodsynopsis>
   &note.resource-migration-8.0-dead-function;
    <note>
-   <para>
-    If cookies need to be written before the handle is automatically
-    destroyed, call
-    <function>curl_setopt</function>(<parameter>handle</parameter>,
-    <constant>CURLOPT_COOKIELIST</constant>, <literal>"FLUSH"</literal>).
-   </para>
-  </note>
+    <para>
+     If cookies need to be written before the <parameter>handle</parameter>
+     is destroyed, call <function>curl_setopt</function> with
+     <constant>CURLOPT_COOKIELIST</constant> set to <literal>"FLUSH"</literal>.
+    </para>
+   </note>
 
   <para>
    Closes a cURL session and frees all resources.  The cURL handle,

--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -9,7 +9,7 @@
  <refsynopsisdiv>
   &warn.deprecated.function-8-5-0;
  </refsynopsisdiv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -18,6 +18,15 @@
    <methodparam><type>CurlHandle</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   &note.resource-migration-8.0-dead-function;
+   <note>
+   <para>
+    If cookies need to be written before the handle is automatically
+    destroyed, call
+    <function>curl_setopt</function>(<parameter>handle</parameter>,
+    <constant>CURLOPT_COOKIELIST</constant>, <literal>"FLUSH"</literal>).
+   </para>
+  </note>
+
   <para>
    Closes a cURL session and frees all resources.  The cURL handle,
    <parameter>handle</parameter>, is also deleted.

--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -21,8 +21,8 @@
    <note>
     <simpara>
      If cookies need to be written before the <parameter>handle</parameter>
-     is destroyed, call <function>curl_setopt</function> with
-     <constant>CURLOPT_COOKIELIST</constant> set to <literal>"FLUSH"</literal>.
+     is destroyed, call <function>curl_setopt</function>(<parameter>handle</parameter>,
+    <constant>CURLOPT_COOKIELIST</constant>, <literal>"FLUSH"</literal>).
     </simpara>
    </note>
 


### PR DESCRIPTION
Prior to php8, curl_close($ch) would flush the cookie list. Code that depend on the cookie list to be flushed on curl_close() breaks on PHP8. Document an alternative way to flush the cookie list: curl_setopt($ch, CURLOPT_COOKIELIST, "FLUSH");

Resolves https://github.com/php/doc-en/issues/2239