### PR TITLE
Revise the Yac extension documentation

### DIFF
--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -9,8 +9,31 @@
  <preface xml:id="intro.yac">
   &reftitle.intro;
   <para>
-   Yac (Yet Another cache), is a lock-free, shared memory user data cache, could be used to replace APC, local memcache.
+   Yac (Yet Another Cache) is a lock-free, shared memory user data cache,
+   and can be used to replace APC or local memcached.
   </para>
+  <para>
+   Yac stores data in shared memory, which makes it visible to every PHP
+   worker of the same machine without any inter-process communication.
+   Instead of locking, Yac relies on atomic slot updates plus a few
+   collision probes, so a cache miss never blocks a request, and a
+   concurrent write can at worst cause a failed store or a missed read
+   that the caller can simply retry.
+  </para>
+  <para>
+   Because Yac trades correctness guarantees for speed and throughput,
+   it is best suited for data that is expensive to produce but easy to
+   recreate: page fragments, configuration snapshots, small service
+   responses, and other local caches. It should not be used as the
+   authoritative store for irreplaceable data.
+  </para>
+  <note>
+   <para>
+    Shared memory is only visible within one machine. To share a cache
+    across several servers, use a network cache such as Memcached or
+    Redis instead.
+   </para>
+  </note>
  </preface>
 
  &reference.yac.setup;

--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -8,31 +8,31 @@
 
  <preface xml:id="intro.yac">
   &reftitle.intro;
-  <para>
+  <simpara>
    Yac (Yet Another Cache) is a lock-free, shared memory user data cache,
    and can be used to replace APC or local memcached.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Yac stores data in shared memory, which makes it visible to every PHP
    worker of the same machine without any inter-process communication.
    Instead of locking, Yac relies on atomic slot updates plus a few
    collision probes, so a cache miss never blocks a request, and a
    concurrent write can at worst cause a failed store or a missed read
    that the caller can simply retry.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Because Yac trades correctness guarantees for speed and throughput,
    it is best suited for data that is expensive to produce but easy to
    recreate: page fragments, configuration snapshots, small service
    responses, and other local caches. It should not be used as the
    authoritative store for irreplaceable data.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Shared memory is only visible within one machine. To share a cache
     across several servers, use a network cache such as Memcached or
     Redis instead.
-   </para>
+   </simpara>
   </note>
  </preface>
 

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -89,10 +89,10 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Reserved for debugging. As of Yac 2.4.0 this directive is
        registered but has no effect.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.enable">
@@ -101,10 +101,10 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Whether Yac is enabled. If disabled, creating a
        <classname>Yac</classname> instance throws an exception.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.enable-cli">
@@ -113,12 +113,12 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Whether Yac is enabled when running under the
        <literal>CLI</literal> SAPI. It is disabled by default because
        command line scripts usually start and stop immediately, and the
        shared memory segment would be created for nothing.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.keys-memory-size">
@@ -127,14 +127,14 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Amount of shared memory used for the hash slots that hold keys
        and bookkeeping. Each slot is a fixed-size structure, so this value
        determines how many items can be tracked at once. Defaults to
        <literal>4M</literal>. Yac splits this area into segments; the
        segment size is 4M, so this value must be a multiple of
        <literal>4M</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.serializer">
@@ -143,7 +143,7 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Serializer used to turn arbitrary PHP values into bytes before
        storing them. Allowed values are <literal>php</literal> (the
        default), <literal>json</literal>, <literal>igbinary</literal> and
@@ -152,7 +152,7 @@
        as <literal>igbinary</literal> and <literal>msgpack</literal> are
        typically faster and produce smaller payloads than
        <literal>php</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.values-memory-size">
@@ -161,13 +161,13 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Amount of shared memory used to store the actual values.
        Defaults to <literal>64M</literal>. Yac allocates this area in
        segments of 4M each, so this value must be a multiple of
        <literal>4M</literal>. When the area is full, least recently used
        entries are kicked to make room for new ones.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -75,7 +75,11 @@
      </term>
      <listitem>
       <para>
-       
+       Serialized values larger than this number of bytes are
+       compressed before being stored (currently with LZ4). Set it to
+       <literal>-1</literal> (the default) to disable compression
+       entirely. Compressing large values saves shared memory at the cost
+       of some CPU on both store and retrieve.
       </para>
      </listitem>
     </varlistentry>
@@ -86,7 +90,8 @@
      </term>
      <listitem>
       <para>
-       
+       Reserved for debugging. As of Yac 2.4.0 this directive is
+       registered but has no effect.
       </para>
      </listitem>
     </varlistentry>
@@ -97,7 +102,8 @@
      </term>
      <listitem>
       <para>
-       
+       Whether Yac is enabled. If disabled, creating a
+       <classname>Yac</classname> instance throws an exception.
       </para>
      </listitem>
     </varlistentry>
@@ -108,7 +114,10 @@
      </term>
      <listitem>
       <para>
-       
+       Whether Yac is enabled when running under the
+       <literal>CLI</literal> SAPI. It is disabled by default because
+       command line scripts usually start and stop immediately, and the
+       shared memory segment would be created for nothing.
       </para>
      </listitem>
     </varlistentry>
@@ -119,7 +128,12 @@
      </term>
      <listitem>
       <para>
-       
+       Amount of shared memory used for the hash slots that hold keys
+       and bookkeeping. Each slot is a fixed-size structure, so this value
+       determines how many items can be tracked at once. Defaults to
+       <literal>4M</literal>. Yac splits this area into segments; the
+       segment size is 4M, so this value must be a multiple of
+       <literal>4M</literal>.
       </para>
      </listitem>
     </varlistentry>
@@ -130,7 +144,14 @@
      </term>
      <listitem>
       <para>
