### PR TITLE
Yar: add protocol chapter, PIE installation and richer examples

### DIFF
--- a/reference/yar/book.xml
+++ b/reference/yar/book.xml
@@ -23,11 +23,13 @@
    are required.
   </simpara>
   <simpara>
-   The protocol is language agnostic: compatible implementations exist
-   for C, Java and Lua.
+   The protocol is language agnostic, so services can be consumed by any
+   language; see <link linkend="yar.protocol">The Yar Protocol</link> for
+   the details.
   </simpara>
  </preface>
 
+ &reference.yar.protocol;
  &reference.yar.setup;
  &reference.yar.constants;
  &reference.yar.examples;

--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -310,6 +310,20 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.yar-err-forbidden">
+   <term>
+    <constant>YAR_ERR_FORBIDDEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     The request was rejected by the server's authentication
+     (see the <literal>provider</literal> and
+     <literal>token</literal> fields of the
+     <link linkend="yar.protocol">Yar protocol header</link>).
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
 </appendix>
 

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -3,13 +3,33 @@
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
+ <simpara>
+  The examples below walk through a complete service: a server that
+  exposes a few arithmetic methods, a synchronous client that calls
+  them, a client that fans several calls out concurrently, and a
+  client that talks to a server over TCP.
+ </simpara>
+
  <example>
   <title>Yar Server Example</title>
+  <simpara>
+   A Yar service is just a regular PHP class wrapped by
+   <classname>Yar_Server</classname>. Every public method of the
+   object becomes an RPC endpoint; protected and private methods, as
+   well as methods whose names start with an underscore, stay hidden
+   from clients. The doc comments of the public methods are collected
+   and shown on the service information page.
+  </simpara>
+  <simpara>
+   RPC requests arrive as HTTP POST requests carrying a binary Yar
+   protocol payload, so the script is usually mapped to a URI on a
+   regular web server.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
 
