### PR TITLE
Revise the Yar extension documentation

### DIFF
--- a/reference/yaconf/book.xml
+++ b/reference/yaconf/book.xml
@@ -8,65 +8,56 @@
 
  <preface xml:id="intro.yaconf">
   &reftitle.intro;
-  <para>
+  <simpara>
    <literal>Yet Another Configurations Container</literal>
-   (<acronym>Yaconf</acronym>) is a configurations container,
-   it parses <literal>INI</literal> files, and store the result
-   in PHP when PHP is started, the result lives with the
-   whole PHP lifecycle.
-  </para>
-  <para>
-   Yaconf stores all configurations as
-   interned string or immutable array, which means they are
-   not refcounted-able, thus when you retrieving configurations
-   from <acronym>Yaconf</acronym>, it could be considered as zero-copy, very fast.
-  </para>
-  <para>
-   Yaconf supports sections and sections
-   inheritance in <literal>INI</literal> files. If PHP is built as non-ZTS build,
-   Yaconf also supports automatically reloading after <literal>INI</literal> files
-   are changed.
-  </para>
-  <para>
+   (<acronym>Yaconf</acronym>) is a configuration container. It parses
+   <literal>INI</literal> files when PHP starts up and keeps the result
+   in persistent memory for the whole PHP lifecycle, so every retrieval
+   is a fast hash lookup with no file I/O and no per-request parsing.
+  </simpara>
+  <simpara>
+   Yaconf stores all configurations as interned strings or immutable
+   arrays. They are not refcounted, so retrieving a configuration from
+   Yaconf is effectively zero-copy. Since Yaconf 1.2.0, the whole parsed
+   configuration tree is additionally compacted into a single contiguous
+   block, which lowers memory overhead and improves cache locality.
+  </simpara>
+  <simpara>
+   The parsed configuration lives in persistent memory shared by all
+   PHP-FPM workers through copy-on-write: until a configuration file
+   changes, the workers share the same physical memory pages no matter
+   how many of them are running.
+  </simpara>
+  <simpara>
+   Yaconf supports sections and section inheritance in INI files. On
+   non-ZTS builds it also reloads the files automatically when they
+   change; on ZTS (thread-safe) builds, configurations are loaded at
+   startup and a restart is required to pick up changes.
+  </simpara>
+  <simpara>
+   Since Yaconf 1.2.0, sub-directories of the configured directory are
+   loaded recursively (up to 16 levels deep) and addressed with the
+   directory name as a key level: for example,
+   <literal>Yaconf::get("users.database.master")</literal> reads the
+   <literal>master</literal> key from the file
+   <filename>database.ini</filename> placed in the
+   <filename>users/</filename> sub-directory.
+  </simpara>
+  <simpara>
+   Storing sensitive configurations outside the web tree also lowers
+   the attack surface. Configuration files under the web root can be
+   retrieved by an attacker, for example through a file disclosure
+   vulnerability. With Yaconf, the <filename>.ini</filename> files can
+   instead be placed in a directory readable only by root, such as
+   <filename>/etc/yaconf</filename>: the PHP-FPM master loads the
+   configurations when the service starts, while the forked workers —
+   which run under an unprivileged user and are the ones executing
+   web requests — do not need, and are not given, access to that
+   directory.
+  </simpara>
+  <simpara>
    Yaconf requires PHP 7.0 or greater.
-  </para>
-  <example>
-   <title>INI example</title>
-   <programlisting role="ini">
-<![CDATA[
-;Simple key val
-key=val
-
-;Hash
-hash.a=val
-
-;Array
-arr.0=val
-;or
-arr[]=val
-
-;PHP constant
-version=PHP_VERSION
-
-;Environment variable
-env=${PATH}
-]]>
-   </programlisting>
-  </example>
-  <example>
-   <title>INI sections example</title>
-   <programlisting role="ini">
-<![CDATA[
-[SectionA]
-key=val
-hash.a=val
-
-;SectionB inherits SectionA
-[SectionB:SectionA]
-key=new_val                  ;override configuration key in SectionA
-]]>
-   </programlisting>
-  </example>
+  </simpara>
  </preface>
 
  &reference.yaconf.setup;

--- a/reference/yaconf/ini.xml
+++ b/reference/yaconf/ini.xml
@@ -18,14 +18,14 @@
     </thead>
     <tbody>
      <row>
-      <entry><link linkend="ini.yaconf.check-delay">yaconf.check_delay</link></entry>
-      <entry>300</entry>
+      <entry><link linkend="ini.yaconf.directory">yaconf.directory</link></entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
-      <entry><link linkend="ini.yaconf.directory">yaconf.directory</link></entry>
-      <entry>/tmp/conf/</entry>
+      <entry><link linkend="ini.yaconf.check-delay">yaconf.check_delay</link></entry>
+      <entry><literal>300</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -38,30 +38,87 @@
 
  <para>
   <variablelist>
+   <varlistentry xml:id="ini.yaconf.directory">
+     <term>
+      <parameter>yaconf.directory</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       The directory where all INI configuration files are placed. Only
+       files with the <filename>.ini</filename> extension are loaded.
+       Sub-directories are loaded recursively (up to 16 levels deep);
+       each one acts as a key level, so a file
+       <filename>database.ini</filename> placed in the
+       <filename>users/</filename> sub-directory is addressed as
+       <literal>"users.database"</literal>. Available since Yaconf
+       1.2.0; before that only files directly in the directory were
+       loaded.
+      </simpara>
+      <simpara>
+       The examples below assume the following
+       <filename>database.ini</filename> placed in the configured
+       directory, alongside a <filename>features.ini</filename> that
+       carries per-feature settings.
+      </simpara>
+      <example>
+       <title>INI file syntax</title>
+       <programlisting role="ini">
+<![CDATA[
+; database.ini
+name=production                        ; scalar value
+version=PHP_VERSION                    ; PHP constants are resolved
+connection_string=${DATABASE_URL}      ; environment variables are resolved
+options.max_connections=50             ; nested hash key
+options.timeout=30
+
+; array entries, both notations are equivalent
+replicas.0=replica-1.example.com
+replicas[]=replica-2.example.com
+]]>
+       </programlisting>
+      </example>
+      <example>
+       <title>INI sections example</title>
+       <programlisting role="ini">
+<![CDATA[
+; features.ini
+[default]
+cache_enabled=on
+rate_limit=100
+
+; the "premium" section inherits every key from "default" and
+; overrides the ones it redefines
+[premium:default]
+rate_limit=1000
+]]>
+       </programlisting>
+      </example>
+     </listitem>
+   </varlistentry>
    <varlistentry xml:id="ini.yaconf.check-delay">
      <term>
       <parameter>yaconf.check_delay</parameter>
       <type>int</type>
      </term>
      <listitem>
-      <para>
-        In which interval Yaconf will detect ini file's change(by directory's mtime),
-        if it is set to zero, you have to restart php to reloading configurations.
-      </para>
+      <simpara>
+       The interval, in seconds, at which Yaconf checks whether any
+       loaded INI file has changed and reloads the changed ones (the
+       change is detected by comparing directory modification times).
+       Setting it to <literal>0</literal> makes Yaconf check on every
+       request.
+      </simpara>
+      <note>
+       <simpara>
+        This directive is only registered in non-ZTS builds. On ZTS
+        (thread-safe) builds configurations are loaded at startup and
+        automatic reloading is not available; restart PHP to pick up
+        changes.
+       </simpara>
+      </note>
      </listitem>
-    </varlistentry>
-    <varlistentry xml:id="ini.yaconf.directory">
-     <term>
-      <parameter>yaconf.directory</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-        Path to directory which all INI configuration files are placed in.
-      </para>
-     </listitem>
-    </varlistentry>
-
+   </varlistentry>
   </variablelist>
  </para>
 </section>

--- a/reference/yaconf/setup.xml
+++ b/reference/yaconf/setup.xml
@@ -13,6 +13,10 @@
 
  <section xml:id="yaconf.installation">
   &reftitle.install;
+  <simpara>
+   Yaconf can be installed in one of three ways: via PECL, via PIE,
+   or by building it from source.
+  </simpara>
   <para>
    &pecl.moved;
   </para>
@@ -23,6 +27,44 @@
   <para>
    &pecl.windows.download.avail;
   </para>
