### PR TITLE
appendices: note the E_STRICT deprecation (8.4.0), mark T_PROPERTY_C available as of 8.4.0

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -587,13 +587,21 @@
     <constant>E_ALL</constant>
     (<type>int</type>)
    </term>
+   <listitem>
+    <simpara>
+     <link linkend="errorfunc.constants">Error reporting constants</link>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
    <term>
     <constant>E_STRICT</constant>
     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     <link linkend="errorfunc.constants">Error reporting constants</link>
+     <link linkend="errorfunc.constants">Error reporting constants</link>.
+     This constant is unused, and has been deprecated as of PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -1070,7 +1070,7 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
      <entry>__PROPERTY__</entry>
      <entry>
-      <link linkend="language.constants.magic">magic constants</link>
+      <link linkend="language.constants.magic">magic constants</link> (available as of PHP 8.4.0)
      </entry>
     </row>
     <row xml:id="constant.t-protected">


### PR DESCRIPTION
Two 8.4.0 annotations missing from the appendices.

`appendices/reserved.constants.core.xml`
- `E_STRICT` is split out of the shared listitem so the note applies to it alone, and states that the constant is unused and deprecated, matching the wording already used by `reference/errorfunc/constants.xml`
- the new `varlistentry` carries no `xml:id` on purpose: `constant.e-strict` is already taken by `reference/errorfunc/constants.xml`, a duplicate would break the build

`appendices/tokens.xml`
- `T_PROPERTY_C` is the last of the four tokens added in 8.4.0 still missing its version annotation; the other three (`T_PRIVATE_SET`, `T_PROTECTED_SET`, `T_PUBLIC_SET`) already carry it