### PR TITLE
ext/ldap: document PHP 8.5 changes

### DIFF
--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -419,9 +419,8 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara>
-     SSL Authentication Mode - No authentication required. (Only for Oracle LDAP)
-    </simpara>
+    <simpara>SSL Authentication Mode - No authentication required. (Only for Oracle LDAP)</simpara>
+    <warning><simpara>Deprecated as of PHP 8.5.0.</simpara></warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.gslc-ssl-oneway-auth">
@@ -430,9 +429,8 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara>
-     SSL Authentication Mode - Only server authentication required. (Only for Oracle LDAP)
-    </simpara>
+    <simpara>SSL Authentication Mode - Only server authentication required. (Only for Oracle LDAP)</simpara>
+    <warning><simpara>Deprecated as of PHP 8.5.0.</simpara></warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.gslc-ssl-twoway-auth">
@@ -441,9 +439,8 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <simpara>
-     SSL Authentication Mode - Both server and client authentication required. (Only for Oracle LDAP)
-    </simpara>
+    <simpara>SSL Authentication Mode - Both server and client authentication required. (Only for Oracle LDAP)</simpara>
+    <warning><simpara>Deprecated as of PHP 8.5.0.</simpara></warning>
    </listitem>
   </varlistentry>
 

--- a/reference/ldap/functions/ldap-connect-wallet.xml
+++ b/reference/ldap/functions/ldap-connect-wallet.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
 <refentry xml:id="function.ldap-connect-wallet" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_connect_wallet</refname>
@@ -70,6 +71,29 @@
   <para>
 
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       This function has been deprecated. Oracle LDAP (Oracle Instant Client)
+       support is deprecated in PHP 8.5.0.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -116,6 +116,14 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Calling <function>ldap_connect</function> with Oracle wallet arguments
+       is deprecated. Oracle LDAP (Oracle Instant Client) support is deprecated
+       as of PHP 8.5.0.
+      </entry>
+     </row>
+     <row>
       <entry>8.4.0</entry>
       <entry>
        Calling <function>ldap_connect</function> with more than

--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -253,6 +253,8 @@
       <entry>8.5.0</entry>
       <entry>
        <parameter>ldap</parameter> is now nullable.
+       A <exceptionname>ValueError</exceptionname> is now thrown when passing an
+       invalid <parameter>option</parameter>.
       </entry>
      </row>
      &ldap.changelog.ldap-object;

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -261,6 +261,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       A <exceptionname>ValueError</exceptionname> is now thrown when passing an
+       invalid <parameter>option</parameter>.
+      </entry>
+     </row>
      &ldap.changelog.ldap-object;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Documents the following PHP 8.5 changes to the LDAP extension:

- Deprecate Oracle Instant Client-related constants (`LDAP_OPT_X_SASL_NOCANON`, `LDAP_OPT_X_SASL_USERNAME`, `LDAP_OPT_X_SASL_MECH`, `LDAP_OPT_X_TLS_CACERTDIR`, `LDAP_OPT_X_TLS_CACERTFILE`, `LDAP_OPT_X_TLS_CERTFILE`, `LDAP_OPT_X_TLS_CIPHER_SUITE`, `LDAP_OPT_X_TLS_KEYFILE`, `LDAP_OPT_X_TLS_REQUIRE_CERT`) and the `ldap_connect_wallet()` function
- `ldap_get_option()` and `ldap_set_option()` now throw `ValueError` for invalid `$option` values

PHP 8.5 tracker: https://wiki.php.net/todo/php85