-/* assume this page can be accessed by http://example.com/operator.php */
+/* assume this page can be accessed by http://api.example.com/operator.php */
 
 class Operator {
 
@@ -56,11 +76,12 @@ $server->handle();
  <example>
   <title>Access the server in browser (GET request)</title>
   <simpara>
-   When a GET request is issued to the service URI, Yar renders an
-   information page listing every public method of the executor object
-   together with its doc comment. This is controlled by the
-   <link linkend="ini.yar.expose-info">yar.expose_info</link>
-   directive.
+   When a GET request is issued to the service URI — for instance by
+   opening it in a browser — Yar does not perform an RPC call but
+   renders an information page listing every public method of the
+   executor object together with its doc comment. This is controlled
+   by the <link linkend="ini.yar.expose-info">yar.expose_info</link>
+   directive; when it is off, a GET request fails instead.
   </simpara>
   &example.outputs.similar;
   <mediaobject>
@@ -73,10 +94,22 @@ $server->handle();
 
  <example>
   <title>Yar Client Example</title>
+  <simpara>
+   A <classname>Yar_Client</classname> is bound to a single service
+   address. Calling any undefined method on it is transparently turned
+   into a synchronous RPC call, so remote methods look and feel like
+   local ones; <methodname>Yar_Client::call</methodname> does the same
+   thing explicitly by name.
+  </simpara>
+  <simpara>
+   Protected methods are not exposed: calling one fails with a
+   <exceptionname>Yar_Client_Exception</exceptionname> whose code is
+   <constant>YAR_ERR_REQUEST</constant>.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://example.com/operator.php");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* call directly */
 var_dump($client->add(1, 2));
@@ -94,17 +127,34 @@ var_dump($client->_add(1, 2));
 <![CDATA[
 int(3)
 int(5)
-PHP Fatal error:  Uncaught Yar_Server_Request_Exception: call to undefined api Operator::_add() in *
+PHP Fatal error:  Uncaught Yar_Client_Exception: call to undefined api Operator::_add() in *
 ]]>
   </screen>
  </example>
 
  <example>
   <title>Yar Concurrent Client Example</title>
+  <simpara>
+   Instead of calling services one after another,
+   <classname>Yar_Concurrent_Client</classname> registers several calls
+   first and then dispatches them all at once with
+   <methodname>Yar_Concurrent_Client::loop</methodname>. The responses
+   are passed to the callback in the order they arrive, not in the
+   order the calls were registered.
+  </simpara>
+  <simpara>
+   Right after all requests have been sent, the callback is invoked
+   once with &null; arguments so that the caller knows no further
+   request is pending; the example below checks for this notification.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
 function callback($ret, $callinfo) {
+    if ($callinfo == NULL) {
+        /* all requests are sent, waiting for the responses */
+        return;
+    }
     echo $callinfo['method'], " result: ", $ret, "\n";
 }
 
@@ -113,9 +163,9 @@ function error_callback($type, $error, $callinfo) {
 }
 
 /* register async calls to remote services */
-Yar_Concurrent_Client::call("http://example.com/operator.php", "add", array(1, 2), "callback");
-Yar_Concurrent_Client::call("http://example.com/operator.php", "sub", array(2, 1), "callback");
-Yar_Concurrent_Client::call("http://example.com/operator.php", "mul", array(2, 2), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "add", array(1, 2), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "sub", array(2, 1), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "mul", array(2, 2), "callback");
 
 /* send all requests and wait for the responses */
 Yar_Concurrent_Client::loop("callback", "error_callback");
@@ -137,8 +187,9 @@ add result: 3
   <simpara>
    Besides HTTP, <classname>Yar_Client</classname> can talk to Yar
    compatible servers over TCP or Unix sockets, for example a service
-   implemented with the Yar C framework. The remote server must
-   implement the same binary Yar protocol.
+   implemented with the
+   <link xlink:href="&url.git.hub;laruence/yar-c">Yar C framework</link>,
+   which serves the same binary Yar protocol that the PHP server uses.
   </simpara>
   <programlisting role="php">
 <![CDATA[

--- a/reference/yar/protocol.xml
+++ b/reference/yar/protocol.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<chapter xml:id="yar.protocol" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>The Yar Protocol</title>
+ <simpara>
+  Yar does not rely on a schema or IDL file: everything is exchanged on
+  the wire as plain bytes. Any language that can read and write bytes
+  can speak to a Yar service, without installing any framework at all —
+  build one fixed-size binary header and a serialized request body,
+  send them to the service URI, and parse the reply.
+ </simpara>
+ <simpara>
+  A message consists of a fixed-size header of 82 bytes followed by a
+  body. The header is laid out exactly like the following C structure,
+  packed with no padding, and is written to the wire field after field
+  in declaration order:
+ </simpara>
+ <programlisting role="c">
+<![CDATA[
+typedef struct _yar_header {
+    uint32_t       id;            /* transaction id */
+    uint16_t       version;       /* protocol version, currently always 0 */
+    uint32_t       magic_num;     /* must be 0x80DFEC60 */
+    uint32_t       reserved;
+    unsigned char  provider[32];  /* request from whom (authentication) */
+    unsigned char  token[32];     /* request token (authentication) */
+    uint32_t       body_len;      /* length of the whole body, including
+                                     the packager identifier */
+} __attribute__ ((packed)) yar_header_t;
+]]>
+ </programlisting>
+ <simpara>
+  The <literal>id</literal>, <literal>magic_num</literal>,
+  <literal>reserved</literal> and <literal>body_len</literal> fields
+  are stored in network byte order (big-endian); the remaining fields
+  are raw bytes.
+ </simpara>
+ <simpara>
+  The body starts with an 8-byte packager identifier —
+  <literal>PHP</literal>, <literal>JSON</literal> or
+  <literal>MSGPACK</literal>, zero-padded — telling the receiver how
+  the remainder was encoded, followed by the serialized content itself.
+ </simpara>
+ <itemizedlist>
+  <listitem>
+   <simpara>
+    The request body decodes to an array with the keys
+    <literal>i</literal> (the transaction id), <literal>m</literal>
+    (the method being called) and <literal>p</literal> (the list of
+    parameters).
+   </simpara>
+  </listitem>
+  <listitem>
+   <simpara>
+    The response body decodes to an array with the keys
+    <literal>i</literal> (the transaction id), <literal>s</literal>
+    (the status, one of the <literal>YAR_ERR_*</literal> codes),
+    <literal>r</literal> (the return value), <literal>o</literal> (any
+    output the service method produced) and <literal>e</literal> (the
+    error or exception, when the call failed).
+   </simpara>
+  </listitem>
+ </itemizedlist>
+ <simpara>
+  Over HTTP the message is sent as the body of a POST request, with
+  the response arriving as the body of the reply; over TCP or Unix
+  sockets it is written directly on the stream.
+ </simpara>
+ <example>
+  <title>Calling a Yar service without the extension</title>
+  <simpara>
+   The following self-contained script builds a valid Yar request for
+   the <literal>php</literal> packager with nothing but standard
+   sockets, sends it to a service URI, and prints the decoded
+   response. Running it against the
+   <classname>Operator</classname> service from the
+   <link linkend="yar.examples">examples</link> prints
+   <literal>int(3)</literal>.
+  </simpara>
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+$uri = "http://api.example.com/operator.php";
+
+/* 1. the body: packager identifier + serialized request */
+$serialized = serialize(array("i" => 1, "m" => "add", "p" => array(1, 2)));
+$body = str_pad("PHP", 8, "\0") . $serialized;
+
+/* 2. the header: 82 bytes, multi-byte integers in network byte order */
+$header = pack("N", 1)                    /* id */
+        . pack("v", 0)                    /* version */
+        . pack("N", 0x80DFEC60)           /* magic number */
+        . pack("N", 0)                    /* reserved */
+        . str_pad("", 32, "\0")           /* provider */
+        . str_pad("", 32, "\0")           /* token */
+        . pack("N", strlen($body));       /* body length */
+
+/* 3. send it as the body of a POST request */
+$stream = stream_context_create(array("http" => array(
+    "method"  => "POST",
+    "header"  => "Content-Type: application/octet-stream\r\n",
+    "content" => $header . $body,
+)));
+$reply = file_get_contents($uri, false, $stream);
+
+/* 4. parse the reply: 82-byte header, then the response body */
+$response = unserialize(substr($reply, 82 + 8));
+var_dump($response["r"]);
+?>
+]]>
+  </programlisting>
+ </example>
+ <simpara>
+  A more complete client implementation in plain PHP, which also
+  decodes the response header and supports concurrent calls, lives in
+  the <literal>tools/</literal> directory of the
+  <link xlink:href="&url.git.hub;laruence/yar">Yar source
+  repository</link>.
+ </simpara>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yar/setup.xml
+++ b/reference/yar/setup.xml
@@ -27,6 +27,10 @@
  <section xml:id="yar.installation">
   &reftitle.install;
   <simpara>
+   Yar can be installed in one of three ways: via PECL, via PIE, or
+   by building it from source.
+  </simpara>
+  <simpara>
    &pecl.moved;
   </simpara>
   <simpara>
@@ -36,66 +40,100 @@
   <simpara>
    &pecl.windows.download.avail;
   </simpara>
-  <para>
-   The source code is hosted on
-   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. To build
-   the extension from source:
-   <screen>
+  <example>
+   <title>Installing Yar with PECL</title>
+   <programlisting role="shell">
 <![CDATA[
-$ git clone https://github.com/laruence/yar.git
-$ cd yar
-$ phpize
-$ ./configure
-$ make
-$ sudo make install
+pecl install yar
 ]]>
-   </screen>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
+   As of Yar 2.4.0, the extension can be installed with
+   &link.pie;, the PHP Installer for Extensions, by running the
+   following on the command line.
+  </simpara>
+  <example>
+   <title>Installing Yar with PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yar
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   The msgpack packager can be enabled at install time:
+  </simpara>
+  <example>
+   <title>Installing Yar with PIE and msgpack</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yar --enable-msgpack
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   The source code is hosted on
+   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. To
+   build the extension from source, run the following on the command
+   line, replacing the paths with those of the local PHP
+   installation.
+  </simpara>
+  <example>
+   <title>Building Yar from source</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
+  <simpara>
    The following <literal>configure</literal> options are available:
-   <variablelist>
-    <varlistentry>
-     <term>
-      <option role="configure">--with-curl</option>
-     </term>
-     <listitem>
-      <simpara>
-       Location of the cURL installation, if it is not found in the
-       default include paths.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <option role="configure">--enable-msgpack</option>
-     </term>
-     <listitem>
-      <simpara>
-       Enables the <literal>msgpack</literal> packager and makes the
-       <literal>msgpack</literal> extension an optional dependency. When
-       Yar is built with this option, the default value of
-       <link linkend="ini.yar.packager">yar.packager</link> becomes
-       <literal>msgpack</literal>.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <option role="configure">--enable-epoll</option>
-     </term>
-     <listitem>
-      <simpara>
-       Uses Linux <literal>epoll</literal> instead of
-       <literal>select()</literal> for I/O multiplexing, available as of
-       Yar 2.1.2. This can improve
-       <classname>Yar_Concurrent_Client</classname> performance under
-       high concurrency. It only takes effect on Linux; on other
-       platforms it is silently ignored.
-      </simpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term>
+     <option role="configure">--with-curl</option>
+    </term>
+    <listitem>
+     <simpara>
+      Location of the cURL installation, if it is not found in the
+      default include paths.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option role="configure">--enable-msgpack</option>
+    </term>
+    <listitem>
+     <simpara>
+      Enables the <literal>msgpack</literal> packager and makes the
+      <literal>msgpack</literal> extension an optional dependency. When
+      Yar is built with this option, the default value of
+      <link linkend="ini.yar.packager">yar.packager</link> becomes
+      <literal>msgpack</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option role="configure">--enable-epoll</option>
+    </term>
+    <listitem>
+     <simpara>
+      Uses Linux <literal>epoll</literal> instead of
+      <literal>select()</literal> for I/O multiplexing, available as of
+      Yar 2.1.2. This can improve
+      <classname>Yar_Concurrent_Client</classname> performance under
+      high concurrency. It only takes effect on Linux; on other
+      platforms it is silently ignored.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </section>
  <!-- }}} -->
 