-       
+       Serializer used to turn arbitrary PHP values into bytes before
+       storing them. Allowed values are <literal>php</literal> (the
+       default), <literal>json</literal>, <literal>igbinary</literal> and
+       <literal>msgpack</literal>. The latter three require the extension
+       to be built with the corresponding support. Binary serializers such
+       as <literal>igbinary</literal> and <literal>msgpack</literal> are
+       typically faster and produce smaller payloads than
+       <literal>php</literal>.
       </para>
      </listitem>
     </varlistentry>
@@ -141,7 +162,11 @@
      </term>
      <listitem>
       <para>
-       
+       Amount of shared memory used to store the actual values.
+       Defaults to <literal>64M</literal>. Yac allocates this area in
+       segments of 4M each, so this value must be a multiple of
+       <literal>4M</literal>. When the area is full, least recently used
+       entries are kicked to make room for new ones.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -74,13 +74,13 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Serialized values larger than this number of bytes are
        compressed before being stored (currently with LZ4). Set it to
        <literal>-1</literal> (the default) to disable compression
        entirely. Compressing large values saves shared memory at the cost
        of some CPU on both store and retrieve.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.debug">

--- a/reference/yac/setup.xml
+++ b/reference/yac/setup.xml
@@ -6,24 +6,24 @@
 
  <section xml:id="yac.requirements">
   &reftitle.required;
-  <para>
+  <simpara>
    No external library is required.
-  </para>
+  </simpara>
  </section>
 
  <!-- {{{ Installation -->
  <section xml:id="yac.installation">
   &reftitle.install;
-  <para>
+  <simpara>
    &pecl.moved;
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;yac">&url.pecl.package;yac</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.windows.download.avail;
-  </para>
+  </simpara>
   <para>
    The source code is hosted on
    <link xlink:href="&url.git.hub;laruence/yac">GitHub</link>. To build the
@@ -39,18 +39,18 @@ $ sudo make install
 ]]>
    </screen>
   </para>
-  <para>
+  <simpara>
    The following <literal>configure</literal> options are available:
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Values are compressed with LZ4 before being stored. By default, Yac uses
    the LZ4 copy bundled with the extension; no extra flag is needed. To link
    against the system LZ4 library instead, use the
    <option role="configure">--with-system-lz4</option> switch, which
    requires the <literal>lz4.h</literal> header and
    <literal>liblz4</literal> to be installed.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Alternative serializers can be compiled in with
    <option role="configure">--enable-json</option>,
    <option role="configure">--enable-msgpack</option> or
@@ -58,7 +58,7 @@ $ sudo make install
    corresponding extension as an optional dependency. The serializer used at
    runtime is selected with the
    <link linkend="ini.yac.serializer">yac.serializer</link> ini directive.
-  </para>
+  </simpara>
  </section>
  <!-- }}} -->
 
@@ -68,9 +68,9 @@ $ sudo make install
 
  <section xml:id="yac.resources">
   &reftitle.resources;
-  <para>
+  <simpara>
    This extension does not define any resources.
-  </para>
+  </simpara>
  </section>
 
 </chapter>

--- a/reference/yac/setup.xml
+++ b/reference/yac/setup.xml
@@ -7,7 +7,7 @@
  <section xml:id="yac.requirements">
   &reftitle.required;
   <para>
-
+   No external library is required.
   </para>
  </section>
 
@@ -24,6 +24,41 @@
   <para>
    &pecl.windows.download.avail;
   </para>
+  <para>
+   The source code is hosted on
+   <link xlink:href="&url.git.hub;laruence/yac">GitHub</link>. To build the
+   extension from source:
+   <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/yac.git
+$ cd yac
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+   </screen>
+  </para>
+  <para>
+   The following <literal>configure</literal> options are available:
+  </para>
+  <para>
+   Values are compressed with LZ4 before being stored. By default, Yac uses
+   the LZ4 copy bundled with the extension; no extra flag is needed. To link
+   against the system LZ4 library instead, use the
+   <option role="configure">--with-system-lz4</option> switch, which
+   requires the <literal>lz4.h</literal> header and
+   <literal>liblz4</literal> to be installed.
+  </para>
+  <para>
+   Alternative serializers can be compiled in with
+   <option role="configure">--enable-json</option>,
+   <option role="configure">--enable-msgpack</option> or
+   <option role="configure">--enable-igbinary</option>, which register the
+   corresponding extension as an optional dependency. The serializer used at
+   runtime is selected with the
+   <link linkend="ini.yac.serializer">yac.serializer</link> ini directive.
+  </para>
  </section>
  <!-- }}} -->
 
@@ -34,7 +69,7 @@
  <section xml:id="yac.resources">
   &reftitle.resources;
   <para>
-
+   This extension does not define any resources.
   </para>
  </section>
 

--- a/reference/yac/versions.xml
+++ b/reference/yac/versions.xml
@@ -7,14 +7,27 @@
  <function name='yac' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::__construct' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::add' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::add key' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::add value' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::add ttl' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::set' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::set key' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::set value' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::set ttl' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::__set' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::get' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::get key' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::get cas' from='PECL yac &gt;= 1.0.0, &lt;= 2.3.1'/>
+ <function name='yac::get default' from='PECL yac &gt;= 2.4.0'/>
  <function name='yac::__get' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::delete' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::delete key' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::delete delay' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::flush' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::info' from='PECL yac &gt;= 1.0.0'/>
  <function name='yac::dump' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::dump limit' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::dump offset' from='PECL yac &gt;= 2.4.0'/>
 </versions>
 
 <!-- Keep this comment at the end of the file

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -4,23 +4,26 @@
 <refentry xml:id="yac.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::add</refname>