+  <example>
+   <title>Installing Yaconf with PECL</title>
+   <programlisting role="shell">
+<![CDATA[
+pecl install yaconf
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Since Yaconf 1.2.0, the extension can be installed with
+   &link.pie;, the PHP Installer for Extensions, by running the
+   following on the command line.
+  </simpara>
+  <example>
+   <title>Installing Yaconf with PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yaconf
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   The source code is hosted on
+   <link xlink:href="&url.git.hub;laruence/yaconf">GitHub</link>. To
+   build the extension from source, run the following on the command
+   line, replacing the paths with those of the local PHP
+   installation.
+  </simpara>
+  <example>
+   <title>Building Yaconf from source</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
  </section>
 
  &reference.yaconf.ini;

--- a/reference/yaconf/versions.xml
+++ b/reference/yaconf/versions.xml
@@ -7,6 +7,7 @@
  <function name='yaconf' from='PECL yaconf &gt;= 1.0.0'/>
  <function name='yaconf::get' from='PECL yaconf &gt;= 1.0.0'/>
  <function name='yaconf::has' from='PECL yaconf &gt;= 1.0.0'/>
+ <function name='yaconf::__debug_info' from='PECL yaconf &gt;= 1.1.0'/>
 </versions>
 
 <!-- Keep this comment at the end of the file

--- a/reference/yaconf/yaconf/debuginfo.xml
+++ b/reference/yaconf/yaconf/debuginfo.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="yaconf.debug-info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaconf::__debug_info</refname>
+  <refpurpose>Inspect how a configuration value is stored</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>Yaconf::__debug_info</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Returns debugging information about the value stored under
+   <parameter>name</parameter>: the memory address of the stored value
+   and whether the value still lives inside Yaconf's compacted storage
+   block.
+  </simpara>
+  <warning>
+   <simpara>
+    This method exists solely for Yaconf's own test suite, which
+    uses it to verify that the extension is working correctly.
+    Do not use it in production code, and do not rely on the
+    format of its output: the returned array may change at any
+    time.
+   </simpara>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      The configuration name to inspect, using the same dot notation as
+      <methodname>Yaconf::get</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   An <type>array</type> with four entries when the configuration
+   exists, &null; otherwise:
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <literal>key</literal> — the name that was looked up.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>address</literal> — the memory address of the stored
+     value. Values are stored as interned strings or immutable arrays,
+     so this address stays constant until the configuration is
+     reloaded.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>val</literal> — the stored value itself.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>changed</literal> — &false; while the value's data still
+     lives inside the compacted storage block, meaning the operating
+     system has not had to copy the page (copy-on-write still applies);
+     &true; when the value has been re-allocated outside the block.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yaconf::__debug_info</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// assuming app.ini contains name="shop"
+var_dump(Yaconf::__debug_info("app.name"));
+/*
+array(4) {
+  ["key"]=>
+  string(8) "app.name"
+  ["address"]=>
+  string(14) "0x7f8b1c0a3d20"
+  ["val"]=>
+  string(4) "shop"
+  ["changed"]=>
+  bool(false)
+}
+*/
+
+var_dump(Yaconf::__debug_info("app.missing")); // NULL
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::get</methodname></member>
+    <member><methodname>Yaconf::has</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/yaconf/get.xml
+++ b/reference/yaconf/yaconf/get.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="yaconf.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaconf::get</refname>
-  <refpurpose>Retrieve a item</refpurpose>
+  <refpurpose>Retrieve a configuration value by name</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -12,11 +12,19 @@
   <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>mixed</type><methodname>Yaconf::get</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>default_value</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Retrieves the configuration value stored under
+   <parameter>name</parameter>. Names use dot notation to traverse
+   nested keys: <literal>"app"</literal> addresses the whole parsed
+   <filename>app.ini</filename> file,
+   <literal>"app.name"</literal> a key inside it, and since Yaconf
+   1.2.0 <literal>"users.database.master"</literal> a key in the
+   file <filename>database.ini</filename> placed in the
+   <filename>users/</filename> sub-directory. The dot notation
+   supports up to 64 levels of nesting.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,17 +33,22 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-      Configuration key, the key looks like "filename.key", or "filename.sectionName,key".
-     </para>
+     <simpara>
+      The configuration name to look up, using dot notation to
+      traverse nested keys, for example
+      <literal>"app.name"</literal>, <literal>"app.features.1"</literal>
+      or, since Yaconf 1.2.0, <literal>"users.database.master"</literal>
+      for files in sub-directories.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>default_value</parameter></term>
+    <term><parameter>default</parameter></term>
     <listitem>
-     <para>
-      if the key doesn't exists, Yaconf::get will return this as result.
-     </para>
+     <simpara>
+      The value to return when <parameter>name</parameter> is not
+      found. When omitted, &null; is returned.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -43,50 +56,69 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns configuration result(string or array) if the key exists,
-   return default_value if not.
-  </para>
+  <simpara>
+   The stored configuration value, a <type>string</type> or an
+   <type>array</type>, when <parameter>name</parameter> exists;
+   otherwise the <parameter>default</parameter> (or &null; when no
+   default was given).
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example>
-   <title><function>INI</function>example</title>
-   <programlisting role="ini">
+  <simpara>
+   The examples below assume the following two files placed in the
+   directory configured with <literal>yaconf.directory</literal>.
+  </simpara>
+  <programlisting role="ini">
 <![CDATA[
-;filenmame foo.ini, placed in directory which is yaconf.directoy
-[SectionA]
-;key value pair
-key=val
-;hash[a]=val
-hash.a=val
-;arr[0]=val
-arr.0=val
-;or
-arr[]=val
+; app.ini
+name="shop"                     ; scalar value
+debug=0                         ; number
+features[]="checkout"           ; array entries, both notations
+features.1="wishlist"
+]]>
+  </programlisting>
+  <programlisting role="ini">
+<![CDATA[
+; users/database.ini, in a sub-directory (Yaconf 1.2.0+)
+master="192.168.0.10"
+replica="192.168.0.20"
+]]>
+  </programlisting>
+  <example>
+   <title><methodname>Yaconf::get</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// fetch a whole parsed file as an array
+var_dump(Yaconf::get("app"));
 
-;SectionB inherits SectionA
-[SectionB:SectionA]
-;override configuration key in SectionA
-key=new_val
+// dot notation traverses nested keys
+var_dump(Yaconf::get("app.name"));           // string(4) "shop"
+var_dump(Yaconf::get("app.features.1"));     // string(8) "wishlist"
+
+// since 1.2.0: files in sub-directories are namespaced by the
+// directory name
+var_dump(Yaconf::get("users.database.master")); // string(12) "192.168.0.10"
+
+// when the key is missing, the default is returned
+var_dump(Yaconf::get("app.missing"));             // NULL
+var_dump(Yaconf::get("app.missing", "fallback")); // string(8) "fallback"
+?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-php7 -r 'var_dump(Yaconf::get("foo.SectionA.key"));'
-//string(3) "val"
-
-php7 -r 'var_dump(Yaconf::get("foo.SectionB.key"));'
-//string(7) "new_val"
-
-php7 -r 'var_dump(Yaconf::get("foo")["SectionA"]["hash"]);'
-//array(1)
-
-]]>
-   </screen>
   </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::has</methodname></member>
