### PR TITLE
ext/mbstring: fix the version of the character index change, it shipped in 8.3.2

### DIFF
--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -517,19 +517,19 @@
   <title>MBString</title>
 
   <simpara>
-   On invalid strings (those with encoding errors),
-   <function>mb_substr</function> now interprets character indices in the same
-   manner as most other mbstring functions.
+   As of PHP 8.3.2, on invalid strings (those with encoding errors),
+   <function>mb_substr</function> and <function>mb_strstr</function> interpret
+   character indices in the same manner as most other mbstring functions.
    This means that character indices returned by <function>mb_strpos</function>
    can be passed to <function>mb_substr</function>.
   </simpara>
 
   <simpara>
-   For SJIS-Mac (MacJapanese) strings, character indices passed to
-   <function>mb_substr</function> now refer to the indices of the Unicode
-   codepoints which are produced when the string is converted to Unicode.
-   This is significant because around 40 SJIS-Mac characters convert to a
-   sequence of multiple Unicode codepoints.
+   For <literal>SJIS-mac</literal> (MacJapanese) strings, those character
+   indices refer to the indices of the Unicode codepoints which are produced
+   when the string is converted to Unicode, which differ from the character
+   indices for the <literal>SJIS-mac</literal> characters that convert to a
+   sequence of several codepoints.
   </simpara>
  </sect2>
 

--- a/reference/mbstring/book.xml
+++ b/reference/mbstring/book.xml
@@ -28,14 +28,19 @@
    the multibyte character and ends up with a corrupted garbage string that
    most likely loses its original meaning.
   </para>
-  <para>
-   <literal>mbstring</literal> provides multibyte specific string functions 
-   that help you deal with multibyte encodings in PHP. In addition to that, 
-   <literal>mbstring</literal> handles character encoding conversion between 
-   the possible encoding pairs. <literal>mbstring</literal> is designed to 
-   handle Unicode-based encodings such as UTF-8 and UCS-2 and many 
+  <simpara>
+   <literal>mbstring</literal> provides multibyte specific string functions
+   that help you deal with multibyte encodings in PHP. In addition to that,
+   <literal>mbstring</literal> handles character encoding conversion between
+   the possible encoding pairs. <literal>mbstring</literal> is designed to
+   handle Unicode-based encodings such as UTF-8 and UCS-2 and many
    single-byte encodings for convenience (listed in <link linkend="mbstring.supported-encodings">Supported Character Encodings</link>).
-  </para>
+  </simpara>
+  <simpara>
+   The Unicode data tables used by <literal>mbstring</literal> have been
+   updated to Unicode 16.0 as of PHP 8.4.0, and to Unicode 17.0 as of
+   PHP 8.5.0.
+  </simpara>
  </preface>
  <!-- }}} -->
  

--- a/reference/mbstring/functions/mb-strstr.xml
+++ b/reference/mbstring/functions/mb-strstr.xml
@@ -84,6 +84,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.2</entry>
+      <entry>
+       On invalid strings (those with encoding errors) and on
+       <literal>SJIS-mac</literal> (MacJapanese) strings, the portion of
+       <parameter>haystack</parameter> returned when
+       <parameter>before_needle</parameter> is &true; is now determined from
+       the same character indices as the other mbstring functions.
+      </entry>
+     </row>
      &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
     </tbody>

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -98,12 +98,17 @@
     </thead>
     <tbody>
      <row>
-      <entry>8.4.0</entry>
+      <entry>8.3.2</entry>
       <entry>
        On invalid strings (those with encoding errors),
        character indices are now interpreted in the same manner as most
        other mbstring functions. This means that character indices returned
        by <function>mb_strpos</function> can be passed directly.
+       For <literal>SJIS-mac</literal> (MacJapanese) strings, character
+       indices now refer to the indices of the Unicode codepoints produced
+       when the string is converted to Unicode, which differ from the
+       character indices for the <literal>SJIS-mac</literal> characters that
+       convert to a sequence of several codepoints.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;
@@ -114,12 +119,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>mb_strcut</function></member>
-    <member><function>mb_internal_encoding</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>mb_strcut</function></member>
+   <member><function>mb_internal_encoding</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
The `mb_substr` changelog dated the character index change to 8.4.0, which is what `UPGRADING` says, but the commit landed on the `PHP-8.3` branch and the first release containing it is **8.3.2**. `git tag --contains ec348a12d11` gives `php-8.3.2` before any 8.4 tag, and the official images bisect cleanly:

| PHP | `mb_substr("A\x85\xABB", 1, 1, "SJIS-mac")` | `mb_substr("\xf0start", 1, 5)` |
|---|---|---|
| 8.3.1 | `85ab` (whole SJIS unit) | `rt` |
| 8.3.2 | `3f` (single codepoint) | `start` |
| 8.4 | `3f` | `start` |

A user on 8.3 reading the current table concludes they are unaffected, which is the failure mode the changelog exists to prevent.

- `mb-substr.xml`: merge the two rows into a single 8.3.2 entry, both described the same commit
- `mb-strstr.xml`: add the same entry, `mb_strstr` is affected too (`mb_strstr("A\x85\xABB", "B", true, "SJIS-mac")` returns `4185ab42` on 8.3.1, `4185ab` from 8.3.2) and had no changelog for it
- `migration84/incompatible.xml`: state the actual version; the change is still relevant to anyone upgrading from 8.3.0 or 8.3.1
- use the encoding name the manual and php-src actually use, `SJIS-mac` (`supported-encodings.xml`, `mbfilter_cjk.c`), and drop the "around 40" figure: an exhaustive scan of the two-byte `SJIS-mac` units gives 56 that produce several codepoints
- `mb-substr.xml`: take the seealso `simplelist` out of its `para`
- `book.xml`: the Unicode table version is not a standing fact, 8.5.0 updated the tables to Unicode 17.0, so name both releases rather than leaving the intro false for 8.5 readers