### PR TITLE
Document the Yar __info magic method and response id validation

### DIFF
--- a/reference/yar/yar-client-protocol-exception.xml
+++ b/reference/yar/yar-client-protocol-exception.xml
@@ -13,6 +13,14 @@
    <simpara>
     Thrown when the response from the RPC service violates the Yar protocol, for example an unsupported protocol address or a malformed response header (exception code <constant>YAR_ERR_PROTOCOL</constant>).
    </simpara>
+   <simpara>
+    As of Yar 2.4.0 this also includes a response whose transaction id
+    does not match the id of the request it answers. The client validates
+    the <literal>i</literal> field of each response; a response carrying
+    a different, non-zero transaction id (for example one misrouted by a
+    proxy) is rejected. Responses with a zero or missing transaction id
+    are still accepted for backward compatibility with older servers.
+   </simpara>
   </section>
 
   <section xml:id="yar-client-protocol-exception.synopsis">

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -27,6 +27,16 @@
     <exceptionname>Yar_Server_Exception</exceptionname>.
    </simpara>
   </note>
+  <note>
+   <simpara>
+    As of Yar 2.3.0, the service information page can be customized by
+    defining a <literal>protected</literal> method named
+    <literal>__info</literal> on the executor object. When a GET request
+    arrives, Yar calls this method, passing it the markup of the page it
+    would otherwise render; if the method returns a &string;, that string
+    is sent to the client instead of the default page.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -130,6 +140,33 @@ class API {
     }
 
     protected function client_can_not_see() {
+    }
+}
+
+$service = new Yar_Server(new API());
+$service->handle();
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>Customizing the service information page with
+   <literal>__info</literal> (as of Yar 2.3.0)</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class API {
+    public function some_method($parameter, $option = "foo") {
+        return "some_method";
+    }
+
+    /*
+     * Must be protected. It is called on GET requests with the markup of
+     * the page Yar would otherwise render, and its string return value is
+     * sent to the client instead.
+     */
+    protected function __info($markup) {
+        return "Hello world";
     }
 }
 


### PR DESCRIPTION
Documents two Yar behaviours that exist in the extension but are missing from the manual.

## `__info` magic method (since Yar 2.3.0)

The server supports a `protected` `__info($markup)` method on the executor object that customises the service information page rendered on GET requests (see `php_yar_server_info()` in `yar_server.c`). The README covers it, but the manual doesn't mention it at all — while the sibling `__auth` method (also 2.3.0) is already documented via `YAR_OPT_PROVIDER`/`YAR_OPT_TOKEN`.

Added a note and an example on `Yar_Server::handle`.

## Response transaction id validation (since Yar 2.4.0)

The client validates the `"i"` field of every response against the id of the request it answers (`transports/curl.c`, `transports/socket.c`, both sync and concurrent paths). A response with a different, non-zero id (e.g. misrouted by a proxy) is rejected with a `response id mismatch` protocol error; zero/missing ids are accepted for backward compatibility with older servers.

Added to the `Yar_Client_Protocol_Exception` introduction, since the failure surfaces as `YAR_ERR_PROTOCOL`.

## Verified against

- `yar_server.c:479-507` (`__info` dispatch, `protected` check, string-return fallback)
- `transports/curl.c:554`, `transports/curl.c:783`, `transports/socket.c:231` (id validation)
- README.md sections "Custom Server Info" and "Response"