+    <member><methodname>Yaconf::__debug_info</methodname></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yaconf/yaconf/has.xml
+++ b/reference/yaconf/yaconf/has.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="yaconf.has" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaconf::has</refname>
-  <refpurpose>Determine if a item exists</refpurpose>
+  <refpurpose>Check whether a configuration value exists</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,9 +13,13 @@
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yaconf::has</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Determines whether a configuration value exists under
+   <parameter>name</parameter>, which uses the same dot notation as
+   <methodname>Yaconf::get</methodname>: for example, <literal>"app.name"</literal>
+   or, since Yaconf 1.2.0, <literal>"users.database.master"</literal> for
+   files in sub-directories.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +28,11 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      The configuration name to look up, using dot notation to
+      traverse nested keys, for example <literal>"app.name"</literal>
+      or <literal>"users.database.master"</literal>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -34,11 +40,48 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   
-  </para>
+  <simpara>
+   Returns &true; if a configuration value exists at
+   <parameter>name</parameter>, &false; otherwise.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <simpara>
+   The examples below assume an <filename>app.ini</filename> placed
+   in the directory configured with <literal>yaconf.directory</literal>,
+   holding the keys <literal>name="shop"</literal> and
+   <literal>debug=0</literal>.
+  </simpara>
+  <example>
+   <title><methodname>Yaconf::has</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(Yaconf::has("app.name"));     // bool(true)
+var_dump(Yaconf::has("app.missing"));  // bool(false)
+
+// useful to distinguish a stored empty value from a missing key,
+// where Yaconf::get() would return the same default for both
+if (Yaconf::has("app.debug")) {
+    $debug = (bool) Yaconf::get("app.debug");
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::get</methodname></member>
+    <member><methodname>Yaconf::__debug_info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yar/book.xml
+++ b/reference/yar/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <book xml:id="book.yar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -8,11 +8,24 @@
 
  <preface xml:id="intro.yar">
   &reftitle.intro;
-  <para>
-    Yar is a RPC framework which aims to provide a simple and easy way to do
-    communication between PHP applications
-    It has the ability to concurrently call multiple remote services.
-  </para>
+  <simpara>
+   Yar (Yet another RPC framework) is a light, concurrent RPC framework
+   which aims to provide a simple and easy way to do communication
+   between PHP applications. It can also issue multiple calls to remote
+   services concurrently.
+  </simpara>
+  <simpara>
+   Yar is a native PHP extension rather than a userland library. It uses
+   a compact binary protocol over HTTP, HTTPS or TCP and ships with three
+   built-in packagers (<literal>php</literal>, <literal>json</literal>
+   and, when built with <option role="configure">--enable-msgpack</option>,
+   <literal>msgpack</literal>), so no extra packages or proxy processes
+   are required.
+  </simpara>
+  <simpara>
+   The protocol is language agnostic: compatible implementations exist
+   for C, Java and Lua.
+  </simpara>
  </preface>
 
  &reference.yar.setup;

--- a/reference/yar/configure.xml
+++ b/reference/yar/configure.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <section xml:id="yar.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
- <para>
+ <simpara>
   &pecl.info;
   <link xlink:href="&url.pecl.package;yar">&url.pecl.package;yar</link>
- </para>
- 
+ </simpara>
+
 </section>
 
 

--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -1,164 +1,316 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <appendix xml:id="yar.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
- <para>
-  <variablelist>
-   <varlistentry xml:id="constant.yar-version">
-    <term>
-     <constant>YAR_VERSION</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-client-protocol-http">
-    <term>
-     <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-packager">
-    <term>
-     <constant>YAR_OPT_PACKAGER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-timeout">
-    <term>
-     <constant>YAR_OPT_TIMEOUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-connect-timeout">
-    <term>
-     <constant>YAR_OPT_CONNECT_TIMEOUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-header">
-    <term>
-     <constant>YAR_OPT_HEADER</constant>
-     (<type>array</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Since 2.0.4
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-packager-php">
-    <term>
-     <constant>YAR_PACKAGER_PHP</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-packager-json">
-    <term>
-     <constant>YAR_PACKAGER_JSON</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-okey">
-    <term>
-     <constant>YAR_ERR_OKEY</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-output">
-    <term>
-     <constant>YAR_ERR_OUTPUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-transport">
-    <term>
-     <constant>YAR_ERR_TRANSPORT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-request">
-    <term>
-     <constant>YAR_ERR_REQUEST</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-protocol">
-    <term>
-     <constant>YAR_ERR_PROTOCOL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-packager">
-    <term>
-     <constant>YAR_ERR_PACKAGER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-exception">
-    <term>
-     <constant>YAR_ERR_EXCEPTION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </para>
+ <variablelist>
+  <varlistentry xml:id="constant.yar-version">
+   <term>
+    <constant>YAR_VERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The version of the Yar extension, e.g.
+     <literal>"2.4.0"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-has-msgpack">
+   <term>
+    <constant>YAR_HAS_MSGPACK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <literal>1</literal> when Yar was built with
+     <option role="configure">--enable-msgpack</option>, otherwise
+     <literal>0</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-http">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifies the HTTP protocol, exposed through the read-only
+     <varname>_protocol</varname> property of
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-tcp">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_TCP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifies the TCP protocol, exposed through the read-only
+     <varname>_protocol</varname> property of
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-unix">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_UNIX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifies the Unix socket protocol, exposed through the read-only
+     <varname>_protocol</varname> property of
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-packager">
+   <term>
+    <constant>YAR_OPT_PACKAGER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option to override the
+     <link linkend="ini.yar.packager">yar.packager</link> directive
+     for a single client. The value must be one of
+     <literal>php</literal>, <literal>json</literal> or
+     <literal>msgpack</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-persistent">
+   <term>
+    <constant>YAR_OPT_PERSISTENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option to enable persistent connections. When set to a
+     truthy value, HTTP keep-alive is used so that repeated calls to
+     the same server reuse the connection for the rest of the PHP
+     request lifecycle.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-timeout">
+   <term>
+    <constant>YAR_OPT_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option to override the
+     <link linkend="ini.yar.timeout">yar.timeout</link> directive, in
+     milliseconds.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-connect-timeout">
+   <term>
+    <constant>YAR_OPT_CONNECT_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option to override the
+     <link linkend="ini.yar.connect-timeout">yar.connect_timeout</link>
+     directive, in milliseconds.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-header">
+   <term>
+    <constant>YAR_OPT_HEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option to add custom HTTP headers. The value must be an
+     array of strings like
+     <literal>"X-Custom: value"</literal>. Only effective with the
+     HTTP and HTTPS protocols. Available as of Yar 2.0.4.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-resolve">
+   <term>
+    <constant>YAR_OPT_RESOLVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option to override hostname resolution for HTTP calls. The
+     value must be an array of strings in the format
+     <literal>HOST:PORT:ADDRESS</literal>, following the curl
+     <constant>CURLOPT_RESOLVE</constant> syntax. Requires libcurl
+     &gt;= 7.21.3. Available as of Yar 2.1.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-proxy">
+   <term>
+    <constant>YAR_OPT_PROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option to route HTTP calls through an HTTP proxy. The value
+     must be a string such as <literal>127.0.0.1:8888</literal>.
+     Available as of Yar 2.2.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-provider">
+   <term>
+    <constant>YAR_OPT_PROVIDER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option carrying the provider identity sent with every
+     request. The value must be a string of at most 32 bytes, which is
+     passed to the server-side <literal>__auth</literal> magic method.
+     Available as of Yar 2.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-token">
+   <term>
+    <constant>YAR_OPT_TOKEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Client option carrying the authentication token sent with every
+     request. The value must be a string of at most 32 bytes, which is
+     passed to the server-side <literal>__auth</literal> magic method.
+     Available as of Yar 2.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-php">
+   <term>
+    <constant>YAR_PACKAGER_PHP</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The identifier of the <literal>php</literal> packager,
+     <literal>"PHP"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-json">
+   <term>
+    <constant>YAR_PACKAGER_JSON</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The identifier of the <literal>json</literal> packager,
+     <literal>"JSON"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-msgpack">
+   <term>
+    <constant>YAR_PACKAGER_MSGPACK</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The identifier of the <literal>msgpack</literal> packager,
+     <literal>"MSGPACK"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-okey">
+   <term>
+    <constant>YAR_ERR_OKEY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No error; the request was processed successfully.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-packager">
+   <term>
+    <constant>YAR_ERR_PACKAGER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A packager error, e.g. a body that could not be unpacked.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-protocol">
+   <term>
+    <constant>YAR_ERR_PROTOCOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A protocol error, e.g. a malformed Yar header.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-request">
+   <term>
+    <constant>YAR_ERR_REQUEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A request error, e.g. a call to an undefined or non-public
+     method.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-output">
+   <term>
+    <constant>YAR_ERR_OUTPUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     An output error, e.g. the server could not start its output
+     buffer.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-transport">
+   <term>
+    <constant>YAR_ERR_TRANSPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A transport error, e.g. a connection failure or timeout.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-exception">
+   <term>
+    <constant>YAR_ERR_EXCEPTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The remote service threw an exception while processing the
+     request.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 </appendix>
 
 <!-- Keep this comment at the end of the file

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
@@ -23,7 +23,7 @@ class Operator {
     }
 
     /**
-     * Sub 
+     * Sub
      */
     public function sub($a, $b) {
         return $a - $b;
@@ -54,7 +54,14 @@ $server->handle();
  </example>
 
  <example>
-  <title>Access the server in browser(GET request)</title>
+  <title>Access the server in browser (GET request)</title>
+  <simpara>
+   When a GET request is issued to the service URI, Yar renders an
+   information page listing every public method of the executor object
+   together with its doc comment. This is controlled by the
+   <link linkend="ini.yar.expose-info">yar.expose_info</link>
+   directive.
+  </simpara>
   &example.outputs.similar;
   <mediaobject>
    <alt>Yar Server Info</alt>
@@ -69,28 +76,27 @@ $server->handle();
   <programlisting role="php">
 <![CDATA[
 <?php
-$client = new yar_client("http://example.com/operator.php");
+$client = new Yar_Client("http://example.com/operator.php");
 
 /* call directly */
 var_dump($client->add(1, 2));
 
-/* call via call */
+/* call via call() */
 var_dump($client->call("add", array(3, 2)));
 
-
-/* _add cannot be called */
+/* _add cannot be called: it is not public */
 var_dump($client->_add(1, 2));
 ?>
 ]]>
   </programlisting>
   &example.outputs.similar;
-   <screen>
+  <screen>
 <![CDATA[
 int(3)
 int(5)
-PHP Fatal error:  Uncaught exception 'Yar_Server_Exception' with message 'call to api Operator::_add() failed' in *
+PHP Fatal error:  Uncaught Yar_Server_Request_Exception: call to undefined api Operator::_add() in *
 ]]>
-   </screen>
+  </screen>
  </example>
 
  <example>
@@ -99,16 +105,20 @@ PHP Fatal error:  Uncaught exception 'Yar_Server_Exception' with message 'call t
 <![CDATA[
 <?php
 function callback($ret, $callinfo) {
-    echo $callinfo['method'] , " result: ", $ret , "\n";
+    echo $callinfo['method'], " result: ", $ret, "\n";
 }
 
-/* register async call to remote services */
+function error_callback($type, $error, $callinfo) {
+    error_log("[$type] $error");
+}
+
+/* register async calls to remote services */
 Yar_Concurrent_Client::call("http://example.com/operator.php", "add", array(1, 2), "callback");
 Yar_Concurrent_Client::call("http://example.com/operator.php", "sub", array(2, 1), "callback");
 Yar_Concurrent_Client::call("http://example.com/operator.php", "mul", array(2, 2), "callback");
 
-/* sent all request and wait for response */
-Yar_Concurrent_Client::loop();
+/* send all requests and wait for the responses */
+Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>
 ]]>
   </programlisting>
@@ -119,7 +129,26 @@ mul result: 4
 sub result: 1
 add result: 3
 ]]>
-   </screen>
+  </screen>
+ </example>
+
+ <example>
+  <title>Yar TCP Client Example</title>
+  <simpara>
+   Besides HTTP, <classname>Yar_Client</classname> can talk to Yar
+   compatible servers over TCP or Unix sockets, for example a service
+   implemented with the Yar C framework. The remote server must
+   implement the same binary Yar protocol.
+  </simpara>
+  <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("tcp://127.0.0.1:8600");
+
+var_dump($client->add(1, 2));
+?>
+]]>
+  </programlisting>
  </example>
 
 </chapter>

