### PR TITLE
ext/session: document the 8.4.0 INI deprecations, drop the removed hash_function recommendation

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -164,13 +164,19 @@
      <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
      <entry>"32"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry>Available as of PHP 7.1.0. Deprecated as of PHP 8.4.0.</entry>
+     <entry>
+      Available as of PHP 7.1.0.
+      Changing this setting is deprecated as of PHP 8.4.0.
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.session.sid-bits-per-character">session.sid_bits_per_character</link></entry>
      <entry>"4"</entry>
      <entry><constant>INI_ALL</constant></entry>
-     <entry>Available as of PHP 7.1.0. Deprecated as of PHP 8.4.0.</entry>
+     <entry>
+      Available as of PHP 7.1.0.
+      Changing this setting is deprecated as of PHP 8.4.0.
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.session.upload-progress.enabled">session.upload_progress.enabled</link></entry>
@@ -838,30 +844,17 @@
      to 256.
     </simpara>
     <simpara>
-     The default is 32. If you need compatibility you may specify 32,
-     40, etc. Longer session ID is harder to guess. At least 32 chars
-     are recommended.
+     The default is 32. A longer session ID is harder to guess.
     </simpara>
-    <tip>
-     <para>
-      Compatibility Note: Use 32 instead of
-      <literal>session.hash_function</literal>=0 (MD5) and
-      <literal>session.hash_bits_per_character</literal>=4,
-      <literal>session.hash_function</literal>=1 (SHA1) and
-      <literal>session.hash_bits_per_character</literal>=6. Use 26 instead of
-      <literal>session.hash_function</literal>=0 (MD5) and
-      <literal>session.hash_bits_per_character</literal>=5. Use 22 instead of
-      <literal>session.hash_function</literal>=0 (MD5) and
-      <literal>session.hash_bits_per_character</literal>=6. You must
-      configure INI values to have at least 128 bits in session ID. Do
-      not forget to set an appropriate value for
-      <literal>session.sid_bits_per_character</literal>, otherwise you
-      will have weaker session ID.
-     </para>
-    </tip> 
+    <warning>
+     <simpara>
+      Changing <literal>session.sid_length</literal> from its default
+      value is deprecated as of PHP 8.4.0.
+     </simpara>
+    </warning>
     <note>
      <simpara>
-      This setting is introduced in PHP 7.1.0.
+      Available as of PHP 7.1.0.
      </simpara>
     </note>
    </listitem>
@@ -879,14 +872,17 @@
      '4' (0-9, a-f), '5' (0-9, a-v), and '6' (0-9, a-z, A-Z, "-", ",").
     </simpara>
     <simpara>
-     The default is 4. The more bits results in stronger session ID. 5 is
-     recommended value for most environments.
+     The default is 4. More bits result in a stronger session ID.
     </simpara>
-    <para>
-    </para>
+    <warning>
+     <simpara>
+      Changing <literal>session.sid_bits_per_character</literal> from its
+      default value is deprecated as of PHP 8.4.0.
+     </simpara>
+    </warning>
     <note>
      <simpara>
-      This setting is introduced in PHP 7.1.0.
+      Available as of PHP 7.1.0.
      </simpara>
     </note>
    </listitem>

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -649,12 +649,16 @@
      <para>
       <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>=Off
      </para>
-     <para>
-      Use of a transparent session ID management is not prohibited.
-      Developers may employ it when it is required.
-      However, disabling transparent session ID management improves the general session
+     <simpara>
+      Disabling transparent session ID management improves the general session
       ID security by eliminating the possibility of a session ID injection and/or leak.
-     </para>
+     </simpara>
+     <warning>
+      <simpara>
+       Enabling <literal>session.use_trans_sid</literal> is deprecated
+       as of PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <para>
        Session ID may leak from bookmarked URLs, e-mailed URLs, saved HTML source, etc.
@@ -663,45 +667,62 @@
     </listitem>
 
     <listitem>
