### PR TITLE
ext/intl: document PHP 8.5 changes

### DIFF
--- a/reference/intl/grapheme/grapheme-levenshtein.xml
+++ b/reference/intl/grapheme/grapheme-levenshtein.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.grapheme-levenshtein" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>grapheme_levenshtein</refname>
-  <refpurpose>Calculate Levenshtein distance between two strings in grapheme units</refpurpose>
+  <refpurpose>Calculate the Levenshtein distance between two strings in grapheme units</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -12,188 +12,88 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>grapheme_levenshtein</methodname>
    <methodparam><type>string</type><parameter>string1</parameter></methodparam>
    <methodparam><type>string</type><parameter>string2</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>insertion_cost</parameter><initializer>1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>replacement_cost</parameter><initializer>1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>deletion_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>cost_ins</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>cost_rep</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>cost_del</parameter><initializer>1</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   The Levenshtein distance is defined as the minimal number of
-   grapheme clusters that have to be replaced, inserted, or deleted to transform
-   <parameter>string1</parameter> into <parameter>string2</parameter>.
-   The complexity of the algorithm is <literal>O(m*n)</literal>,
-   where <literal>n</literal> and <literal>m</literal> are the
-   length of <parameter>string1</parameter> and
-   <parameter>string2</parameter> in grapheme units.
-  </simpara>
-  <simpara>
-   Unlike <function>levenshtein</function>, which operates on bytes, this
-   function counts Unicode grapheme clusters, so composed and decomposed
-   forms of the same character (e.g. <literal>U+00E9</literal> and
-   <literal>U+0065 U+0301</literal>, both representing <literal>é</literal>)
-   are treated as equivalent and have a distance of zero.
-  </simpara>
-  <simpara>
-   If <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>
-   and/or <parameter>deletion_cost</parameter> are unequal to <literal>1</literal>,
-   the algorithm adapts to choose the cheapest transforms.
-   For example, if <literal>$insertion_cost + $deletion_cost &lt; $replacement_cost</literal>,
-   no replacements will be done, but rather inserts and deletions instead.
+   Calculates the Levenshtein distance between two strings, where the distance
+   is measured in grapheme units rather than bytes or characters.
   </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>string1</parameter></term>
-     <listitem>
-      <simpara>
-       One of the strings being evaluated for Levenshtein distance.
-       Must be valid UTF-8.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>string2</parameter></term>
-     <listitem>
-      <simpara>
-       One of the strings being evaluated for Levenshtein distance.
-       Must be valid UTF-8.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>insertion_cost</parameter></term>
-     <listitem>
-      <simpara>
-       Defines the cost of insertion. Must be greater than <literal>0</literal>.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>replacement_cost</parameter></term>
-     <listitem>
-      <simpara>
-       Defines the cost of replacement. Must be greater than <literal>0</literal>.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>deletion_cost</parameter></term>
-     <listitem>
-      <simpara>
-       Defines the cost of deletion. Must be greater than <literal>0</literal>.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><parameter>locale</parameter></term>
-     <listitem>
-      &intl.param.grapheme.locale;
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string1</parameter></term>
+    <listitem>
+     <simpara>
+      One of the strings being evaluated for Levenshtein distance.
+      Must be valid UTF-8.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>string2</parameter></term>
+    <listitem>
+     <simpara>
+      One of the strings being evaluated for Levenshtein distance.
+      Must be valid UTF-8.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cost_ins</parameter></term>
+    <listitem>
+     <simpara>
+      Defines the cost of insertion.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cost_rep</parameter></term>
+    <listitem>
+     <simpara>
+      Defines the cost of replacement.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cost_del</parameter></term>
+    <listitem>
+     <simpara>
+      Defines the cost of deletion.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     &intl.param.grapheme.locale;
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Returns the Levenshtein distance between the two strings, measured in
-   grapheme units, or &false; on failure. Use
-   <function>intl_get_error_message</function> to retrieve details about
-   the failure.
+   This function returns the Levenshtein-Distance between the two argument
+   strings (in grapheme units), or &false; if one of the argument strings is
+   longer than the limit of 255 grapheme units.
   </simpara>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  <simpara>