-  <refpurpose>Store into cache</refpurpose>
+  <refpurpose>Store a value without overwriting an existing one</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>array</type><parameter>key_vals</parameter></methodparam>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-    Added a item into cache.
+   Stores a value in the cache. Unlike <methodname>Yac::set</methodname>,
+   it does not overwrite an existing entry that is still valid; the store
+   is rejected in that case.
   </para>
  </refsect1>
 
@@ -31,7 +34,8 @@
     <term><parameter>keys</parameter></term>
     <listitem>
      <para>
-       &string; key
+      A <type>string</type> key, or an <type>array</type> of
+      <literal>key =&gt; value</literal> pairs to store in one call.
      </para>
     </listitem>
    </varlistentry>
@@ -39,7 +43,10 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <para>
-      mixed value, All php value type could be stored except &resource;
+      The value to store. Every PHP type except <type>resource</type> can
+      be stored. Only used in the single-key form; when
+      <parameter>keys</parameter> is an array, this argument is instead the
+      optional <parameter>ttl</parameter>.
      </para>
     </listitem>
    </varlistentry>
@@ -47,7 +54,8 @@
     <term><parameter>ttl</parameter></term>
     <listitem>
      <para>
-      expire time
+      Time to live in seconds. <literal>0</literal> means the entry never
+      expires by time.
      </para>
     </listitem>
    </varlistentry>
@@ -57,24 +65,61 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &boolean;, &true; on success, &false; on failure 
-   <note>
-    <para>
-     <methodname>Yac::add</methodname> may fail if cas lock could not obtain,
-     so, if you need the value to be stored properly, you may write codes like:
-     <example>
-      <title>Make sure the item is stored</title>
-      <programlisting role="php">
-       <![CDATA[
-       while(!$yac->set("key", "value"));
-       ]]>
-      </programlisting> 
-     </example>
-    </para>
-   </note>
+   Returns &true; on success, &false; on failure. A store is also rejected
+   (returning &false;) when the key already exists and has not expired.
   </para>
+  <note>
+   <para>
+    Yac stores entries without locks. Under heavy contention a store can
+    fail transiently; if the value must eventually be stored, retry:
+    <programlisting role="php">
+<![CDATA[
+<?php
+while (!$yac->add("key", "value")) {
+    // retry on transient failure
+}
+?>
+]]>
+    </programlisting>
+   </para>
+  </note>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::add</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+var_dump($yac->add("foo", "bar"));          // bool(true)
+var_dump($yac->add("foo", "baz"));          // bool(false): "foo" already exists
+
+// ttl in seconds; 0 (the default) means the entry never expires
+$yac->add("short-lived", "value", 5);
+sleep(6);
+var_dump($yac->get("short-lived"));        // bool(false): expired
+
+// store several key => value pairs with one call, with a ttl
+$yac->add(array("a" => 1, "b" => 2), 60);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::delete</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -20,11 +20,11 @@
    <methodparam><type>array</type><parameter>values</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Stores a value in the cache. Unlike <methodname>Yac::set</methodname>,
    it does not overwrite an existing entry that is still valid; the store
    is rejected in that case.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -33,30 +33,30 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A <type>string</type> key, or an <type>array</type> of
       <literal>key =&gt; value</literal> pairs to store in one call.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The value to store. Every PHP type except <type>resource</type> can
       be stored. Only used in the single-key form; when
       <parameter>keys</parameter> is an array, this argument is instead the
       optional <parameter>ttl</parameter>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>ttl</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Time to live in seconds. <literal>0</literal> means the entry never
       expires by time.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -64,10 +64,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; on success, &false; on failure. A store is also rejected
    (returning &false;) when the key already exists and has not expired.
-  </para>
+  </simpara>
   <note>
    <para>
     Yac stores entries without locks. Under heavy contention a store can

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -14,9 +14,11 @@
    <methodparam choice="opt"><type>string</type><parameter>prefix</parameter><initializer>""</initializer></methodparam>
   </constructorsynopsis>
   <para>
-    prefix is used to prepended to keys, this could be used to avoiding conflicts between apps.
+   Creates a new <classname>Yac</classname> instance. The optional
+   <parameter>prefix</parameter> is prepended to every key this instance stores,
+   which lets several applications or caches on the same machine use
+   overlapping key names without colliding.
   </para>
-
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,30 +28,48 @@
     <term><parameter>prefix</parameter></term>
     <listitem>
      <para>
-       &string; prefix
+      A key prefix, up to 48 bytes (<constant>YAC_MAX_KEY_LEN</constant>).
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
 