--- a/reference/yar/versions.xml
+++ b/reference/yar/versions.xml
@@ -7,7 +7,6 @@
  <function name='yar_server::handle' from='PECL yar &gt;= 1.0.0'/>
  <function name='yar_client::__construct' from='PECL yar &gt;= 1.0.0'/>
  <function name='yar_client::call' from='PECL yar &gt;= 1.0.0'/>
- <function name='yar_client::__call' from='PECL yar &gt;= 1.0.0'/>
  <function name='yar_client::setopt' from='PECL yar &gt;= 1.0.0'/>
  <function name='yar_client::getopt' from='PECL yar &gt;= 1.1.0'/>
  <function name='yar_concurrent_client::call' from='PECL yar &gt;= 1.0.0'/>

--- a/reference/yar/yar-concurrent-client.xml
+++ b/reference/yar/yar-concurrent-client.xml
@@ -17,9 +17,21 @@
     immediately; they are all dispatched together, in parallel, by
     <methodname>Yar_Concurrent_Client::loop</methodname>.
    </simpara>
+   <simpara>
+    The class is meant for applications that need the results of several
+    remote calls. Only independent calls — ones that do not need each
+    other's results — can be batched this way; when one call depends on
+    the result of another, the two have to run sequentially. Through
+    <classname>Yar_Client</classname> the calls are sent one after
+    another, each paying its full round-trip time; with the concurrent
+    client they are sent at the same time, so the overall waiting time
+    drops to the duration of the single slowest call.
+   </simpara>
    <note>
     <simpara>
