### PR TITLE
ext/sqlite3: document typed class constants (PHP 8.4)

### DIFF
--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -525,6 +525,28 @@
    </variablelist>
   </section>
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        The class constants are now typed.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.sqlite3.entities.sqlite3;


### PR DESCRIPTION
Class constants in ext/sqlite3 are now typed as of PHP 8.4.0. Update the reference pages accordingly.

Tracked in https://github.com/orgs/php/projects/11