### PR TITLE
Add examples for mb_scrub()

### DIFF
--- a/reference/mbstring/functions/mb-scrub.xml
+++ b/reference/mbstring/functions/mb-scrub.xml
@@ -71,6 +71,90 @@
   </informaltable>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Byte-level replacement performed by <function>mb_scrub</function></title>
+    <simpara>
+     <function>bin2hex</function> is used here because terminals, browsers and
+     fonts may render an ill-formed byte sequence with a replacement character
+     of their own, which hides what the string actually contains.
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+// The byte 0xFF cannot appear in a valid UTF-8 string.
+$input = "A\xFFB";
+echo bin2hex($input), "\n";
+
+// The default substitute character is "?" (0x3F).
+echo bin2hex(mb_scrub($input, 'UTF-8')), "\n";
+
+// U+FFFD REPLACEMENT CHARACTER is encoded as EF BF BD in UTF-8.
+mb_substitute_character(0xFFFD);
+echo bin2hex(mb_scrub($input, 'UTF-8')), "\n";
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+41ff42
+413f42
+41efbfbd42
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Using <function>mb_scrub</function> before UTF-8 aware processing</title>
+    <simpara>
+     PCRE patterns using the <literal>u</literal> modifier reject subjects that
+     are not well-formed UTF-8. Scrubbing the input first makes it acceptable.
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$input = "A\xFFB";
+
+var_dump(preg_match_all('/./us', $input));
+echo preg_last_error_msg(), "\n";
+
+$clean = mb_scrub($input, 'UTF-8');
+
+var_dump(preg_match_all('/./us', $clean));
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(false)
+Malformed UTF-8 characters, possibly incorrectly encoded
+int(3)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>mb_substitute_character</function></member>
+    <member><function>mb_check_encoding</function></member>
+    <member><function>mb_convert_encoding</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/mbstring/functions/mb-scrub.xml
+++ b/reference/mbstring/functions/mb-scrub.xml
@@ -73,15 +73,14 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Byte-level replacement performed by <function>mb_scrub</function></title>
-    <simpara>
-     <function>bin2hex</function> is used here because terminals, browsers and
-     fonts may render an ill-formed byte sequence with a replacement character
-     of their own, which hides what the string actually contains.
-    </simpara>
-    <programlisting role="php">
+  <example>
+   <title>Byte-level replacement performed by <function>mb_scrub</function></title>
+   <simpara>
+    <function>bin2hex</function> is used here because terminals, browsers and
+    fonts may render an ill-formed byte sequence with a replacement character
+    of their own, which hides what the string actually contains.
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -98,25 +97,23 @@ echo bin2hex(mb_scrub($input, 'UTF-8')), "\n";
 
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 41ff42
 413f42
 41efbfbd42
 ]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Using <function>mb_scrub</function> before UTF-8 aware processing</title>
-    <simpara>
-     PCRE patterns using the <literal>u</literal> modifier reject subjects that
-     are not well-formed UTF-8. Scrubbing the input first makes it acceptable.
-    </simpara>
-    <programlisting role="php">
+   </screen>
+  </example>
+  <example>
+   <title>Using <function>mb_scrub</function> before UTF-8 aware processing</title>
+   <simpara>
+    PCRE patterns using the <literal>u</literal> modifier reject subjects that
+    are not well-formed UTF-8. Scrubbing the input first makes it acceptable.
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
@@ -131,28 +128,25 @@ var_dump(preg_match_all('/./us', $clean));
 
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 bool(false)
 Malformed UTF-8 characters, possibly incorrectly encoded
 int(3)
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>mb_substitute_character</function></member>
-    <member><function>mb_check_encoding</function></member>
-    <member><function>mb_convert_encoding</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>mb_substitute_character</function></member>
+   <member><function>mb_check_encoding</function></member>
+   <member><function>mb_convert_encoding</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
The `mb_scrub()` page had no example, which made it hard to see that the replacement happens in the string itself. Terminals, browsers and fonts render an ill-formed byte sequence with a replacement character of their own, so visual output alone is misleading. Both examples therefore use `bin2hex()` or `var_dump()`, so the reader sees the bytes rather than the rendering.

**Byte-level replacement.** The first example also shows that the result depends on the substitute character. `mbstring.substitute_character` defaults to `"?"` (`0x3F`), so scrubbing `"A\xFFB"` yields `41 3f 42`; `41 ef bf bd 42` is only produced after calling `mb_substitute_character(0xFFFD)`. This differs from the output given in the issue, which assumed U+FFFD by default.

**Use before UTF-8 aware processing.** The second example shows the practical case: a PCRE pattern with the `u` modifier fails on the raw input with `Malformed UTF-8 characters, possibly incorrectly encoded`, and succeeds once the string has been scrubbed.

A see also section is added, since the page had none and the substitute character is a prerequisite for reading the first example.

Both `<screen>` blocks were extracted from the file and compared byte for byte against the real output on PHP 8.1, 8.4 and 8.5.

Fixes: #5562