- <!-- Return values commented out, as constructors generally don't return a
-      value. Uncomment this if you do need a return values section (for
-      example, because there's also a procedural version of the method).
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   
-  </para>
- </refsect1>
- -->
-
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Throws an <classname>Exception</classname> if Yac is not enabled. Throws 
-   <classname>Exception</classname> if <parameter>prefix</parameter> exceeds 
-   max key length of 48 (<constant>YAC_MAX_KEY_LEN</constant>) bytes.
+   Throws an <classname>Exception</classname> if the cache is disabled
+   (<literal>yac.enable=0</literal>), or if <parameter>prefix</parameter> is
+   longer than 48 bytes.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::__construct</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+$other = new Yac("app2_");
+var_dump($other->get("foo"));    // bool(false): different namespace
+$other->set("foo", "baz");       // stored as "app2_foo"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -13,12 +13,12 @@
    <modifier>public</modifier> <methodname>Yac::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>prefix</parameter><initializer>""</initializer></methodparam>
   </constructorsynopsis>
-  <para>
+  <simpara>
    Creates a new <classname>Yac</classname> instance. The optional
    <parameter>prefix</parameter> is prepended to every key this instance stores,
    which lets several applications or caches on the same machine use
    overlapping key names without colliding.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
    <varlistentry>
     <term><parameter>prefix</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A key prefix, up to 48 bytes (<constant>YAC_MAX_KEY_LEN</constant>).
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,11 +37,11 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Throws an <classname>Exception</classname> if the cache is disabled
+  <simpara>
+   Throws an <exceptionname>Exception</exceptionname> if the cache is disabled
    (<literal>yac.enable=0</literal>), or if <parameter>prefix</parameter> is
    longer than 48 bytes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -12,10 +12,10 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::delete</methodname>
    <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>delay</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   remove items from cache
+   Removes one or more items from the cache.
   </para>
  </refsect1>
 
@@ -26,15 +26,19 @@
     <term><parameter>keys</parameter></term>
     <listitem>
      <para>
-      string key, or array of multiple keys to be removed
+      A <type>string</type> key, or an <type>array</type> of keys to be
+      removed.
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>ttl</parameter></term>
+    <term><parameter>delay</parameter></term>
     <listitem>
      <para>
-      if delay is set, delete will mark the items to be invalid in ttl second.
+      Number of seconds before the item becomes invalid. When omitted or
+      <literal>0</literal>, the item is invalidated immediately. A positive
+      value keeps the item readable for that many seconds before it
+      expires.
      </para>
     </listitem>
    </varlistentry>
@@ -44,10 +48,46 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   
+   Returns &true; on success, or &false; if the key was not present in
+   the cache.
   </para>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::delete</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+var_dump($yac->delete("foo"));            // bool(true)
+var_dump($yac->delete("foo"));            // bool(false): already gone
+
+// delayed deletion: keep the entry readable for 60 more seconds,
+// it disappears only after that time has passed
+$yac->set("tmp", "value");
+var_dump($yac->delete("tmp", 60));        // bool(true)
+
+// delete several keys at once
+var_dump($yac->delete(array("a", "b")));
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::flush</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -14,9 +14,9 @@
    <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>delay</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Removes one or more items from the cache.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,21 +25,21 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A <type>string</type> key, or an <type>array</type> of keys to be
       removed.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>delay</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Number of seconds before the item becomes invalid. When omitted or
       <literal>0</literal>, the item is invalidated immediately. A positive
       value keeps the item readable for that many seconds before it
       expires.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -47,10 +47,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; on success, or &false; if the key was not present in
    the cache.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -14,10 +14,10 @@
    <methodparam choice="opt"><type>int</type><parameter>limit</parameter><initializer>100</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Dumps metadata of the entries currently stored in the cache. The
    values themselves are not returned.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,19 +26,19 @@
    <varlistentry>
     <term><parameter>limit</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Maximum number of entries to return.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>offset</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Number of entries to skip before collecting, which can be used to
       page through a cache that holds more entries than
       <parameter>limit</parameter>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,105 +46,105 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    An <type>array</type> with one element per dumped entry. Each element
    is itself an array describing the entry:
-  </para>
+  </simpara>
   <variablelist>
    <varlistentry>
     <term><literal>index</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The slot index of the entry in the hash table.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>hash</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The 64-bit hash of the key, used for slot probing.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>crc</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The CRC32 checksum of the stored value, used to detect torn reads.
      <literal>0</literal> for embedded entries, which have no value block.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>ttl</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The expiration timestamp (Unix time). <literal>0</literal> means the
      entry never expires by time. Note that
      <methodname>Yac::delete</methodname> only marks an entry expired, so
      deleted entries can still show up in the dump; a non-zero
      <literal>ttl</literal> in the past indicates an expired or deleted
      entry.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>k_len</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The length of the key, in bytes.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>v_len</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The length of the value, in bytes. For compressed entries this is the
      length of the <emphasis>original</emphasis> value before compression
      (as of yac 2.4.0; earlier versions reported the stored, compressed
      length).
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>c_len</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Only present for compressed entries (as of yac 2.4.0): the length of
      the compressed payload actually stored in shared memory, in bytes.
      Comparing <literal>c_len</literal> with <literal>v_len</literal> shows
      how much compression saves per entry.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>size</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The allocated size of the value block in shared memory, in bytes.
      <literal>0</literal> for embedded entries.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>atime</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The last access time (Unix time), updated on each successful
      <methodname>Yac::get</methodname>. When the cache is full, the entry
      with the oldest <literal>atime</literal> among the candidate slots is
      evicted first (as of yac 2.4.0).
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>hits</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      A per-entry hit counter, bumped on each successful
      <methodname>Yac::get</methodname>, reset when the entry is overwritten,
      deleted or expires (as of yac 2.4.0).
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>embedded</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Whether the value is stored directly inside the slot instead of in a
      separate value block (as of yac 2.4.0). Small values —
      <constant>NULL</constant>, booleans, small integers, strings of up to
      7 bytes and empty arrays — are embedded this way and allocate no value
      memory at all; for them <literal>crc</literal> and
      <literal>size</literal> are reported as <literal>0</literal>.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>key</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The cache key, without any instance prefix.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
@@ -202,22 +202,22 @@ Array
 )
 ]]>
    </screen>
-   <para>
+   <simpara>
     Entries are listed in slot order, not in the order they were stored.
     Embedded entries (short scalars kept inside the slot itself) have
     <literal>crc</literal> and <literal>size</literal> set to zero; entries
     stored in a separate value block carry their checksum and block size,
     and compressed entries additionally carry <literal>c_len</literal>.
-   </para>
+   </simpara>
   </example>
   <example>
    <title>Paging through a large cache</title>