-   Throws a <exceptionname>ValueError</exceptionname> if
-   <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>,
-   or <parameter>deletion_cost</parameter> is less than or equal to
-   <literal>0</literal>.
-  </simpara>
-  <simpara>
-   Returns &false; and sets an intl error if either input string is not
-   valid UTF-8, if <parameter>locale</parameter> is not a valid locale
-   identifier, or if an internal ICU error occurs.
-  </simpara>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <informaltable>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Version;</entry>
-      <entry>&Description;</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>8.5.0</entry>
-      <entry>
-       This function has been added.
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
- </refsect1>
-
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>grapheme_levenshtein</function> example</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-// Composed form (NFC): U+00E9 LATIN SMALL LETTER E WITH ACUTE
-$e_composed = "\u{00E9}";
-
-// Decomposed form (NFD): U+0065 + U+0301 (e + combining acute accent)
-$e_decomposed = "\u{0065}\u{0301}";
-
-// grapheme_levenshtein treats them as the same grapheme cluster
-var_dump(grapheme_levenshtein($e_composed, $e_decomposed));
-
-// levenshtein() operates on bytes and sees them as different
-var_dump(levenshtein($e_composed, $e_decomposed));
-
-?>
-]]>
-   </programlisting>
-   &example.outputs;
-   <screen>
-<![CDATA[
-int(0)
-int(3)
-]]>
-   </screen>
-  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>levenshtein</function></member>
-    <member><function>grapheme_strlen</function></member>
-    <member><function>grapheme_substr</function></member>
-    <member><function>similar_text</function></member>
-    <member>
-     <link xlink:href="&uri.unicode.graphemes;">
-      Unicode Text Segmentation: Grapheme Cluster Boundaries
-     </link>
-    </member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>levenshtein</function></member>
+   <member><function>grapheme_strlen</function></member>
+  </simplelist>
  </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/intl/grapheme/grapheme-levenshtein.xml
+++ b/reference/intl/grapheme/grapheme-levenshtein.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.grapheme-levenshtein" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>grapheme_levenshtein</refname>
-  <refpurpose>Calculate the Levenshtein distance between two strings in grapheme units</refpurpose>
+  <refpurpose>Calculate Levenshtein distance between two strings in grapheme units</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -12,88 +12,188 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>grapheme_levenshtein</methodname>
    <methodparam><type>string</type><parameter>string1</parameter></methodparam>
    <methodparam><type>string</type><parameter>string2</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>cost_ins</parameter><initializer>1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>cost_rep</parameter><initializer>1</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>cost_del</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>insertion_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>replacement_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>deletion_cost</parameter><initializer>1</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Calculates the Levenshtein distance between two strings, where the distance
-   is measured in grapheme units rather than bytes or characters.
+   The Levenshtein distance is defined as the minimal number of
+   grapheme clusters that have to be replaced, inserted, or deleted to transform
+   <parameter>string1</parameter> into <parameter>string2</parameter>.
+   The complexity of the algorithm is <literal>O(m*n)</literal>,
+   where <literal>n</literal> and <literal>m</literal> are the
+   length of <parameter>string1</parameter> and
+   <parameter>string2</parameter> in grapheme units.
+  </simpara>
+  <simpara>
+   Unlike <function>levenshtein</function>, which operates on bytes, this
+   function counts Unicode grapheme clusters, so composed and decomposed
+   forms of the same character (e.g. <literal>U+00E9</literal> and
+   <literal>U+0065 U+0301</literal>, both representing <literal>é</literal>)
+   are treated as equivalent and have a distance of zero.
+  </simpara>
+  <simpara>
+   If <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>
+   and/or <parameter>deletion_cost</parameter> are unequal to <literal>1</literal>,
+   the algorithm adapts to choose the cheapest transforms.
+   For example, if <literal>$insertion_cost + $deletion_cost &lt; $replacement_cost</literal>,
+   no replacements will be done, but rather inserts and deletions instead.
   </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <variablelist>
-   <varlistentry>
-    <term><parameter>string1</parameter></term>
-    <listitem>
-     <simpara>
-      One of the strings being evaluated for Levenshtein distance.
-      Must be valid UTF-8.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>string2</parameter></term>
-    <listitem>
-     <simpara>
-      One of the strings being evaluated for Levenshtein distance.
-      Must be valid UTF-8.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>cost_ins</parameter></term>
-    <listitem>
-     <simpara>
-      Defines the cost of insertion.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>cost_rep</parameter></term>
-    <listitem>
-     <simpara>
-      Defines the cost of replacement.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>cost_del</parameter></term>
-    <listitem>
-     <simpara>
-      Defines the cost of deletion.
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><parameter>locale</parameter></term>
-    <listitem>
-     &intl.param.grapheme.locale;
-    </listitem>
-   </varlistentry>
-  </variablelist>
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>string1</parameter></term>
+     <listitem>
+      <simpara>
+       One of the strings being evaluated for Levenshtein distance.
+       Must be valid UTF-8.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>string2</parameter></term>
+     <listitem>
+      <simpara>
+       One of the strings being evaluated for Levenshtein distance.
+       Must be valid UTF-8.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>insertion_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Defines the cost of insertion. Must be greater than <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>replacement_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Defines the cost of replacement. Must be greater than <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>deletion_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Defines the cost of deletion. Must be greater than <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>locale</parameter></term>
+     <listitem>
+      &intl.param.grapheme.locale;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   This function returns the Levenshtein-Distance between the two argument
-   strings (in grapheme units), or &false; if one of the argument strings is
-   longer than the limit of 255 grapheme units.
+   Returns the Levenshtein distance between the two strings, measured in
+   grapheme units, or &false; on failure. Use
+   <function>intl_get_error_message</function> to retrieve details about
+   the failure.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Throws a <exceptionname>ValueError</exceptionname> if
+   <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>,
+   or <parameter>deletion_cost</parameter> is less than or equal to
+   <literal>0</literal>.
+  </simpara>
+  <simpara>
+   Returns &false; and sets an intl error if either input string is not
+   valid UTF-8, if <parameter>locale</parameter> is not a valid locale
+   identifier, or if an internal ICU error occurs.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       This function has been added.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>grapheme_levenshtein</function> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+// Composed form (NFC): U+00E9 LATIN SMALL LETTER E WITH ACUTE
+$e_composed = "\u{00E9}";
+
+// Decomposed form (NFD): U+0065 + U+0301 (e + combining acute accent)
+$e_decomposed = "\u{0065}\u{0301}";
+
+// grapheme_levenshtein treats them as the same grapheme cluster
+var_dump(grapheme_levenshtein($e_composed, $e_decomposed));
+
+// levenshtein() operates on bytes and sees them as different
+var_dump(levenshtein($e_composed, $e_decomposed));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(0)
+int(3)
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <simplelist>
-   <member><function>levenshtein</function></member>
-   <member><function>grapheme_strlen</function></member>
-  </simplelist>
+  <para>
+   <simplelist>
+    <member><function>levenshtein</function></member>
+    <member><function>grapheme_strlen</function></member>
+    <member><function>grapheme_substr</function></member>
+    <member><function>similar_text</function></member>
+    <member>
+     <link xlink:href="&uri.unicode.graphemes;">
+      Unicode Text Segmentation: Grapheme Cluster Boundaries
+     </link>
+    </member>
+   </simplelist>
+  </para>
  </refsect1>
