### PR TITLE
ext/spl: document typed class constants (PHP 8.4)

### DIFF
--- a/reference/spl/arrayiterator.xml
+++ b/reference/spl/arrayiterator.xml
@@ -114,6 +114,28 @@
   </section>
 }}} -->
  
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.arrayiterator;

--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -116,6 +116,28 @@
   </section>
 }}} -->
  
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.arrayobject;

--- a/reference/spl/cachingiterator.xml
+++ b/reference/spl/cachingiterator.xml
@@ -180,6 +180,28 @@
   </section>
 
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.cachingiterator;

--- a/reference/spl/filesystemiterator.xml
+++ b/reference/spl/filesystemiterator.xml
@@ -208,6 +208,28 @@
   </section>
   <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.spl.entities.filesystemiterator;

--- a/reference/spl/multipleiterator.xml
+++ b/reference/spl/multipleiterator.xml
@@ -114,6 +114,28 @@
 <!-- }}} -->
 
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.spl.entities.multipleiterator;

--- a/reference/spl/recursivearrayiterator.xml
+++ b/reference/spl/recursivearrayiterator.xml
@@ -94,6 +94,28 @@
   </section>
 }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.spl.entities.recursivearrayiterator;

--- a/reference/spl/recursiveiteratoriterator.xml
+++ b/reference/spl/recursiveiteratoriterator.xml
@@ -103,6 +103,28 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.spl.entities.recursiveiteratoriterator;

--- a/reference/spl/recursivetreeiterator.xml
+++ b/reference/spl/recursivetreeiterator.xml
@@ -173,6 +173,28 @@
 <!-- }}} -->
 
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.spl.entities.recursivetreeiterator;

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -209,6 +209,28 @@
   </section>
 }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.spl.entities.regexiterator;

--- a/reference/spl/spldoublylinkedlist.xml
+++ b/reference/spl/spldoublylinkedlist.xml
@@ -144,6 +144,28 @@
   </section>
 }}} -->
  
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.spldoublylinkedlist;

--- a/reference/spl/splfileobject.xml
+++ b/reference/spl/splfileobject.xml
@@ -114,6 +114,28 @@
   </section>
 <!-- }}} -->
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.spl.entities.splfileobject;

--- a/reference/spl/splpriorityqueue.xml
+++ b/reference/spl/splpriorityqueue.xml
@@ -106,6 +106,28 @@
   </section>
 }}} -->
  
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.splpriorityqueue;


### PR DESCRIPTION
Class constants in ext/spl are now typed as of PHP 8.4.0. Update the reference pages accordingly.

Tracked in https://github.com/orgs/php/projects/11