-   <para>
+   <simpara>
     <parameter>limit</parameter> bounds how many entries a single call returns,
     and <parameter>offset</parameter> skips that many entries before collecting,
     so the two can be combined to page through a cache that holds more
     entries than one call may return.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -239,11 +239,11 @@ var_dump(count($page));
 int(100)
 ]]>
    </screen>
-   <para>
+   <simpara>
     Fewer entries than requested are returned when the cache holds fewer
     entries than the requested page covers, and an empty array is returned
     once the offset points past the last occupied slot.
-   </para>
+   </simpara>
   </example>
  </refsect1>
 

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -4,17 +4,19 @@
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::dump</refname>
-  <refpurpose>Dump cache</refpurpose>
+  <refpurpose>Dump cache entries for inspection</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>mixed</type><methodname>Yac::dump</methodname>
-   <methodparam><type>int</type><parameter>num</parameter></methodparam>
+   <modifier>public</modifier> <type>array</type><methodname>Yac::dump</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>limit</parameter><initializer>100</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Dump values stored in cache
+   Dumps metadata of the entries currently stored in the cache. The
+   values themselves are not returned.
   </para>
  </refsect1>
 
@@ -22,10 +24,20 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>num</parameter></term>
+    <term><parameter>limit</parameter></term>
     <listitem>
      <para>
-       Maximum number of items should be returned
+      Maximum number of entries to return.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <para>
+      Number of entries to skip before collecting, which can be used to
+      page through a cache that holds more entries than
+      <parameter>limit</parameter>.
      </para>
     </listitem>
    </varlistentry>
@@ -35,10 +47,214 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   mixed
+   An <type>array</type> with one element per dumped entry. Each element
+   is itself an array describing the entry:
   </para>
+  <variablelist>
+   <varlistentry>
+    <term><literal>index</literal></term>
+    <listitem><para>
+     The slot index of the entry in the hash table.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hash</literal></term>
+    <listitem><para>
+     The 64-bit hash of the key, used for slot probing.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>crc</literal></term>
+    <listitem><para>
+     The CRC32 checksum of the stored value, used to detect torn reads.
+     <literal>0</literal> for embedded entries, which have no value block.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>ttl</literal></term>
+    <listitem><para>
+     The expiration timestamp (Unix time). <literal>0</literal> means the
+     entry never expires by time. Note that
+     <methodname>Yac::delete</methodname> only marks an entry expired, so
+     deleted entries can still show up in the dump; a non-zero
+     <literal>ttl</literal> in the past indicates an expired or deleted
+     entry.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>k_len</literal></term>
+    <listitem><para>
+     The length of the key, in bytes.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>v_len</literal></term>
+    <listitem><para>
+     The length of the value, in bytes. For compressed entries this is the
+     length of the <emphasis>original</emphasis> value before compression
+     (as of yac 2.4.0; earlier versions reported the stored, compressed
+     length).
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>c_len</literal></term>
+    <listitem><para>
+     Only present for compressed entries (as of yac 2.4.0): the length of
+     the compressed payload actually stored in shared memory, in bytes.
+     Comparing <literal>c_len</literal> with <literal>v_len</literal> shows
+     how much compression saves per entry.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>size</literal></term>
+    <listitem><para>
+     The allocated size of the value block in shared memory, in bytes.
+     <literal>0</literal> for embedded entries.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>atime</literal></term>
+    <listitem><para>
+     The last access time (Unix time), updated on each successful
+     <methodname>Yac::get</methodname>. When the cache is full, the entry
+     with the oldest <literal>atime</literal> among the candidate slots is
+     evicted first (as of yac 2.4.0).
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hits</literal></term>
+    <listitem><para>
+     A per-entry hit counter, bumped on each successful
+     <methodname>Yac::get</methodname>, reset when the entry is overwritten,
+     deleted or expires (as of yac 2.4.0).
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>embedded</literal></term>
+    <listitem><para>
+     Whether the value is stored directly inside the slot instead of in a
+     separate value block (as of yac 2.4.0). Small values —
+     <constant>NULL</constant>, booleans, small integers, strings of up to
+     7 bytes and empty arrays — are embedded this way and allocate no value
+     memory at all; for them <literal>crc</literal> and
+     <literal>size</literal> are reported as <literal>0</literal>.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>key</literal></term>
+    <listitem><para>
+     The cache key, without any instance prefix.
+    </para></listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::dump</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+$yac->set("baz", "qux");
+
+print_r($yac->dump());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [0] => Array
+        (
+            [index] => 12345
+            [hash] => 14463105906481965911
+            [crc] => 0
+            [ttl] => 0
+            [k_len] => 3
+            [v_len] => 3
+            [size] => 0
+            [atime] => 1725955200
+            [hits] => 0
+            [embedded] => 1
+            [key] => foo
+        )
+
+    [1] => Array
+        (
+            [index] => 12987
+            [hash] => 15132029420525657053
+            [crc] => 0
+            [ttl] => 0
+            [k_len] => 3
+            [v_len] => 3
+            [size] => 0
+            [atime] => 1725955200
+            [hits] => 0
+            [embedded] => 1
+            [key] => baz
+        )
+
+)
+]]>
+   </screen>
+   <para>
+    Entries are listed in slot order, not in the order they were stored.
+    Embedded entries (short scalars kept inside the slot itself) have
+    <literal>crc</literal> and <literal>size</literal> set to zero; entries
+    stored in a separate value block carry their checksum and block size,
+    and compressed entries additionally carry <literal>c_len</literal>.
+   </para>
+  </example>
+  <example>
+   <title>Paging through a large cache</title>
+   <para>
+    <parameter>limit</parameter> bounds how many entries a single call returns,
+    and <parameter>offset</parameter> skips that many entries before collecting,
+    so the two can be combined to page through a cache that holds more
+    entries than one call may return.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$page_size = 100;
+$page_num  = 2;
+
+// skip the first 100 entries and return the next 100 (page 2)
+$page = $yac->dump($page_size, $page_size * ($page_num - 1));
+
+var_dump(count($page));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(100)
+]]>
+   </screen>
+   <para>
+    Fewer entries than requested are returned when the cache holds fewer
+    entries than the requested page covers, and an empty array is returned
+    once the offset points past the last occupied slot.
+   </para>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/flush.xml
+++ b/reference/yac/yac/flush.xml
@@ -14,7 +14,10 @@
    <void />
   </methodsynopsis>
   <para>
