### PR TITLE
ext/intl: correct the 8.4.0 Error normalization, it only concerns cloning

### DIFF
--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -551,9 +551,12 @@
    <title>Intl</title>
 
    <simpara>
-    The behaviour of Intl class has been normalized to always throw
-    <exceptionname>Error</exceptionname> exceptions when attempting to use
-    a non-initialized object, or when cloning fails.
+    Cloning an Intl object consistently throws an
+    <exceptionname>Error</exceptionname> when the clone cannot be performed,
+    either because the object has not been initialized, or because the
+    underlying ICU clone operation failed. Formerly, most of these classes
+    threw an <exceptionname>Exception</exceptionname> instead, and
+    <classname>Spoofchecker</classname> raised a fatal error.
    </simpara>
   </sect3>
 

--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -93,6 +93,18 @@
    </listitem>
   </itemizedlist>
 
+  <note>
+   <simpara>
+    As of PHP 8.4.0, cloning an Intl object consistently throws an
+    <exceptionname>Error</exceptionname> when the clone cannot be performed,
+    either because the object has not been initialized (created without
+    invoking its constructor), or because the underlying ICU clone operation
+    failed. Formerly, most of these classes threw an
+    <exceptionname>Exception</exceptionname> instead, and
+    <classname>Spoofchecker</classname> raised a fatal error.
+   </simpara>
+  </note>
+
   <!-- {{{ Links -->
   <section xml:id="intl.links">
    <title>Links</title>


### PR DESCRIPTION
Only the clone path changed in 8.4.0, so the note is restated accordingly.

Throwing an `Error` when a method is called on a non-initialized Intl object is **not** new: the macros doing so date back to 2012 and PHP 8.3 behaves identically (verified on `php:8.3` and `php:8.4` with `intl` built in, across `Collator`, `NumberFormatter`, `MessageFormatter`, `IntlDateFormatter`, `IntlCalendar`, `IntlTimeZone`, `Spoofchecker`, `Transliterator`, `IntlDatePatternGenerator`, `IntlBreakIterator`). Saying the classes *always* throw is also falsifiable on 8.4: `UConverter::convert()` returns `false`, `ResourceBundle::get()` returns `null` and `Collator::getAttribute()` returns `-1` on a non-initialized object.