--- a/reference/yar/ini.xml
+++ b/reference/yar/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <section xml:id="yar.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -18,9 +18,15 @@
     </thead>
     <tbody>
      <row>
-      <entry><link linkend="ini.yar.packager">yar.packager</link></entry>
-      <entry>php</entry>
-      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></entry>
+      <entry>1000</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.content-type">yar.content_type</link></entry>
+      <entry>application/octet-stream</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
@@ -30,8 +36,20 @@
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
-      <entry><link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></entry>
-      <entry>1000</entry>
+      <entry><link linkend="ini.yar.expose-info">yar.expose_info</link></entry>
+      <entry>On</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.packager">yar.packager</link></entry>
+      <entry>php</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.ssl-verify">yar.ssl_verify</link></entry>
+      <entry>Off</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -39,12 +57,6 @@
       <entry><link linkend="ini.yar.timeout">yar.timeout</link></entry>
       <entry>5000</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
-     </row>
-     <row>
-      <entry><link linkend="ini.yar.expose-info">yar.expose_info</link></entry>
-      <entry>On</entry>
-      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>
@@ -56,48 +68,53 @@
 
  <para>
   <variablelist>
-   <varlistentry xml:id="ini.yar.packager">
-     <term>
-      <parameter>yar.packager</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-        it could be php, json, and msgpack(require built with msgpack support)
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="ini.yar.debug">
-     <term>
-      <parameter>yar.debug</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="ini.yar.connect-timeout">
+   <varlistentry xml:id="ini.yar.connect-timeout">
      <term>
       <parameter>yar.connect_timeout</parameter>
       <type>int</type>
      </term>
      <listitem>
-      <para>
-       timeout in ms 
-      </para>
+      <simpara>
+       Connect timeout in milliseconds for HTTP calls issued through
+       <classname>Yar_Client</classname> and
+       <classname>Yar_Concurrent_Client</classname>.
+      </simpara>
+      <note>
+       <simpara>
+        This value is interpreted in milliseconds. Prior to Yar 1.2.1 it
+        was measured in seconds (the default was
+        <literal>1</literal>).
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
-    <varlistentry xml:id="ini.yar.timeout">
+    <varlistentry xml:id="ini.yar.content-type">
      <term>
-      <parameter>yar.timeout</parameter>
-      <type>int</type>
+      <parameter>yar.content_type</parameter>
+      <type>string</type>
      </term>
      <listitem>
-      <para>
-       timeout in ms
-      </para>
+      <simpara>
+       The value of the <literal>Content-Type</literal> response header
+       sent by <classname>Yar_Server</classname>. Yar speaks a binary
+       protocol, so the default is
+       <literal>application/octet-stream</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.debug">
+     <term>
+      <parameter>yar.debug</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       Enables debug mode. When on, Yar emits
+       <constant>E_WARNING</constant> messages with protocol-level
+       details for every request and response, prefixed with
+       <literal>[Debug Yar_Server]</literal> or
+       <literal>[Debug Yar_Client]</literal> and a timestamp.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yar.expose-info">
@@ -106,9 +123,64 @@
       <type>bool</type>
      </term>
      <listitem>
-      <para>
-       whether expose the service info(when access the server via GET)
-      </para>
+      <simpara>
+       Whether <methodname>Yar_Server::handle</methodname> outputs the
+       service information page for non-POST (usually GET) requests.
+       When this directive is off, such requests throw a
+       <exceptionname>Yar_Server_Exception</exceptionname> instead.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.packager">
+     <term>
+      <parameter>yar.packager</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       The default packager used to serialize request and response
+       bodies. Valid values are <literal>php</literal> (PHP
+       serialization), <literal>json</literal>, and
+       <literal>msgpack</literal> (only when Yar was built with
+       <option role="configure">--enable-msgpack</option>).
+      </simpara>
+      <simpara>
+       When Yar is built with msgpack support, the default becomes
+       <literal>msgpack</literal>.
+      </simpara>
+      <simpara>
+       This value can be overridden per client with the
+       <constant>YAR_OPT_PACKAGER</constant> option.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.ssl-verify">
+     <term>
+      <parameter>yar.ssl_verify</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       Whether to verify the TLS certificate of HTTPS servers. When on,
+       the curl transport sets
+       <constant>CURLOPT_SSL_VERIFYPEER</constant> and
+       <constant>CURLOPT_SSL_VERIFYHOST</constant>, and requests to
+       servers with invalid certificates fail. Off by default for
+       backward compatibility. Available as of Yar 2.4.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.timeout">
+     <term>
+      <parameter>yar.timeout</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       Timeout in milliseconds for RPC calls issued by
+       <classname>Yar_Client</classname> and
+       <classname>Yar_Concurrent_Client</classname>.
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/yar/setup.xml
+++ b/reference/yar/setup.xml
@@ -1,35 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <chapter xml:id="yar.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
  <section xml:id="yar.requirements">
   &reftitle.required;
-  <para>
-   if you want to use msgpack as packager, you need compile Yar by your self
-   with ./configure --enable-msgpack
-  </para>
+  <simpara>
+   The cURL library is required for the HTTP and HTTPS transports. The
+   TCP transport is implemented with plain sockets and needs no extra
+   library.
+  </simpara>
+  <simpara>
+   The <link linkend="book.json">JSON</link> extension is required,
+   which is bundled with PHP and always available as of PHP 8.0.0.
+  </simpara>
+  <simpara>
+   To use the <literal>msgpack</literal> packager, the
+   <link xlink:href="&url.pecl.package;msgpack">msgpack</link> extension
+   must be installed and Yar must be built with the
+   <option role="configure">--enable-msgpack</option> configure option.
+  </simpara>
  </section>
 
+ <!-- {{{ Installation -->
  <section xml:id="yar.installation">
   &reftitle.install;
-  <para>
+  <simpara>
    &pecl.moved;
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;yar">&url.pecl.package;yar</link>.
+  </simpara>
+  <simpara>
+   &pecl.windows.download.avail;
+  </simpara>
+  <para>
+   The source code is hosted on
+   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. To build
+   the extension from source:
+   <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/yar.git
+$ cd yar
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+   </screen>
+  </para>
+  <para>
+   The following <literal>configure</literal> options are available:
+   <variablelist>
+    <varlistentry>
+     <term>
+      <option role="configure">--with-curl</option>
+     </term>
+     <listitem>
+      <simpara>
+       Location of the cURL installation, if it is not found in the
+       default include paths.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <option role="configure">--enable-msgpack</option>
+     </term>
+     <listitem>
+      <simpara>
+       Enables the <literal>msgpack</literal> packager and makes the
+       <literal>msgpack</literal> extension an optional dependency. When
+       Yar is built with this option, the default value of
+       <link linkend="ini.yar.packager">yar.packager</link> becomes
+       <literal>msgpack</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <option role="configure">--enable-epoll</option>
+     </term>
+     <listitem>
+      <simpara>
+       Uses Linux <literal>epoll</literal> instead of
+       <literal>select()</literal> for I/O multiplexing, available as of
+       Yar 2.1.2. This can improve
+       <classname>Yar_Concurrent_Client</classname> performance under
+       high concurrency. It only takes effect on Linux; on other
+       platforms it is silently ignored.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </para>
  </section>
- 
+ <!-- }}} -->
+
+ <!-- {{{ Configuration -->
  &reference.yar.ini;
+ <!-- }}} -->
 
  <section xml:id="yar.resources">
   &reftitle.resources;
-  <para>
-
-  </para>
+  <simpara>
+   This extension does not define any resources.
+  </simpara>
  </section>
 
 </chapter>

--- a/reference/yar/versions.xml
+++ b/reference/yar/versions.xml
@@ -9,6 +9,7 @@
  <function name='yar_client::call' from='PECL yar &gt;= 1.0.0'/>
  <function name='yar_client::__call' from='PECL yar &gt;= 1.0.0'/>
  <function name='yar_client::setopt' from='PECL yar &gt;= 1.0.0'/>
+ <function name='yar_client::getopt' from='PECL yar &gt;= 1.1.0'/>
  <function name='yar_concurrent_client::call' from='PECL yar &gt;= 1.0.0'/>
  <function name='yar_concurrent_client::loop' from='PECL yar &gt;= 1.0.0'/>
  <function name='yar_concurrent_client::reset' from='PECL yar &gt;= 1.2.4'/>

--- a/reference/yar/yar-client-exception.xml
+++ b/reference/yar/yar-client-exception.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
-<reference xml:id="class.yar-client-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Client_Exception class</title>
  <titleabbrev>Yar_Client_Exception</titleabbrev>