-    Remove all cached values
+    Removes all cached values. Because the cache is shared by every
+    process of the same machine, this empties the cache globally; the
+    key prefix given to <methodname>Yac::__construct</methodname> does
+    not limit what gets flushed.
   </para>
  </refsect1>
 
@@ -26,10 +29,44 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   bool, always true 
+   Returns &true;.
   </para>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::flush</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+$other = new Yac("app2_");
+$other->set("baz", "qux");
+
+// flush empties the whole cache: entries of every instance,
+// regardless of the prefix used when they were stored
+$yac->flush();
+
+var_dump($yac->get("foo"));   // bool(false)
+var_dump($other->get("baz")); // bool(false)
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::delete</methodname></member>
+    <member><methodname>Yac::info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/flush.xml
+++ b/reference/yac/yac/flush.xml
@@ -13,12 +13,12 @@
    <modifier>public</modifier> <type>bool</type><methodname>Yac::flush</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
     Removes all cached values. Because the cache is shared by every
     process of the same machine, this empties the cache globally; the
     key prefix given to <methodname>Yac::__construct</methodname> does
     not limit what gets flushed.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -14,9 +14,9 @@
    <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Retrieve values from cache
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,26 +25,26 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A <type>string</type> key, or an <type>array</type> of keys.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>default</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The value to return when the requested key (or keys) is not
       present in the cache, available as of yac 2.4.0. When omitted, a
       miss returns &false;.
-     </para>
+     </simpara>
      <note>
-      <para>
+      <simpara>
        Before yac 2.4.0, this argument slot held a by-reference
        <literal>$cas</literal> token rather than a default value. Code
        that passed or relied on that token must be updated when
        upgrading to 2.4.0.
-      </para>
+      </simpara>
      </note>
     </listitem>
    </varlistentry>
@@ -53,18 +53,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    For a <type>string</type> key, returns the cached value on a hit,
    otherwise the <parameter>default</parameter> (or &false; when no default
    was given).
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    For an <type>array</type> of keys, returns an array containing the
    found values indexed by their keys. Keys that are not present in
    the cache are omitted from the result as of yac 2.4.0, or filled
    with the <parameter>default</parameter> when one was given; before
    2.4.0, a &false; placeholder was inserted for every missing key.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -11,8 +11,8 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::get</methodname>
-   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter role="reference">cas</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
     Retrieve values from cache
@@ -23,19 +23,29 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>key</parameter></term>
+    <term><parameter>keys</parameter></term>
     <listitem>
      <para>
-      &string; keys, or &array; of multiple keys.
+      A <type>string</type> key, or an <type>array</type> of keys.
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>cas</parameter></term>
+    <term><parameter>default</parameter></term>
     <listitem>
      <para>
-      if not &null;, it will be set to the retrieved item's cas.
+      The value to return when the requested key (or keys) is not
+      present in the cache, available as of yac 2.4.0. When omitted, a
+      miss returns &false;.
      </para>
+     <note>
+      <para>
+       Before yac 2.4.0, this argument slot held a by-reference
+       <literal>$cas</literal> token rather than a default value. Code
+       that passed or relied on that token must be updated when
+       upgrading to 2.4.0.
+      </para>
+     </note>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,10 +54,60 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   mixed on success, false on failure
+   For a <type>string</type> key, returns the cached value on a hit,
+   otherwise the <parameter>default</parameter> (or &false; when no default
+   was given).
+  </para>
+  <para>
+   For an <type>array</type> of keys, returns an array containing the
+   found values indexed by their keys. Keys that are not present in
+   the cache are omitted from the result as of yac 2.4.0, or filled
+   with the <parameter>default</parameter> when one was given; before
+   2.4.0, a &false; placeholder was inserted for every missing key.
   </para>
  </refsect1>
 
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::get</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");
+var_dump($yac->get("foo"));                 // string(3) "bar"
+var_dump($yac->get("missing"));             // bool(false): a miss
+
+// a miss and a stored false are indistinguishable without a default;
+// a sentinel default (available as of yac 2.4.0) tells them apart
+$yac->set("flag", false);
+var_dump($yac->get("flag"));                // bool(false): the stored value
+var_dump($yac->get("missing", false));      // bool(false): a miss, same shape
+var_dump($yac->get("flag", "__NONE__"));    // bool(false): the stored value
+var_dump($yac->get("missing", "__NONE__")); // string(8) "__NONE__": a miss
+
+// with an array of keys, only the found keys are present in the result
+$yac->set("foo2", "bar2");
+var_dump($yac->get(array("foo", "foo2", "missing")));
+// array(2) { ["foo"]=> string(3) "bar" ["foo2"]=> string(4) "bar2" }
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::__get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/getter.xml
+++ b/reference/yac/yac/getter.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="yac.getter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::__get</refname>
-  <refpurpose>Getter</refpurpose>
+  <refpurpose>Retrieve a value using property syntax</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,9 @@
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Retrieve values from cache
+   Retrieves a value from the cache, invoked when reading a property of a
+   <classname>Yac</classname> instance: <literal>$yac->foo</literal> is
+   equivalent to <literal>$yac->get("foo")</literal>.
   </para>
  </refsect1>
 
