### PR TITLE
ext/pdo: document the PHP 8.5 fetch mode changes and deprecations

### DIFF
--- a/reference/pdo/pdo.xml
+++ b/reference/pdo/pdo.xml
@@ -493,6 +493,17 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Driver-specific constants of the <classname>PDO</classname> class have
+        been deprecated in favor of the equivalent constants of the
+        driver-specific subclasses (<classname>Pdo\Dblib</classname>,
+        <classname>Pdo\Firebird</classname>, <classname>Pdo\Mysql</classname>,
+        <classname>Pdo\Odbc</classname>, <classname>Pdo\Pgsql</classname>,
+        <classname>Pdo\Sqlite</classname>).
+       </entry>
+      </row>
+      <row>
        <entry>8.4.0</entry>
        <entry>
         The class constants are now typed.

--- a/reference/pdo/pdo/construct.xml
+++ b/reference/pdo/pdo/construct.xml
@@ -60,6 +60,13 @@
            the DSN string. The URI can specify a local file or a remote URL.
           </para>
           <para><userinput>uri:file:///path/to/dsnfile</userinput></para>
+          <warning>
+           <simpara>
+            The <userinput>uri:</userinput> DSN scheme is deprecated as of
+            PHP 8.5.0 due to security concerns with DSNs coming from remote
+            URIs.
+           </simpara>
+          </warning>
          </listitem>
         </varlistentry>
         <varlistentry><term>Aliasing</term>
@@ -113,11 +120,33 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   A <classname>PDOException</classname> is thrown if the attempt
+  <simpara>
+   A <exceptionname>PDOException</exceptionname> is thrown if the attempt
    to connect to the requested database fails,
    regardless of which <constant>PDO::ATTR_ERRMODE</constant> is currently set.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The <userinput>uri:</userinput> DSN scheme is now deprecated.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -153,6 +153,17 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Using <constant>PDO::FETCH_INTO</constant> as a fetch mode now throws a
+       <exceptionname>ValueError</exceptionname>, similar to
+       <constant>PDO::FETCH_LAZY</constant>.
+       Using <constant>PDO::FETCH_PROPS_LATE</constant> with a fetch mode
+       other than <constant>PDO::FETCH_CLASS</constant> now throws a
+       <exceptionname>ValueError</exceptionname>.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        This method always returns an &array; now, while previously &false; may have

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -64,6 +64,39 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   As of PHP 8.5.0, when using the Firebird driver, a
+   <exceptionname>ValueError</exceptionname> is thrown if the cursor name set via
+   <constant>PDO::ATTR_CURSOR_NAME</constant> is too long.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       When using the Firebird driver, a <exceptionname>ValueError</exceptionname>
+       is now thrown if the cursor name set via
+       <constant>PDO::ATTR_CURSOR_NAME</constant> is too long.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -69,7 +69,9 @@
      <term><parameter>constructorArgs</parameter></term>
      <listitem>
       <simpara>
-       Constructor arguments.
+       Constructor arguments. As of PHP 8.5.0, string keys act as named
+       arguments. To pass a variable by reference, use a reference element:
+       <code>$constructorArgs = [&amp;$valByRef]</code>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -92,6 +94,16 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   As of PHP 8.5.0, an <exceptionname>Error</exceptionname> is thrown if this method
+   is called during a call to <methodname>PDOStatement::fetch</methodname>,
+   <methodname>PDOStatement::fetchObject</methodname>, or
+   <methodname>PDOStatement::fetchAll</methodname>.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -103,6 +115,26 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The <parameter>constructorArgs</parameter> for
+       <constant>PDO::FETCH_CLASS</constant> now follow CUFA
+       (<function>call_user_func_array</function>) semantics: string keys act
+       as named arguments, and automatic wrapping of by-value arguments for
+       by-reference parameters has been removed.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Calling this method during a call to
+       <methodname>PDOStatement::fetch</methodname>,
+       <methodname>PDOStatement::fetchObject</methodname>, or
+       <methodname>PDOStatement::fetchAll</methodname> now throws an
+       <exceptionname>Error</exceptionname>.
+      </entry>
+     </row>
      &return.type.true.84;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Documents the PHP 8.5 fetch mode changes and deprecations of ext/pdo: the new constant values, the `ValueError`s thrown for `PDO::FETCH_INTO` and `PDO::FETCH_PROPS_LATE`, the CUFA semantics of the `PDO::FETCH_CLASS` constructor arguments, the `Error` thrown when `PDOStatement::setFetchMode()` is called during a fetch, the deprecation of the `uri:` DSN scheme and of the driver specific constants and methods, and the Firebird cursor name `ValueError`.

Tracker items:
- [PDO] setFetchMode during a fetch: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199833520
- [PDO] FETCH_PROPS_LATE ValueError: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199833531
- [PDO] FETCH_INTO ValueError: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199833538
- [PDO] FETCH_CLASS constructor arguments: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834498
- [PDO] fetch constant values changed: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834516
- [PDO] uri: DSN scheme deprecated: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834519
- [PDO] driver specific constants deprecated: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834528
- [PDO] driver specific methods deprecated: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834534
- [PDO_FIREBIRD] cursor name ValueError: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199833547