-     <para>
-      <link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link>=[limited tags]
-     </para>
-     <para>
-      (PHP 7.1.0 &gt;=) Developers should not rewrite unneeded HTML tags.
-      Default value should be sufficient for most usages.
+     <simpara>
+      <link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link>="a=href,area=href,frame=src,form="
+     </simpara>
+     <simpara>
+      Unneeded HTML tags should not be rewritten.
+      The default value is sufficient for most usages.
       Older PHP versions use
       <link linkend="ini.url-rewriter.tags">url_rewriter.tags</link> instead.
-     </para>
+     </simpara>
+     <warning>
+      <simpara>
+       Changing <literal>session.trans_sid_tags</literal> from its default
+       value is deprecated as of PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
 
     <listitem>
-     <para>
-      <link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link>=[limited hosts]
-     </para>
-     <para>
-      (PHP 7.1.0 &gt;=) This INI defines whitelist hosts that allows trans sid rewrite.
-      Never add untrusted hosts.
-      Session module only allows <literal>$_SERVER['HTTP_HOST']</literal>
-      when this setting is empty.
-     </para>
+     <simpara>
+      <link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link>=""
+     </simpara>
+     <simpara>
+      This setting lists the hosts for which the session ID may be added
+      to URLs. Untrusted hosts must never be added.
+      When it is empty, the session module only allows
+      <literal>$_SERVER['HTTP_HOST']</literal>.
+     </simpara>
+     <warning>
+      <simpara>
+       Setting <literal>session.trans_sid_hosts</literal> to a non-empty
+       value is deprecated as of PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
 
     <listitem>
-     <para>
-      <link linkend="ini.session.referer-check">session.referer_check</link>=[originating URL]
-     </para>
-     <para>
+     <simpara>
+      <link linkend="ini.session.referer-check">session.referer_check</link>=""
+     </simpara>
+     <simpara>
       When <link
       linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
-      is enabled.
-      It reduces the risk of session ID injection.
-      If a website is <literal>http://example.com/</literal>,
-      set <literal>http://example.com/</literal> to it.
-      Note that with HTTPS browsers will not send the referrer header.
-      Browsers may not send the referrer header by configuration.
+      is enabled, a non-empty value reduces the risk of session ID
+      injection: the session ID sent by the client is discarded unless the
+      <literal>Referer</literal> header contains that value.
+      Note that with HTTPS browsers will not send the
+      <literal>Referer</literal> header, and browsers may omit it by
+      configuration.
       Therefore, this setting is not a reliable security measure.
-      Use of this setting is recommended.
-     </para>
+     </simpara>
+     <warning>
+      <simpara>
+       Setting <literal>session.referer_check</literal> to a non-empty
+       value is deprecated as of PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
 
     <listitem>
@@ -718,20 +739,6 @@
       cached by shared clients.
       <literal>"public"</literal> must only be used when HTTP content does
       not contain any private data at all.
-     </para>
-    </listitem>
-
-    <listitem>
-     <para>
-      <link linkend="ini.session.hash-function">session.hash_function</link>="sha256"
-     </para>
-     <para>
-      (PHP 7.1.0 &lt;) A stronger hash function will generate a stronger session ID.
-      Although hash collision is unlikely even with the MD5 hashing algorithm,
-      developers should use SHA-2 or a stronger hashing algorithm like sha384 and sha512.
-      Developers must ensure they feed a long enough
-      <link linkend="ini.session.entropy-length">entropy</link>
-      for the hashing function used.
      </para>
     </listitem>
 


### PR DESCRIPTION
The 8.4.0 session INI deprecations are conditional: PHP only emits `E_DEPRECATED` when a setting is moved away from its default value. The wording therefore says *changing* / *enabling* / *setting a non-empty value* rather than describing the settings themselves as deprecated, which is also how `reference/session/ini.xml` already words the deprecations added earlier.