@@ -25,7 +27,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-       &string; key
+      The property name, used as the cache key.
      </para>
     </listitem>
    </varlistentry>
@@ -35,10 +37,45 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   mixed on success, &null; on failure
+   The cached value on a hit, &null; when the key is not present in the
+   cache.
   </para>
+  <note>
+   <para>
+    Unlike <methodname>Yac::get</methodname>, property syntax cannot
+    distinguish a stored &null; from a missing key, and only supports
+    single keys.
+   </para>
+  </note>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::__get</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+var_dump($yac->foo);       // string(3) "bar"
+var_dump($yac->missing);   // NULL
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::__set</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/getter.xml
+++ b/reference/yac/yac/getter.xml
@@ -13,11 +13,11 @@
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::__get</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retrieves a value from the cache, invoked when reading a property of a
    <classname>Yac</classname> instance: <literal>$yac->foo</literal> is
    equivalent to <literal>$yac->get("foo")</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
    <varlistentry>
     <term><parameter>key</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The property name, used as the cache key.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,16 +36,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    The cached value on a hit, &null; when the key is not present in the
    cache.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Unlike <methodname>Yac::get</methodname>, property syntax cannot
     distinguish a stored &null; from a missing key, and only supports
     single keys.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/yac/yac/info.xml
+++ b/reference/yac/yac/info.xml
@@ -26,12 +26,146 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Return an array, consistent with:
-   "memory_size", "slots_memory_size", "values_memory_size", "segment_size", "segment_num",
-   "miss", "hits", "fails", "kicks", "recycles", "slots_size", "slots_used"
+   Returns an <type>array</type> with the following keys:
   </para>
+  <variablelist>
+   <varlistentry>
+    <term><literal>memory_size</literal></term>
+    <listitem><para>
+     Total shared memory in use, in bytes: the slot table plus the value
+     blocks.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_memory_size</literal></term>
+    <listitem><para>
+     Memory reserved for the hash slot table, in bytes.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>values_memory_size</literal></term>
+    <listitem><para>
+     Memory reserved for the stored values, in bytes.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>segment_size</literal></term>
+    <listitem><para>
+     Size of one value memory segment, in bytes.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>segment_num</literal></term>
+    <listitem><para>
+     Number of value memory segments.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>miss</literal></term>
+    <listitem><para>
+     Number of cache misses: lookups that found nothing or an expired
+     entry.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hits</literal></term>
+    <listitem><para>
+     Number of cache hits: successful lookups.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>fails</literal></term>
+    <listitem><para>
+     Number of failed stores: stores that could not allocate a value
+     block.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>kicks</literal></term>
+    <listitem><para>
+     Number of evictions: how often an existing entry had to be evicted
+     because the candidate slot path was full.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>recycles</literal></term>
+    <listitem><para>
+     Number of times the allocator reached the end of a segment and
+     wrapped around to its beginning.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>start_time</literal></term>
+    <listitem><para>
+     The Unix timestamp at which the shared memory cache was initialized.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_size</literal></term>
+    <listitem><para>
+     Total number of hash slots.
+    </para></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_used</literal></term>
+    <listitem><para>
+     Number of hash slots currently occupied.
+    </para></listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::info</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+print_r($yac->info());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [memory_size] => 46137344
+    [slots_memory_size] => 4194304
+    [values_memory_size] => 41943040
+    [segment_size] => 4194304
+    [segment_num] => 10
+    [miss] => 0
+    [hits] => 0
+    [fails] => 0
+    [kicks] => 0
+    [recycles] => 0
+    [start_time] => 1725955200
+    [slots_size] => 32768
+    [slots_used] => 1
+)
+]]>
+   </screen>
+   <para>
+    The hit ratio can be computed as <literal>hits / (hits + miss)</literal>;
+    a growing <literal>kicks</literal> or <literal>fails</literal> counter
+    indicates that the cache is under memory pressure.
+   </para>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::dump</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/info.xml
+++ b/reference/yac/yac/info.xml
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>array</type><methodname>Yac::info</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
     Get status of cache system
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,92 +25,92 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns an <type>array</type> with the following keys:
-  </para>
+  </simpara>
   <variablelist>
    <varlistentry>
     <term><literal>memory_size</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Total shared memory in use, in bytes: the slot table plus the value
      blocks.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>slots_memory_size</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Memory reserved for the hash slot table, in bytes.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>values_memory_size</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Memory reserved for the stored values, in bytes.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>segment_size</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Size of one value memory segment, in bytes.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>segment_num</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Number of value memory segments.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>miss</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Number of cache misses: lookups that found nothing or an expired
      entry.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>hits</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Number of cache hits: successful lookups.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>fails</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Number of failed stores: stores that could not allocate a value
      block.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>kicks</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Number of evictions: how often an existing entry had to be evicted
      because the candidate slot path was full.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>recycles</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Number of times the allocator reached the end of a segment and
      wrapped around to its beginning.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>start_time</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      The Unix timestamp at which the shared memory cache was initialized.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>slots_size</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Total number of hash slots.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>slots_used</literal></term>
-    <listitem><para>
+    <listitem><simpara>
      Number of hash slots currently occupied.
-    </para></listitem>
+    </simpara></listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
@@ -150,11 +150,11 @@ Array
 )
 ]]>
    </screen>
-   <para>
+   <simpara>
     The hit ratio can be computed as <literal>hits / (hits + miss)</literal>;
     a growing <literal>kicks</literal> or <literal>fails</literal> counter
     indicates that the cache is under memory pressure.
-   </para>
+   </simpara>
   </example>
  </refsect1>
 