@@ -11,9 +11,12 @@
 <!-- {{{ Yar_Client_Exception intro -->
   <section xml:id="yar-client-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Base class of the exceptions thrown when a request fails before,
+    during or after reaching the remote service: a subclass is thrown
+    depending on where the failure occurred. The exception code is one of
+    the <literal>YAR_ERR_*</literal> constants.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -21,68 +24,29 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
 
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Client_Exception properties -->
-  <section xml:id="yar-client-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client-packager-exception.xml
+++ b/reference/yar/yar-client-packager-exception.xml
@@ -1,86 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<reference xml:id="class.yar-client-packager-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-packager-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Client_Packager_Exception class</title>
  <titleabbrev>Yar_Client_Packager_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Packager_Exception intro -->
   <section xml:id="yar-client-packager-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Thrown when the response body cannot be unpacked with the requested packager (exception code <constant>YAR_ERR_PACKAGER</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-packager-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Packager_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Packager_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Packager_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Client_Packager_Exception properties -->
-  <section xml:id="yar-client-packager-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-packager-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client-protocol-exception.xml
+++ b/reference/yar/yar-client-protocol-exception.xml
@@ -1,86 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<reference xml:id="class.yar-client-protocol-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-protocol-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Client_Protocol_Exception class</title>
  <titleabbrev>Yar_Client_Protocol_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Protocol_Exception intro -->
   <section xml:id="yar-client-protocol-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Thrown when the response from the RPC service violates the Yar protocol, for example an unsupported protocol address or a malformed response header (exception code <constant>YAR_ERR_PROTOCOL</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-protocol-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Protocol_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Protocol_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Protocol_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Client_Protocol_Exception properties -->
-  <section xml:id="yar-client-protocol-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-protocol-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client-transport-exception.xml
+++ b/reference/yar/yar-client-transport-exception.xml
@@ -1,86 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<reference xml:id="class.yar-client-transport-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-transport-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Client_Transport_Exception class</title>
  <titleabbrev>Yar_Client_Transport_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Transport_Exception intro -->
   <section xml:id="yar-client-transport-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Thrown when the connection to the RPC service fails: connection refused, timeout, or an empty response (exception code <constant>YAR_ERR_TRANSPORT</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-transport-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Transport_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Transport_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Transport_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Client_Transport_Exception properties -->
-  <section xml:id="yar-client-transport-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-transport-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client.xml
+++ b/reference/yar/yar-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <reference xml:id="class.yar-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,11 @@
 <!-- {{{ Yar_Client intro -->
   <section xml:id="yar-client.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    The client side of the Yar RPC framework. A client is bound to a
+    single service address; invoking any undefined method on it issues a
+    remote call with that method name and the given arguments.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -21,43 +23,41 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Client</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>int</type>
      <varname linkend="yar-client.props.protocol">_protocol</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>string</type>
      <varname linkend="yar-client.props.uri">_uri</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type class="union"><type>array</type><type>null</type></type>
      <varname linkend="yar-client.props.options">_options</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>bool</type>
      <varname linkend="yar-client.props.running">_running</varname>
     </fieldsynopsis>
 
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Yar_Client'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
 <!-- {{{ Yar_Client properties -->
   <section xml:id="yar-client.props">
    &reftitle.properties;
@@ -65,31 +65,44 @@
     <varlistentry xml:id="yar-client.props.protocol">
      <term><varname>_protocol</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Read-only. The protocol derived from the service address: one of
+       <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>,
+       <constant>YAR_CLIENT_PROTOCOL_TCP</constant> or
+       <constant>YAR_CLIENT_PROTOCOL_UNIX</constant>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.uri">
      <term><varname>_uri</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Read-only. The service address the client was created with.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.options">
      <term><varname>_options</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Read-only. An &array; of the options set on this client, keyed by
+       the <literal>YAR_OPT_*</literal> constants, or &null; if none were
+       set.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.running">
      <term><varname>_running</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Read-only. Whether a call issued by this client is currently in
+       progress.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-concurrent-client.xml
+++ b/reference/yar/yar-concurrent-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <reference xml:id="class.yar-concurrent-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,17 @@
 <!-- {{{ Yar_Concurrent_Client intro -->
   <section xml:id="yar-concurrent-client.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    A static helper that batches remote RPC calls. Calls registered with
+    <methodname>Yar_Concurrent_Client::call</methodname> are not sent
+    immediately; they are all dispatched together, in parallel, by
+    <methodname>Yar_Concurrent_Client::loop</methodname>.
+   </simpara>
+   <note>
+    <simpara>
+     Only HTTP(S) services are supported for concurrent calls.
+    </simpara>
+   </note>
   </section>
 <!-- }}} -->
 
@@ -21,65 +29,17 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Concurrent_Client</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Concurrent_Client</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Concurrent_Client</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.callstack">_callstack</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.callback">_callback</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.error-callback">_error_callback</varname>
-    </fieldsynopsis>
-
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-concurrent-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-concurrent-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Concurrent_Client'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Concurrent_Client properties -->
-  <section xml:id="yar-concurrent-client.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-concurrent-client.props.callstack">
-     <term><varname>_callstack</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-concurrent-client.props.callback">
-     <term><varname>_callback</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-concurrent-client.props.error-callback">
-     <term><varname>_error_callback</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-exception.xml
+++ b/reference/yar/yar-server-exception.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
-<reference xml:id="class.yar-server-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Server_Exception class</title>
  <titleabbrev>Yar_Server_Exception</titleabbrev>
@@ -11,10 +11,13 @@
 <!-- {{{ Yar_Server_Exception intro -->
   <section xml:id="yar-server-exception.intro">
    &reftitle.intro;
-   <para>
-     If service threw exceptions, A Yar_Server_Exception will be threw in
-     client side.
-   </para>
+   <simpara>
+    Thrown on the client side when the RPC request failed on the server.
+    If the remote service method itself threw an exception, its message,
+    code, file, line and class name are carried over, and
+    <methodname>Yar_Server_Exception::getType</methodname> returns the
+    class name of the original exception.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -22,78 +25,56 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>string</type>
      <varname linkend="yar-server-exception.props.type">_type</varname>
+     <initializer>"Yar_Exception_Server"</initializer>
     </fieldsynopsis>
 
-    
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
 <!-- {{{ Yar_Server_Exception properties -->
   <section xml:id="yar-server-exception.props">
    &reftitle.properties;
    <variablelist>
-    <varlistentry xml:id="yar-server-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
     <varlistentry xml:id="yar-server-exception.props.type">
      <term><varname>_type</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       The class name of the exception thrown by the remote service, or
+       <literal>"Yar_Exception_Server"</literal> if the error was not
+       caused by a userland exception. Read via
+       <methodname>Yar_Server_Exception::getType</methodname>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-output-exception.xml
+++ b/reference/yar/yar-server-output-exception.xml
@@ -1,86 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<reference xml:id="class.yar-server-output-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-output-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Server_Output_Exception class</title>
  <titleabbrev>Yar_Server_Output_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Output_Exception intro -->
   <section xml:id="yar-server-output-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Thrown when the server cannot capture the output of the service method (exception code <constant>YAR_ERR_OUTPUT</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-output-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Output_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Output_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Output_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Server_Output_Exception properties -->
-  <section xml:id="yar-server-output-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-output-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-packager-exception.xml
+++ b/reference/yar/yar-server-packager-exception.xml
@@ -1,86 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<reference xml:id="class.yar-server-packager-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-packager-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Server_Packager_Exception class</title>
  <titleabbrev>Yar_Server_Packager_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Packager_Exception intro -->
   <section xml:id="yar-server-packager-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Thrown when the request body cannot be unpacked with the packager announced in the request (exception code <constant>YAR_ERR_PACKAGER</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-packager-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Packager_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Packager_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Packager_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Server_Packager_Exception properties -->
-  <section xml:id="yar-server-packager-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-packager-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-protocol-exception.xml
+++ b/reference/yar/yar-server-protocol-exception.xml
@@ -1,86 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<reference xml:id="class.yar-server-protocol-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-protocol-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Server_Protocol_Exception class</title>
  <titleabbrev>Yar_Server_Protocol_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Protocol_Exception intro -->
   <section xml:id="yar-server-protocol-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Thrown when the incoming request violates the Yar protocol, for example a malformed request header (exception code <constant>YAR_ERR_PROTOCOL</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-protocol-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Protocol_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Protocol_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Protocol_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Server_Protocol_Exception properties -->
-  <section xml:id="yar-server-protocol-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-protocol-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-request-exception.xml
+++ b/reference/yar/yar-server-request-exception.xml
@@ -1,86 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<reference xml:id="class.yar-server-request-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-request-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>The Yar_Server_Request_Exception class</title>
  <titleabbrev>Yar_Server_Request_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Request_Exception intro -->
   <section xml:id="yar-server-request-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Thrown when the requested remote method does not exist on the server object, or is not public (exception code <constant>YAR_ERR_REQUEST</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-request-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Request_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Request_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Request_Exception</classname>
-     </ooclass>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-
-<!-- {{{ Yar_Server_Request_Exception properties -->
-  <section xml:id="yar-server-request-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-request-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server.xml
+++ b/reference/yar/yar-server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <reference xml:id="class.yar-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,11 @@
 <!-- {{{ Yar_Server intro -->
   <section xml:id="yar-server.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Wraps an object and exposes all of its public methods as a remote
+    service, served over HTTP by
+    <methodname>Yar_Server::handle</methodname>.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -21,31 +23,27 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Server</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>object</type>
      <varname linkend="yar-server.props.executor">_executor</varname>
+     <initializer>null</initializer>
     </fieldsynopsis>
 
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Yar_Server'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
 <!-- {{{ Yar_Server properties -->
   <section xml:id="yar-server.props">
    &reftitle.properties;
@@ -53,13 +51,14 @@
     <varlistentry xml:id="yar-server.props.executor">
      <term><varname>_executor</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       The object whose public methods are exposed as RPC services.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar_client/call.xml
+++ b/reference/yar/yar_client/call.xml
@@ -1,22 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>Yar_Client::__call</refname>
-  <refpurpose>Call service</refpurpose>
+  <refname>Yar_Client::call</refname>
+  <refpurpose>Call a remote service</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>Yar_Client::__call</methodname>
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type>mixed</type><methodname>Yar_Client::call</methodname>
    <methodparam><type>string</type><parameter>method</parameter></methodparam>
-   <methodparam><type>array</type><parameter>parameters</parameter></methodparam>
+   <methodparam><type>array</type><parameter>arguments</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Issue a call to remote RPC method.
-  </para>
+  <simpara>
+   Issues an RPC call to the remote method <literal>method</literal>. This
+   is exactly what happens when a non-existent method is invoked on a
+   <classname>Yar_Client</classname> object (see
+   <methodname>Yar_Client::__call</methodname>);
+   <methodname>Yar_Client::call</methodname> only exists so that remote
+   methods literally named <literal>call</literal> or
+   <literal>__call</literal> can still be reached.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,17 +31,17 @@
    <varlistentry>
     <term><parameter>method</parameter></term>
     <listitem>
-     <para>
-       Remote RPC method name.    
-     </para>
+     <simpara>
+      The name of the remote service method.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>parameters</parameter></term>
+    <term><parameter>arguments</parameter></term>
     <listitem>
-     <para>
-       Parameters.
-     </para>
+     <simpara>
+      The list of arguments passed to the remote method.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -43,38 +49,25 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Returns the return value of the remote service method.
+  </simpara>
  </refsect1>
 
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>Yar_Client::__call</function> example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-$client = new Yar_Client("http://host/api/");
-
-/* call remote service */
-$result = $client->some_method("parameter");
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
-  </example>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   When the <literal>call</literal> method does not exist on the server
+   side, a <exceptionname>Yar_Server_Request_Exception</exceptionname> is
+   thrown. See <methodname>Yar_Client::__call</methodname> for the full
+   list of failures and their exception classes.
+  </simpara>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
+   <member><methodname>Yar_Client::__call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/construct.xml
+++ b/reference/yar/yar_client/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-client.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,26 +9,40 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="Yar_Client">
    <modifier>final</modifier> <modifier>public</modifier> <methodname>Yar_Client::__construct</methodname>
-   <methodparam><type>string</type><parameter>url</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
-  </methodsynopsis>
-  <para>
-    Create a <classname>Yar_Client</classname> to a
-    <classname>Yar_Server</classname>.
-  </para>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Creates a <classname>Yar_Client</classname> for the RPC service located
+   at <literal>uri</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>url</parameter></term>
+    <term><parameter>uri</parameter></term>
     <listitem>
-     <para>
-       Yar Server URL.  
-     </para>
+     <simpara>
+      Address of the RPC service. The protocol is derived from the scheme:
+      <literal>http://</literal> and <literal>https://</literal> select the
+      HTTP transport, <literal>tcp://</literal> selects the TCP transport,
+      and <literal>unix://</literal> selects the Unix socket transport.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <simpara>
+      An &array; of client options, keyed by the
+      <literal>YAR_OPT_*</literal> constants, equivalent to calling
+      <methodname>Yar_Client::setOpt</methodname> for each entry. Invalid
+      options are silently skipped.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,30 +50,38 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-    <classname>Yar_Client</classname> instance.
-  </para>
+  <simpara>
+   A new <classname>Yar_Client</classname> instance.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   If the URI does not start with a supported scheme, a
+   <exceptionname>Yar_Client_Protocol_Exception</exceptionname> is thrown.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yar_Client::__construct</function> example</title>
+   <title><methodname>Yar_Client::__construct</methodname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 $client = new Yar_Client("http://host/api/");
+
+/* with options */
+$client = new Yar_Client("http://host/api/", [
+    YAR_OPT_TIMEOUT => 1000,
+    YAR_OPT_PACKAGER => "json",
+]);
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/yar/yar_client/getopt.xml
+++ b/reference/yar/yar_client/getopt.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="yar-client.getopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yar_Client::getOpt</refname>
+  <refpurpose>Read a client option</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type>mixed</type><methodname>Yar_Client::getOpt</methodname>
+   <methodparam><type>int</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Returns the value previously set with
+   <methodname>Yar_Client::setOpt</methodname>, or with the
+   <literal>options</literal> parameter of
+   <methodname>Yar_Client::__construct</methodname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      One of the <literal>YAR_OPT_*</literal> constants, see
+      <methodname>Yar_Client::setOpt</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   The option value, or &false; if the option has not been set on this
+   client or the option name is unknown.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yar_Client::getOpt</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("http://host/api/");
+$client->setOpt(YAR_OPT_TIMEOUT, 1000);
+
+var_dump($client->getOpt(YAR_OPT_TIMEOUT));
+var_dump($client->getOpt(YAR_OPT_PACKAGER));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(1000)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Yar_Client::setOpt</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yar/yar_client/setopt.xml
+++ b/reference/yar/yar_client/setopt.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-client.setopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client::setOpt</refname>
-  <refpurpose>Set calling contexts</refpurpose>
+  <refpurpose>Set client options</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type class="union"><type>Yar_Client</type><type>false</type></type><methodname>Yar_Client::setOpt</methodname>
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type class="union"><type>Yar_Client</type><type>bool</type></type><methodname>Yar_Client::setOpt</methodname>
    <methodparam><type>int</type><parameter>name</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Sets an option on the client. Options are evaluated when a call is
+   issued, so they can be changed between calls.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,23 +26,29 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-      it can be:
-        <constant>YAR_OPT_PACKAGER</constant>,
-        <constant>YAR_OPT_PERSISTENT</constant> (Need server support),
-        <constant>YAR_OPT_TIMEOUT</constant>,
-        <constant>YAR_OPT_CONNECT_TIMEOUT</constant>,
-        <constant>YAR_OPT_HEADER</constant> (as of 2.0.4),
-        <constant>YAR_OPT_PROXY</constant> (as of 2.2.0)
-     </para>
+     <simpara>
+      One of the <literal>YAR_OPT_*</literal> constants:
+     </simpara>
+     <simplelist>
+      <member><constant>YAR_OPT_PACKAGER</constant> — a packager name: <literal>php</literal>, <literal>json</literal> or, when built with msgpack support, <literal>msgpack</literal></member>
+      <member><constant>YAR_OPT_PERSISTENT</constant> — a boolean persistent-connection flag (HTTP keep-alive)</member>
+      <member><constant>YAR_OPT_TIMEOUT</constant> — a timeout in milliseconds, overriding <link linkend="ini.yar.timeout">yar.timeout</link></member>
+      <member><constant>YAR_OPT_CONNECT_TIMEOUT</constant> — a connect timeout in milliseconds, overriding <link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></member>
+      <member><constant>YAR_OPT_HEADER</constant> (as of 2.0.4) — an &array; of additional HTTP header lines</member>
+      <member><constant>YAR_OPT_RESOLVE</constant> (as of 2.1.0) — an &array; of hostname resolution entries</member>
+      <member><constant>YAR_OPT_PROXY</constant> (as of 2.2.0) — an HTTP proxy address</member>
+      <member><constant>YAR_OPT_PROVIDER</constant> (as of 2.3.0) — the provider identity, up to 32 bytes</member>
+      <member><constant>YAR_OPT_TOKEN</constant> (as of 2.3.0) — the authentication token, up to 32 bytes</member>
+     </simplelist>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      The option value. An invalid value raises a warning and makes the call
+      return &false;.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -49,50 +56,78 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Returns <varname>$this</varname> on success&return.falseforfailure;.
-  </para>
+  <simpara>
+   Returns the client object itself, allowing a fluent interface, or
+   &false; when the option name is unknown, the value is invalid, or the
+   option does not apply to the protocol the client was created with.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Conditions that make the call return &false; also raise a warning:
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <constant>YAR_OPT_HEADER</constant>,
+     <constant>YAR_OPT_RESOLVE</constant> and
+     <constant>YAR_OPT_PROXY</constant> only work with the HTTP protocol;
+     using them with a <literal>tcp://</literal> or
+     <literal>unix://</literal> client raises a warning.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>YAR_OPT_RESOLVE</constant> additionally requires libcurl
+     &gt;= 7.21.3.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     Each option expects a specific value type (string, boolean, integer or
+     array), described on the
+     <link linkend="yar.constants">constants</link> page.
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yar_Client::setOpt</function> example</title>
+   <title><methodname>Yar_Client::setOpt</methodname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
-$cient = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://host/api/");
 
-//Set timeout to 1s
-$client->SetOpt(YAR_OPT_CONNECT_TIMEOUT, 1000);
+/* Set timeout to 1s */
+$client->setOpt(YAR_OPT_TIMEOUT, 1000);
 
-//Set packager to JSON
-$client->SetOpt(YAR_OPT_PACKAGER, "json");
+/* Set packager to JSON */
+$client->setOpt(YAR_OPT_PACKAGER, "json");
 
-//Set Custom headers
-$client->SetOpt(YAR_OPT_HEADER, array("hr1: val1", "hd2: val2"));
+/* Set custom headers */
+$client->setOpt(YAR_OPT_HEADER, ["X-Api-Key: value"]);
 
-// Set Http Proxy
-$client->SetOpt(YAR_OPT_PROXY, "127.0.0.1:8888");
+/* Route through an HTTP proxy */
+$client->setOpt(YAR_OPT_PROXY, "127.0.0.1:8888");
 
 /* call remote service */
 $result = $client->some_method("parameter");
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
+   <member><methodname>Yar_Client::getOpt</methodname></member>
    <member><methodname>Yar_Client::__call</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client_exception/gettype.xml
+++ b/reference/yar/yar_client_exception/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-client-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,13 +9,19 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="Yar_Client_Exception">
    <modifier>public</modifier> <type>string</type><methodname>Yar_Client_Exception::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Returns the type of the exception. Client-side exceptions are raised by
+   the client itself (transport failures, protocol errors and so on), so
+   the type is always the fixed string
+   <literal>"Yar_Exception_Client"</literal>. Use
+   <methodname>Exception::getCode</methodname> to tell the individual
+   failure apart; the code is one of the <literal>YAR_ERR_*</literal>
+   constants.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,38 +31,43 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns <literal>"Yar_Exception_Client"</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yar_Client_Exception::getType</function> example</title>
+   <title><methodname>Yar_Client_Exception::getType</methodname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
+$client = new Yar_Client("http://host/api/");
 
-/* ... */
-
+try {
+    $client->some_method("parameter");
+} catch (Yar_Client_Exception $e) {
+    var_dump($e->getType());
+    var_dump($e->getCode());
+}
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-...
+string(20) "Yar_Exception_Client"
+int(16)
 ]]>
    </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yaf_Server_Exception::getType</methodname></member>
+   <member><methodname>Yar_Server_Exception::getType</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,19 +9,27 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>int</type><methodname>Yar_Concurrent_Client::call</methodname>
+  <methodsynopsis role="Yar_Concurrent_Client">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>false</type><type>null</type></type><methodname>Yar_Concurrent_Client::call</methodname>
    <methodparam><type>string</type><parameter>uri</parameter></methodparam>
    <methodparam><type>string</type><parameter>method</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>parameters</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>parameters</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>error_callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Register a RPC call, but won't sent it immediately, it will be send while
-   further call to <methodname>Yar_Concurrent_Client::loop</methodname>.
-  </para>
+  <simpara>
+   Registers a remote RPC call. The request is not sent immediately; all
+   registered calls are sent together by
+   <methodname>Yar_Concurrent_Client::loop</methodname>, and the responses
+   are handled as they arrive.
+  </simpara>
+  <note>
+   <simpara>
+    Only HTTP and HTTPS URIs are supported. TCP and Unix socket transports
+    are not available for concurrent calls.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -30,40 +38,51 @@
    <varlistentry>
     <term><parameter>uri</parameter></term>
     <listitem>
-     <para>
-       The RPC server URI (HTTP, TCP).
-     </para>
+     <simpara>
+      Address of the RPC service, starting with
+      <literal>http://</literal> or <literal>https://</literal>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>method</parameter></term>
     <listitem>
-     <para>
-      Service name (aka the method name).
-     </para>
+     <simpara>
+      The name of the remote service method.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>parameters</parameter></term>
     <listitem>
-     <para>
-      Parameters.
-     </para>
+     <simpara>
+      The list of arguments passed to the remote method.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-      A function callback, which will be called while the response return.
-     </para>
+     <simpara>
+      A <type>callable</type> invoked when the response for this call
+      arrives, with two arguments: the response value, and a
+      <literal>callinfo</literal> &array; with the keys
+      <literal>sequence</literal>, <literal>uri</literal> and
+      <literal>method</literal>. If omitted, the
+      <literal>callback</literal> of
+      <methodname>Yar_Concurrent_Client::loop</methodname> is used.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>error_callback</parameter></term>
     <listitem>
      <simpara>
-      If this callback is set, then Yar will call this callback while error occurred.
+      A <type>callable</type> invoked when this call fails, with three
+      arguments: the error type (one of the <literal>YAR_ERR_*</literal>
+      codes), the error message, and the <literal>callinfo</literal>
+      &array;. If omitted, the <literal>error_callback</literal> of
+      <methodname>Yar_Concurrent_Client::loop</methodname> is used.
      </simpara>
     </listitem>
    </varlistentry>
@@ -71,8 +90,10 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      An &array; of options.
-      See the <link linkend="yar.constants">constants</link> list.
+      An &array; of client options, keyed by the
+      <literal>YAR_OPT_*</literal> constants, see
+      <methodname>Yar_Client::setOpt</methodname>. Applied to this call
+      only.
      </simpara>
     </listitem>
    </varlistentry>
@@ -82,7 +103,13 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   A unique ID, can be used to identified which call it is.
+   Returns the sequence number of the registered call, a unique ID
+   starting from <literal>1</literal> that identifies the call. Returns
+   &false; when the concurrent client is already inside
+   <methodname>Yar_Concurrent_Client::loop</methodname> or when the maximum
+   of <literal>128</literal> registered calls is reached; in both cases a
+   warning is raised. Returns &null; if the URI or method name is empty, or
+   the URI is not an HTTP(S) address, with a warning.
   </simpara>
  </refsect1>
 
@@ -105,23 +132,18 @@ function error_callback($type, $error, $callinfo)
 
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
 
-// If the callback is not specified callback in loop will be used
+/* If the callback is not specified, the callback of loop() will be used */
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
 
-// This server accept JSON packager
+/* This server accepts the JSON packager */
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
 
-// Custom timeout
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1));
+/* Custom timeout */
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
 
-// The requests are not sent yet
+/* The requests are not sent yet */
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </informalexample>
  </refsect1>
 
@@ -130,8 +152,6 @@ Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::loop</methodname></member>
    <member><methodname>Yar_Concurrent_Client::reset</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -1,21 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::loop</refname>
-  <refpurpose>Send all calls</refpurpose>
+  <refpurpose>Send and wait for all registered calls</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yar_Concurrent_Client::loop</methodname>
-   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
+  <methodsynopsis role="Yar_Concurrent_Client">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>bool</type><type>null</type></type><methodname>Yar_Concurrent_Client::loop</methodname>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>error_callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-    Send all registered remote RPC calls.
+   Sends all calls registered with
+   <methodname>Yar_Concurrent_Client::call</methodname> in parallel and
+   blocks until every response has arrived and been handled. The call list
+   is emptied when this method returns.
   </simpara>
  </refsect1>
 
@@ -25,24 +29,34 @@
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-      If this callback is set, then Yar will call this callback after all
-      calls are sent and before any response return, with a $callinfo NULL.
-     </para>
-     <para>
-      Then, if user didn't specify callback when registering concurrent call,
-      this callback will be used to handle response, otherwise, the callback
-      specified while registering will be used.
-     </para>
+     <simpara>
+      A <type>callable</type> used to handle responses for calls that were
+      registered without their own callback. Right after all requests have
+      been sent, it is additionally called once with two &null; arguments,
+      before any response arrives.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>error_callback</parameter></term>
     <listitem>
-     <para>
-      If this callback is set, then Yar will call this callback while error
-      occurred.
-     </para>
+     <simpara>
+      A <type>callable</type> used to handle errors for calls that were
+      registered without their own error callback. It receives three
+      arguments: the error type (one of the <literal>YAR_ERR_*</literal>
+      codes), the error message, and the <literal>callinfo</literal>
+      &array;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <simpara>
+      An &array; of client options, keyed by the
+      <literal>YAR_OPT_*</literal> constants, applied to every registered
+      call that does not override them.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -50,42 +64,41 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Returns &true; when every registered call has been handled, or when no
+   calls have been registered at all. Returns &false; if the concurrent
+   client is already running inside another loop; in that case a warning is
+   raised.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yar_Concurrent_Client::loop</function> example</title>
+   <title><methodname>Yar_Concurrent_Client::loop</methodname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 function callback($retval, $callinfo) {
-     if ($callinfo == NULL) {
+    if ($callinfo == NULL) {
         echo "Now, all requests are sent, and no response available\n";
-     } else {
-        echo "This is a remote call response, the method name is", $callinfo["method"], 
-             ". calling sequence is " , $callinfo["sequence"] , "\n";
+    } else {
+        echo "This is a remote call response, the method name is ", $callinfo["method"],
+             ". calling sequence is ", $callinfo["sequence"], "\n";
         var_dump($retval);
-     }
-} 
+    }
+}
 
 function error_callback($type, $error, $callinfo) {
     error_log($error);
 }
 
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));   // if the callback is not specificed, 
-                                                                               // callback in loop will be used
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
-                                                                               //this server accept json packager
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
-                                                                               //custom timeout 
 
-Yar_Concurrent_Client::loop("callback", "error_callback"); //send the requests, 
-                                                           //the error_callback is optional
+/* if the callback is not specified, the callback of loop() will be used */
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+
+Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>
 ]]>
    </programlisting>
@@ -93,27 +106,20 @@ Yar_Concurrent_Client::loop("callback", "error_callback"); //send the requests,
    <screen>
 <![CDATA[
 Now, all requests are sent, and no response available
-This is a remote call response, the method name issome_method. calling sequence is 4
+This is a remote call response, the method name is some_method. calling sequence is 2
 string(11) "some_method"
-This is a remote call response, the method name issome_method. calling sequence is 1
-string(11) "some_method"
-This is a remote call response, the method name issome_method. calling sequence is 2
-string(11) "some_method"
-This is a remote call response, the method name issome_method. calling sequence is 3
+This is a remote call response, the method name is some_method. calling sequence is 1
 string(11) "some_method"
 ]]>
    </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::call</methodname></member>
    <member><methodname>Yar_Concurrent_Client::reset</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-concurrent-client.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,13 +9,22 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="Yar_Concurrent_Client">
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yar_Concurrent_Client::reset</methodname>
    <void />
   </methodsynopsis>
-  <para>
-   Clean all registered calls
-  </para>
+  <simpara>
+   Discards all calls registered with
+   <methodname>Yar_Concurrent_Client::call</methodname> that have not been
+   sent yet.
+  </simpara>
+  <note>
+   <simpara>
+    <methodname>Yar_Concurrent_Client::loop</methodname> empties the call
+    list automatically once it has finished, so reset is only needed to
+    abort a batch that was never sent.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,8 +34,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-  </para>
+  <simpara>
+   Returns &true;, or &false; when the concurrent client is currently inside
+   <methodname>Yar_Concurrent_Client::loop</methodname>, in which case an
+   <constant>E_WARNING</constant>-level error is raised.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -35,13 +47,18 @@
    <title><function>Yar_Concurrent_Client::reset</function> example</title>
    <programlisting role="php">
 <![CDATA[
+<?php
+function callback($retval, $callinfo) {
+    var_dump($retval);
+}
+
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+
+/* never sent: throw the registered call away */
+Yar_Concurrent_Client::reset();
+?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
 
@@ -50,8 +67,6 @@
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::call</methodname></member>
    <member><methodname>Yar_Concurrent_Client::loop</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_server/construct.xml
+++ b/reference/yar/yar_server/construct.xml
@@ -1,34 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server::__construct</refname>
-  <refpurpose>Register a server</refpurpose>
+  <refpurpose>Create an RPC server</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="Yar_Server">
    <modifier>final</modifier> <modifier>public</modifier> <methodname>Yar_Server::__construct</methodname>
-   <methodparam><type>Object</type><parameter>obj</parameter></methodparam>
-  </methodsynopsis>
-  <para>
-   Set up a Yar HTTP RPC Server, All the public methods of $obj will be
-   register as a RPC service.
-  </para>
+   <methodparam><type>object</type><parameter>executor</parameter></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Creates a Yar HTTP RPC server. All public methods of
+   <parameter>executor</parameter> are registered as RPC services.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>obj</parameter></term>
+    <term><parameter>executor</parameter></term>
     <listitem>
-     <para>
-       An Object, all public methods of its will be registered as RPC
-       services.   
-     </para>
+     <simpara>
+      Any object whose public methods should be exposed as RPC
+      services. Protected and private methods, and methods whose name
+      starts with an underscore, are not exposed.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,23 +37,23 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    An instance of <classname>Yar_Server</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yar_Server::__construct</function> example</title>
+   <title><methodname>Yar_Server::__construct</methodname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 class API {
     /**
-     * the doc info will be generated automatically into service info page.
-     * @params 
-     * @return
+     * The doc block is shown on the service info page.
+     * @param string $parameter
+     * @return string
      */
     public function some_method($parameter, $option = "foo") {
          return "some_method";
@@ -67,20 +68,16 @@ $service->handle();
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <simplelist>
-   <member><methodname>Yar_Server::handle</methodname></member>
-  </simplelist>
+  <para>
+   <simplelist>
+    <member><methodname>Yar_Server::handle</methodname></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -1,28 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-server.handle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server::handle</refname>
-  <refpurpose>Start RPC Server</refpurpose>
+  <refpurpose>Start the RPC server</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type> <methodname>Yar_Server::handle</methodname>
-   <void/>
+  <methodsynopsis role="Yar_Server">
+   <modifier>public</modifier> <type>bool</type><methodname>Yar_Server::handle</methodname>
+   <void />
   </methodsynopsis>
-  <para>
-   Start a RPC HTTP server, and ready for accpet RPC requests.
-   <note>
-    <para>
-     Usual RPC calls will be issued as HTTP POST requests. If a HTTP GET
-     request is issued to the uri, the service information (commented section
-     above) will be printed on the page
-    </para>
-   </note>
-  </para>
+  <simpara>
+   Starts handling the incoming RPC request.
+  </simpara>
+  <note>
+   <simpara>
+    Usual RPC calls are issued as HTTP POST requests. If an HTTP GET
+    request is issued instead, the service information page, generated
+    from the public methods and their doc comments of the executor
+    object, is printed. This behaviour can be disabled with the
+    <link linkend="ini.yar.expose-info">yar.expose_info</link>
+    directive, in which case a GET request throws a
+    <exceptionname>Yar_Server_Exception</exceptionname>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,25 +36,97 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Returns &true;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
   <para>
-   boolean
+   <table>
+    <title><methodname>Yar_Server::handle</methodname> errors</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Condition</entry>
+       <entry>Exception</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>
+        The remote method threw an exception.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Exception</exceptionname> (with the
+        original class name in its <literal>_type</literal> property).
+       </entry>
+      </row>
+      <row>
+       <entry>
+        The remote method was not found or is not public.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Request_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        The request body could not be unpacked.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Packager_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        The request is malformed on the protocol level.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Protocol_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        The server output could not be captured.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Output_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        Authentication failed, or the info page was requested while
+        <link linkend="ini.yar.expose-info">yar.expose_info</link> is
+        off.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Exception</exceptionname> with code
+        <constant>YAR_ERR_FORBIDDEN</constant>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yar_Server::handle</function> example</title>
+   <title><methodname>Yar_Server::handle</methodname> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 class API {
     /**
-     * the doc info will be generated automatically into service info page.
-     * @params 
-     * @return
+     * The doc block is shown on the service info page.
+     * @param string $parameter
+     * @return string
      */
     public function some_method($parameter, $option = "foo") {
+        return "some_method";
     }
 
     protected function client_can_not_see() {
@@ -62,20 +138,16 @@ $service->handle();
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <simplelist>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-  </simplelist>
+  <para>
+   <simplelist>
+    <member><methodname>Yar_Server::__construct</methodname></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yar/yar_server_exception/gettype.xml
+++ b/reference/yar/yar_server_exception/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="yar-server-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,13 +9,16 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>Yar_Server_Exception::getType</methodname>
+  <methodsynopsis role="Yar_Server_Exception">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>int</type></type><methodname>Yar_Server_Exception::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
-   Get the exception original type threw by server
-  </para>
+  <simpara>
+   When a remote method throws an exception, the server embeds the original
+   exception in the response and the client re-throws it as a
+   <exceptionname>Yar_Server_Exception</exceptionname>. This method returns the
+   class name of that original exception.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,19 +28,21 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   string
-  </para>
+  <simpara>
+   The class name of the exception thrown by the remote service, or
+   <literal>"Yar_Exception_Server"</literal> when the server-side exception
+   carried no class name.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>Yar_Server_Exception::getType</function> example</title>
+   <title><methodname>Yar_Server_Exception::getType</methodname> example</title>
    <programlisting role="php">
 <![CDATA[
-//Server.php
 <?php
+/* Server.php */
 class Custom_Exception extends Exception {};
 
 class API {
@@ -49,9 +54,12 @@ class API {
 $service = new Yar_Server(new API());
 $service->handle();
 ?>
-
-//Client.php
+]]>
+   </programlisting>
+   <programlisting role="php">
+<![CDATA[
 <?php
+/* Client.php */
 $client = new Yar_Client("http://host/api.php");
 
 try {
@@ -60,6 +68,7 @@ try {
     var_dump($e->getType());
     var_dump($e->getMessage());
 }
+?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -72,11 +81,10 @@ string(6) "client"
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member></member>
+   <member><methodname>Yar_Client_Exception::getType</methodname></member>
   </simplelist>
  </refsect1>
 


### PR DESCRIPTION
## Summary

Rewrites the entire Yar extension documentation against the current source of the extension (all nine `YAR_OPT_*` client options, the exception hierarchy and transport/packager behaviour), fixing outdated and incomplete information that had accumulated.

## Changes

- Document all nine `YAR_OPT_*` client options and their effect on call behaviour, including the previously undocumented resolve, proxy, token and provider options
- Add the missing `Yar_Client::getOpt()` method page
- Describe the exception hierarchy accurately: which transport, protocol and packager failures raise which exception class, and how errors surface as `Yar_Client_Exception` codes
- Rewrite the ini page with correct defaults and ranges, the concurrent client examples with realistic usage, and the packager section with msgpack support
- Modernize markup: `simpara` instead of `para`, `exceptionname` for exception classes, union return types, and cross-link related pages via See Also

## Validation

- Full `doc-base/configure.php` build passes (no partial build)
- `phd -f php` renders the whole manual cleanly
- `docbook-cs` reports zero new violations introduced by this change
- XML validated as well-formed (libxml); all 30 files parse cleanly