-     Only HTTP(S) services are supported for concurrent calls.
+     Only HTTP(S) services are supported for concurrent calls. They are
+     sent concurrently through curl's multi-handle interface, which the
+     TCP/Unix socket transport does not implement.
     </simpara>
    </note>
   </section>

--- a/reference/yar/yar-server.xml
+++ b/reference/yar/yar-server.xml
@@ -16,6 +16,11 @@
     service, served over HTTP by
     <methodname>Yar_Server::handle</methodname>.
    </simpara>
+   <simpara>
+    The PHP extension only provides an HTTP server. A TCP and Unix
+    socket server speaking the same Yar protocol is provided by the
+    <link xlink:href="&url.git.hub;laruence/yar-c">Yar C framework</link>.
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/yar/yar_client/call.xml
+++ b/reference/yar/yar_client/call.xml
@@ -17,8 +17,8 @@
   <simpara>
    Issues an RPC call to the remote method <literal>method</literal>. This
    is exactly what happens when a non-existent method is invoked on a
-   <classname>Yar_Client</classname> object (see
-   <methodname>Yar_Client::__call</methodname>);
+   <classname>Yar_Client</classname> object (via PHP's
+   <literal>__call</literal> magic method);
    <methodname>Yar_Client::call</methodname> only exists so that remote
    methods literally named <literal>call</literal> or
    <literal>__call</literal> can still be reached.