--- a/reference/yac/yac/set.xml
+++ b/reference/yac/yac/set.xml
@@ -4,23 +4,25 @@
 <refentry xml:id="yac.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::set</refname>
-  <refpurpose>Store into cache</refpurpose>
+  <refpurpose>Store a value into the cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>array</type><parameter>key_vals</parameter></methodparam>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-    Add a item into cache, it the key is already exists, override it.
+   Stores a value in the cache. If the key already exists, the existing
+   entry is overwritten, regardless of whether it has expired.
   </para>
  </refsect1>
 
@@ -31,7 +33,8 @@
     <term><parameter>keys</parameter></term>
     <listitem>
      <para>
-       &string; key
+      A <type>string</type> key, or an <type>array</type> of
+      <literal>key =&gt; value</literal> pairs to store in one call.
      </para>
     </listitem>
    </varlistentry>
@@ -39,7 +42,10 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <para>
-      mixed value, All php value type could be stored except &resource;
+      The value to store. Every PHP type except <type>resource</type> can
+      be stored. Only used in the single-key form; when
+      <parameter>keys</parameter> is an array, this argument is instead the
+      optional <parameter>ttl</parameter>.
      </para>
     </listitem>
    </varlistentry>
@@ -47,7 +53,8 @@
     <term><parameter>ttl</parameter></term>
     <listitem>
      <para>
-      expire time
+      Time to live in seconds. <literal>0</literal> means the entry never
+      expires by time.
      </para>
     </listitem>
    </varlistentry>
@@ -57,7 +64,43 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   the value self
+   Returns &true; on success, &false; on failure.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::set</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");                    // store a single value
+$yac->set("foo", "baz");                    // overwrite the existing entry
+
+// ttl in seconds: the entry expires after 5 seconds
+$yac->set("short-lived", "value", 5);
+sleep(6);
+var_dump($yac->get("short-lived"));        // bool(false): expired
+
+// store several key => value pairs with one call
+$yac->set(array("a" => 1, "b" => 2));
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::add</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::__set</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/yac/yac/set.xml
+++ b/reference/yac/yac/set.xml
@@ -20,10 +20,10 @@
    <methodparam><type>array</type><parameter>values</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Stores a value in the cache. If the key already exists, the existing
    entry is overwritten, regardless of whether it has expired.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,30 +32,30 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A <type>string</type> key, or an <type>array</type> of
       <literal>key =&gt; value</literal> pairs to store in one call.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The value to store. Every PHP type except <type>resource</type> can
       be stored. Only used in the single-key form; when
       <parameter>keys</parameter> is an array, this argument is instead the
       optional <parameter>ttl</parameter>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>ttl</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Time to live in seconds. <literal>0</literal> means the entry never
       expires by time.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -63,9 +63,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns &true; on success, &false; on failure.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/yac/yac/setter.xml
+++ b/reference/yac/yac/setter.xml
@@ -4,18 +4,21 @@
 <refentry xml:id="yac.setter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::__set</refname>
-  <refpurpose>Setter</refpurpose>
+  <refpurpose>Store a value using property syntax</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::__set</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-    store a item into cache
+   Stores a value in the cache, invoked when writing a property of a
+   <classname>Yac</classname> instance: <literal>$yac->foo = "bar"</literal>
+   is equivalent to <literal>$yac->set("foo", "bar")</literal>, with no
+   ttl.
   </para>
  </refsect1>
 
@@ -23,10 +26,10 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>keys</parameter></term>
+    <term><parameter>key</parameter></term>
     <listitem>
      <para>
-       &string; key
+      The property name, used as the cache key.
      </para>
     </listitem>
    </varlistentry>
@@ -34,7 +37,8 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <para>
-      mixed value, All php value type could be stored except &resource;
+      The value to store. Every PHP type except <type>resource</type> can
+      be stored.
      </para>
     </listitem>
    </varlistentry>
@@ -44,7 +48,34 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Always return the value self
+   Returns the stored value.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yac::__set</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->foo = "bar";          // stored without a ttl
+var_dump($yac->get("foo")); // string(3) "bar"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::__get</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/yac/yac/setter.xml
+++ b/reference/yac/yac/setter.xml
@@ -14,12 +14,12 @@
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Stores a value in the cache, invoked when writing a property of a
    <classname>Yac</classname> instance: <literal>$yac->foo = "bar"</literal>
    is equivalent to <literal>$yac->set("foo", "bar")</literal>, with no
    ttl.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,18 +28,18 @@
    <varlistentry>
     <term><parameter>key</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The property name, used as the cache key.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       The value to store. Every PHP type except <type>resource</type> can
       be stored.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -47,9 +47,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns the stored value.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
## Summary

- Fix method signatures against the extension source code (checked against `zend_parse_parameters`, arginfo and `yac.stub.php`):
  - `Yac::get()` takes `string|array $keys` plus an optional `mixed $default` (the documented `&$cas` by-reference parameter never existed in any release; the slot is reused for `$default` as of 2.4.0)
  - `Yac::delete()` takes `$delay`, not `$ttl`
  - `Yac::set()` returns `bool`, not the value itself
- Rewrite `book.xml` to state the lock-free semantics and suitability boundaries; document default values for every INI entry in `ini.xml`; add the yac 2.4.0 records to `versions.xml`
- Expand the examples on all ten method pages so every parameter is exercised (e.g. the `$default` sentinel on misses, `Yac::dump` field details, `Yac::info` counters), and add See Also cross-references
- Document the `--with-system-lz4` configure option, the serializer configure switches and the GitHub repository in the setup section

## Test plan

- [x] `php doc-base/configure.php` passes locally
- [x] `docbook-cs` (this PR's CI)
- [x] Full phd xhtml render succeeds; all 18 yac pages spot-checked