-
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -35,7 +35,9 @@
    </simpara>
    <simpara>
     Locales cannot be instantiated as objects. All of the functions/methods
-    provided are static.
+    provided are static. Use <methodname>Locale::getDefault</methodname> and
+    <methodname>Locale::setDefault</methodname> to read and write the default
+    locale used by ICU.
    </simpara>
    <simpara>
     The null or empty string obtains the "root" locale. The "root" locale is

--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -178,6 +178,14 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.5.0</entry>
+       <entry>
+        <classname>Locale</classname> methods now throw a
+        <exceptionname>ValueError</exceptionname> when a locale argument
+        contains null bytes.
+       </entry>
+      </row>
+      <row>
        <entry>8.4.0</entry>
        <entry>
         The class constants are now typed.

--- a/reference/intl/locale/add-likely-subtags.xml
+++ b/reference/intl/locale/add-likely-subtags.xml
@@ -62,6 +62,7 @@
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Locale::minimizeSubtags</methodname></member>
+   <member><methodname>Locale::canonicalize</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/intl/locale/add-likely-subtags.xml
+++ b/reference/intl/locale/add-likely-subtags.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="locale.addlikelysubtags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Locale::addLikelySubtags</refname>
+  <refname>locale_add_likely_subtags</refname>
+  <refpurpose>Add likely subtags to a locale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &style.oop;
+  </simpara>
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>Locale::addLikelySubtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   &style.procedural;
+  </simpara>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>locale_add_likely_subtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Expands a locale tag by adding likely subtags based on the ICU locale data.
+   For example, <literal>en</literal> becomes <literal>en_Latn_US</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      The locale to expand.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns the locale with likely subtags added, or &false; on failure.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Throws a <exceptionname>ValueError</exceptionname> when the <parameter>locale</parameter>
+   argument contains null bytes.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Locale::minimizeSubtags</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/locale/minimize-subtags.xml
+++ b/reference/intl/locale/minimize-subtags.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="locale.minimizesubtags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Locale::minimizeSubtags</refname>
+  <refname>locale_minimize_subtags</refname>
+  <refpurpose>Remove likely subtags from a locale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &style.oop;
+  </simpara>
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>Locale::minimizeSubtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   &style.procedural;
+  </simpara>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>locale_minimize_subtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Minimizes a locale tag by removing subtags that can be inferred using the
+   ICU likely subtag data. For example, <literal>en_Latn_US</literal> becomes
+   <literal>en</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      The locale to minimize.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns the locale with likely subtags removed, or &false; on failure.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Throws a <exceptionname>ValueError</exceptionname> when the <parameter>locale</parameter>
+   argument contains null bytes.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Locale::addLikelySubtags</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/locale/minimize-subtags.xml
+++ b/reference/intl/locale/minimize-subtags.xml
@@ -63,6 +63,7 @@
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Locale::addLikelySubtags</methodname></member>
+   <member><methodname>Locale::canonicalize</methodname></member>
   </simplelist>
  </refsect1>
 


### PR DESCRIPTION
Documents the following PHP 8.5 changes to the Intl extension:

- Add `Locale::addLikelySubtags()` method
- Add `Locale::minimizeSubtags()` method
- Add `grapheme_levenshtein()` function
- `IntlChar`, `Locale`, and related functions now throw `IntlException` instead of triggering warnings/notices on invalid input

PHP 8.5 tracker: https://github.com/orgs/php/projects/13