@@ -57,17 +57,51 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   When the <literal>call</literal> method does not exist on the server
-   side, a <exceptionname>Yar_Server_Request_Exception</exceptionname> is
-   thrown. See <methodname>Yar_Client::__call</methodname> for the full
-   list of failures and their exception classes.
+   When the remote method does not exist on the server, or is not
+   public, the client throws a
+   <exceptionname>Yar_Client_Exception</exceptionname> with the code
+   <constant>YAR_ERR_REQUEST</constant>. See
+   <link linkend="class.yar-client-exception">Yar_Client_Exception</link>
+   for the other client-side failures and their exception classes.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><methodname>Yar_Client::call</methodname> example</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("http://api.example.com/operator.php");
+
+/* The usual way: invoke the remote method as if it were local.
+ * This is translated into call("add", array(1, 2)) behind the scenes. */
+var_dump($client->add(1, 2));
+
+/* Equivalent: call the method explicitly by name */
+var_dump($client->call("add", array(1, 2)));
+
+/* Needed only when the remote service literally exposes a method
+ * named call (or __call), which the magic __call cannot reach */
+var_dump($client->call("call", array($some_argument)));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(3)
+int(3)
+...
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yar_Client::__call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/construct.xml
+++ b/reference/yar/yar_client/construct.xml
@@ -70,10 +70,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* with options */
-$client = new Yar_Client("http://host/api/", [
+$client = new Yar_Client("http://api.example.com/operator.php", [
     YAR_OPT_TIMEOUT => 1000,
     YAR_OPT_PACKAGER => "json",
 ]);
@@ -86,7 +86,7 @@ $client = new Yar_Client("http://host/api/", [
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yar_Client::__call</methodname></member>
+   <member><methodname>Yar_Client::call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/getopt.xml
+++ b/reference/yar/yar_client/getopt.xml
@@ -51,7 +51,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 $client->setOpt(YAR_OPT_TIMEOUT, 1000);
 
 var_dump($client->getOpt(YAR_OPT_TIMEOUT));

--- a/reference/yar/yar_client/setopt.xml
+++ b/reference/yar/yar_client/setopt.xml
@@ -102,7 +102,7 @@
 <![CDATA[
 <?php
 
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* Set timeout to 1s */
 $client->setOpt(YAR_OPT_TIMEOUT, 1000);
@@ -128,7 +128,7 @@ $result = $client->some_method("parameter");
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Yar_Client::getOpt</methodname></member>
-   <member><methodname>Yar_Client::__call</methodname></member>
+   <member><methodname>Yar_Client::call</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_client_exception/gettype.xml
+++ b/reference/yar/yar_client_exception/gettype.xml
@@ -43,7 +43,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 try {
     $client->some_method("parameter");

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -26,8 +26,9 @@
   </simpara>
   <note>
    <simpara>
-    Only HTTP and HTTPS URIs are supported. TCP and Unix socket transports
-    are not available for concurrent calls.
+    Only HTTP and HTTPS URIs are supported. Concurrent calls are sent
+    simultaneously using curl's multi-handle interface, and the TCP/Unix
+    socket transport does not provide this facility.
    </simpara>
   </note>
  </refsect1>
@@ -66,11 +67,18 @@
      <simpara>
       A <type>callable</type> invoked when the response for this call
       arrives, with two arguments: the response value, and a
-      <literal>callinfo</literal> &array; with the keys
-      <literal>sequence</literal>, <literal>uri</literal> and
-      <literal>method</literal>. If omitted, the
-      <literal>callback</literal> of
-      <methodname>Yar_Concurrent_Client::loop</methodname> is used.
+      <literal>callinfo</literal> &array; describing the call:
+     </simpara>
+     <simplelist>
+      <member><literal>sequence</literal> — the sequence number returned
+       when the call was registered</member>
+      <member><literal>uri</literal> — the address of the service</member>
+      <member><literal>method</literal> — the name of the remote method</member>
+     </simplelist>
+     <simpara>
+      If omitted, the <literal>callback</literal> of
+      <methodname>Yar_Concurrent_Client::loop</methodname> is used;
+      see that method for what happens when neither is given.
      </simpara>
     </listitem>
    </varlistentry>
@@ -81,8 +89,10 @@
       A <type>callable</type> invoked when this call fails, with three
       arguments: the error type (one of the <literal>YAR_ERR_*</literal>
       codes), the error message, and the <literal>callinfo</literal>
-      &array;. If omitted, the <literal>error_callback</literal> of
-      <methodname>Yar_Concurrent_Client::loop</methodname> is used.
+      &array; described above. If omitted, the
+      <literal>error_callback</literal> of
+      <methodname>Yar_Concurrent_Client::loop</methodname> is used;
+      see that method for what happens when neither is given.
      </simpara>
     </listitem>
    </varlistentry>
@@ -130,16 +140,16 @@ function error_callback($type, $error, $callinfo)
     error_log($error);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* If the callback is not specified, the callback of loop() will be used */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"));
 
 /* This server accepts the JSON packager */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
 
 /* Custom timeout */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
 
 /* The requests are not sent yet */
 ]]>

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -21,6 +21,20 @@
    blocks until every response has arrived and been handled. The call list
    is emptied when this method returns.
   </simpara>
+  <simpara>
+   Because the calls run simultaneously, the loop takes only as long as
+   the slowest single call rather than the sum of all calls. The
+   callbacks, however, are not invoked in the order the calls were
+   registered: a callback fires as soon as its response arrives. To find
+   out which call a response belongs to, check the
+   <literal>sequence</literal> entry of the <literal>callinfo</literal>
+   argument against the sequence number returned by
+   <methodname>Yar_Concurrent_Client::call</methodname>. The
+   <literal>callinfo</literal> &array; holds the
+   <literal>sequence</literal>, <literal>uri</literal> and
+   <literal>method</literal> of the call; see
+   <methodname>Yar_Concurrent_Client::call</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -35,6 +49,10 @@
       been sent, it is additionally called once with two &null; arguments,
       before any response arrives.
      </simpara>
+     <simpara>
+      If this parameter is omitted, the return value of a successful call
+      is simply printed when its response arrives.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -46,6 +64,11 @@
       arguments: the error type (one of the <literal>YAR_ERR_*</literal>
       codes), the error message, and the <literal>callinfo</literal>
       &array;.
+     </simpara>
+     <simpara>
+      If this parameter is omitted, a failed call raises a PHP warning
+      instead; unlike the synchronous
+      <classname>Yar_Client</classname>, no exception is thrown.
      </simpara>
     </listitem>
    </varlistentry>
@@ -93,10 +116,10 @@ function error_callback($type, $error, $callinfo) {
     error_log($error);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* if the callback is not specified, the callback of loop() will be used */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"));
 
 Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -52,7 +52,7 @@ function callback($retval, $callinfo) {
     var_dump($retval);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* never sent: throw the registered call away */
 Yar_Concurrent_Client::reset();

--- a/reference/yar/yar_server/construct.xml
+++ b/reference/yar/yar_server/construct.xml
@@ -30,6 +30,42 @@
       services. Protected and private methods, and methods whose name
       starts with an underscore, are not exposed.
      </simpara>
+     <simpara>
+      The executor can optionally define two protected magic methods,
+      which are recognized by
+      <methodname>Yar_Server::handle</methodname> and never exposed as
+      RPC endpoints:
+     </simpara>
+     <itemizedlist>
+      <listitem>
+       <simpara>
+        <literal>protected function __info(string $markup):
+        string</literal> — as of Yar 2.3.0. Called when the service
+        information page is requested; it receives the markup of the
+        page Yar would otherwise render, and if it returns a &string;,
+        that string is sent to the client instead. See
+        <methodname>Yar_Server::handle</methodname>.
+       </simpara>
+      </listitem>
+      <listitem>
+       <simpara>
+        <literal>protected function __auth(string $provider, string
+        $token): bool</literal> — as of Yar 2.3.0. Called at the very
+        beginning of every request with the
+        <literal>provider</literal> and <literal>token</literal>
+        fields of the request header, set by the client with the
+        <constant>YAR_OPT_PROVIDER</constant> and
+        <constant>YAR_OPT_TOKEN</constant> options. Returning exactly
+        &false; rejects the request; any other return value lets it
+        proceed. See <methodname>Yar_Server::handle</methodname>.
+       </simpara>
+      </listitem>
+     </itemizedlist>
+     <simpara>
+      Both methods only take effect when they are
+      <literal>protected</literal>; a public or private method with
+      the same name is ignored.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -29,12 +29,11 @@
   </note>
   <note>
    <simpara>
-    As of Yar 2.3.0, the service information page can be customized by
-    defining a <literal>protected</literal> method named
-    <literal>__info</literal> on the executor object. When a GET request
-    arrives, Yar calls this method, passing it the markup of the page it
-    would otherwise render; if the method returns a &string;, that string
-    is sent to the client instead of the default page.
+    As of Yar 2.3.0, the executor object may define the protected
+    magic methods <literal>__info</literal> and
+    <literal>__auth</literal> to customize the service information
+    page and to authenticate requests; see
+    <methodname>Yar_Server::__construct</methodname> for details.
    </simpara>
   </note>
  </refsect1>

--- a/reference/yar/yar_server_exception/gettype.xml
+++ b/reference/yar/yar_server_exception/gettype.xml
@@ -60,7 +60,7 @@ $service->handle();
 <![CDATA[
 <?php
 /* Client.php */
-$client = new Yar_Client("http://host/api.php");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 try {
     $client->throw_exception("client");


### PR DESCRIPTION
## Summary

Follow-up on the Yar documentation rework (#5804): this makes the manual cover the wire protocol, offer the modern PIE installation path, and ship substantially more complete examples and usage notes.

## Changes

**1. A new "The Yar Protocol" chapter** (placed before the installation chapter)

- Documents the 82-byte binary header layout, the packager-prefixed body and the network-byte-order fields
- Includes a self-contained plain-PHP client example that calls a Yar service without the extension
- Documents the `YAR_ERR_FORBIDDEN` constant, which the extension registers for failed server authentication but was missing from the manual

**2. PIE installation**

- The setup chapter now covers three installation methods: PECL (marked as moved), PIE (`pie install laruence/yar`, including the `--enable-msgpack` variant) and building from source

**3. More complete examples and usage notes**

- `Yar_Client::call()` previously had no examples section at all; it now shows the magic-method form, the explicit form, and when `call()` itself is needed
- `Yar_Concurrent_Client` now explains the design (batch several independent calls; the total waiting time drops to the slowest single call), why only HTTP(S) is supported (calls are dispatched through curl's multi-handle interface, which the socket transport does not implement), the `callinfo` array layout, and what happens when no callback/error callback is set (return value printed / PHP warning raised)

## Validation

- `docbook-cs` on the full `reference/yar/` directory: 31 files scanned, no violations
- `doc-base/configure.php --with-partial=book.yar` validates cleanly
- Rendered with `phd` (PHP chunked XHTML package) without errors