### PR TITLE
ext/sqlite3, ext/sockets: document the PHP 8.5 additions

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -3185,6 +3185,198 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.shut-rd">
+   <term>
+    <constant>SHUT_RD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Disables further receive operations on the socket.
+     Used with <function>socket_shutdown</function>.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.shut-wr">
+   <term>
+    <constant>SHUT_WR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Disables further send operations on the socket.
+     Used with <function>socket_shutdown</function>.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.shut-rdwr">
+   <term>
+    <constant>SHUT_RDWR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Disables further send and receive operations on the socket.
+     Used with <function>socket_shutdown</function>.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.udp-segment">
+   <term>
+    <constant>UDP_SEGMENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Sets the maximum size of UDP Generic Segmentation Offload (GSO) segments,
+     allowing multiple datagrams to be sent in a single system call.
+     Available on Linux only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-busy-poll">
+   <term>
+    <constant>SO_BUSY_POLL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Sets the approximate time in microseconds to busy poll on a blocking
+     receive when there is no data. This reduces latency at the cost of CPU.
+     Available on Linux only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-bindany">
+   <term>
+    <constant>IP_BINDANY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Allows binding a socket to any address, even if it is not local.
+     Available on FreeBSD, NetBSD, and OpenBSD only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-function-blk">
+   <term>
+    <constant>TCP_FUNCTION_BLK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Selects the TCP stack (function block) used by the socket. With
+     <function>socket_set_option</function> the value is the name of the stack
+     as a <type>string</type>; <function>socket_get_option</function> returns an
+     array with the <literal>function_set_name</literal> and
+     <literal>pcbcnt</literal> keys.
+     Available on FreeBSD only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-function-alias">
+   <term>
+    <constant>TCP_FUNCTION_ALIAS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Retrieves the alias of the TCP stack used by the socket, as an array with
+     the <literal>function_set_name</literal> and <literal>pcbcnt</literal> keys.
+     Available on FreeBSD only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-reusport-lb-numa">
+   <term>
+    <constant>TCP_REUSPORT_LB_NUMA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Controls NUMA domain affinity for load-balanced port reuse.
+     Available on FreeBSD only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-reusport-lb-numa-nodom">
+   <term>
+    <constant>TCP_REUSPORT_LB_NUMA_NODOM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Constant value for <constant>TCP_REUSPORT_LB_NUMA</constant> indicating
+     no NUMA domain affinity.
+     Available on FreeBSD only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-reusport-lb-numa-curdom">
+   <term>
+    <constant>TCP_REUSPORT_LB_NUMA_CURDOM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Constant value for <constant>TCP_REUSPORT_LB_NUMA</constant> indicating
+     affinity for the current NUMA domain.
+     Available on FreeBSD only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-bbr-algorithm">
+   <term>
+    <constant>TCP_BBR_ALGORITHM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Socket option related to the BBR (Bottleneck Bandwidth and Round-trip
+     propagation time) congestion control algorithm.
+     Available on FreeBSD only.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipproto-icmp">
+   <term>
+    <constant>IPPROTO_ICMP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Internet Control Message Protocol (ICMP) protocol number,
+     used when creating raw sockets.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipproto-icmpv6">
+   <term>
+    <constant>IPPROTO_ICMPV6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Internet Control Message Protocol version 6 (ICMPv6) protocol number,
+     used when creating raw IPv6 sockets.
+     Available as of PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
 
 </appendix>

--- a/reference/sqlite3/sqlite3stmt.xml
+++ b/reference/sqlite3/sqlite3stmt.xml
@@ -11,6 +11,9 @@
    &reftitle.intro;
    <para>
     A class that handles prepared statements for the SQLite 3 extension.
+    Instances are obtained from <methodname>SQLite3::prepare</methodname>.
+    Calling <methodname>SQLite3Stmt::execute</methodname> runs the query and
+    returns a <classname>SQLite3Result</classname> for result sets.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/sqlite3/sqlite3stmt.xml
+++ b/reference/sqlite3/sqlite3stmt.xml
@@ -9,12 +9,12 @@
 <!-- {{{ SQLite3Stmt intro -->
   <section xml:id="sqlite3stmt.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     A class that handles prepared statements for the SQLite 3 extension.
     Instances are obtained from <methodname>SQLite3::prepare</methodname>.
     Calling <methodname>SQLite3Stmt::execute</methodname> runs the query and
     returns a <classname>SQLite3Result</classname> for result sets.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/sqlite3/sqlite3stmt.xml
+++ b/reference/sqlite3/sqlite3stmt.xml
@@ -24,6 +24,29 @@
      <classname>SQLite3Stmt</classname>
     </ooclass>
 
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-prepared">SQLite3Stmt::EXPLAIN_MODE_PREPARED</varname>
+     <initializer>0</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-explain">SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-explain-query-plan">SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Stmt'])"/>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Stmt'])"/>
@@ -31,6 +54,47 @@
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ SQLite3Stmt constants -->
+  <section xml:id="sqlite3stmt.constants">
+   &reftitle.constants;
+   <variablelist>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-prepared">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_PREPARED</constant></term>
+     <listitem>
+      <simpara>
+       The statement operates in normal prepared statement mode (no <literal>EXPLAIN</literal>).
+       Available as of PHP 8.5.0, when compiled against libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-explain">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</constant></term>
+     <listitem>
+      <simpara>
+       The statement operates as if prefixed with <literal>EXPLAIN</literal>,
+       returning opcode information from the virtual machine.
+       Available as of PHP 8.5.0, when compiled against libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-explain-query-plan">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant></term>
+     <listitem>
+      <simpara>
+       The statement operates as if prefixed with <literal>EXPLAIN QUERY PLAN</literal>,
+       returning high-level query plan information.
+       Available as of PHP 8.5.0, when compiled against libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+   </variablelist>
+  </section>
+<!-- }}} -->
 
  </partintro>
 

--- a/reference/sqlite3/sqlite3stmt/busy.xml
+++ b/reference/sqlite3/sqlite3stmt/busy.xml
@@ -59,6 +59,7 @@
   <simplelist>
    <member><methodname>SQLite3Stmt::execute</methodname></member>
    <member><methodname>SQLite3Stmt::reset</methodname></member>
+   <member><methodname>SQLite3Stmt::close</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/busy.xml
+++ b/reference/sqlite3/sqlite3stmt/busy.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="sqlite3stmt.busy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3Stmt::busy</refname>
+  <refpurpose>Returns whether the statement has been fetched but not yet completed</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3Stmt">
+   <modifier>public</modifier> <type>bool</type><methodname>SQLite3Stmt::busy</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Returns whether the statement is busy, i.e. it has been started with
+   <methodname>SQLite3Stmt::execute</methodname> and has rows remaining to be fetched,
+   but has not yet been completed or reset.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns &true; if the statement has been executed and still has rows to fetch,
+   &false; otherwise.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       This method was added.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3Stmt::execute</methodname></member>
+   <member><methodname>SQLite3Stmt::reset</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/sqlite3stmt/explain.xml
+++ b/reference/sqlite3/sqlite3stmt/explain.xml
@@ -36,6 +36,8 @@
   &reftitle.seealso;
   <simplelist>
    <member><methodname>SQLite3Stmt::setExplain</methodname></member>
+   <member><methodname>SQLite3Stmt::execute</methodname></member>
+   <member><methodname>SQLite3Stmt::reset</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/explain.xml
+++ b/reference/sqlite3/sqlite3stmt/explain.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="sqlite3stmt.explain" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3Stmt::explain</refname>
+  <refpurpose>Returns the explain mode of the statement</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3Stmt">
+   <modifier>public</modifier> <type>int</type><methodname>SQLite3Stmt::explain</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Returns the explain mode currently set on the statement with
+   <methodname>SQLite3Stmt::setExplain</methodname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns one of <constant>SQLite3Stmt::EXPLAIN_MODE_PREPARED</constant>,
+   <constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</constant>, or
+   <constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3Stmt::setExplain</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/sqlite3stmt/setexplain.xml
+++ b/reference/sqlite3/sqlite3stmt/setexplain.xml
@@ -54,6 +54,7 @@
   &reftitle.seealso;
   <simplelist>
    <member><methodname>SQLite3Stmt::explain</methodname></member>
+   <member><methodname>SQLite3Stmt::execute</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/setexplain.xml
+++ b/reference/sqlite3/sqlite3stmt/setexplain.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="sqlite3stmt.setexplain" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3Stmt::setExplain</refname>
+  <refpurpose>Changes the explain mode of the statement</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3Stmt">
+   <modifier>public</modifier> <type>bool</type><methodname>SQLite3Stmt::setExplain</methodname>
+   <methodparam><type>int</type><parameter>mode</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Changes the explain mode of the statement, so that it behaves as if its SQL
+   was prefixed with <literal>EXPLAIN</literal> or
+   <literal>EXPLAIN QUERY PLAN</literal>, or as an ordinary statement again.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+     <simpara>
+      One of <constant>SQLite3Stmt::EXPLAIN_MODE_PREPARED</constant>,
+      <constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</constant>, or
+      <constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   A <exceptionname>ValueError</exceptionname> is thrown if <parameter>mode</parameter>
+   is not one of the <constant>SQLite3Stmt::EXPLAIN_MODE_*</constant> constants.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3Stmt::explain</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/versions.xml
+++ b/reference/sqlite3/versions.xml
@@ -32,6 +32,9 @@
  <function name="SQLite3Exception" from="PHP 8 &gt;= 8.3.0"/>
 
  <function name="SQLite3Stmt" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
+ <function name="SQLite3Stmt::EXPLAIN_MODE_PREPARED" from="PHP 8 &gt;= 8.5.0"/>
+ <function name="SQLite3Stmt::EXPLAIN_MODE_EXPLAIN" from="PHP 8 &gt;= 8.5.0"/>
+ <function name="SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN" from="PHP 8 &gt;= 8.5.0"/>
  <function name="SQLite3Stmt::__construct" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Stmt::bindParam" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Stmt::bindValue" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
@@ -41,6 +44,9 @@
  <function name="SQLite3Stmt::getSQL" from="PHP 7 &gt;= 7.4.0, PHP 8"/>
  <function name="SQLite3Stmt::paramCount" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
  <function name="SQLite3Stmt::readOnly" from="PHP 5 &gt;= 5.3.6, PHP 7, PHP 8"/>
+ <function name="SQLite3Stmt::busy" from="PHP 8 &gt;= 8.5.0"/>
+ <function name="SQLite3Stmt::explain" from="PHP 8 &gt;= 8.5.0"/>
+ <function name="SQLite3Stmt::setExplain" from="PHP 8 &gt;= 8.5.0"/>
  <function name="SQLite3Stmt::reset" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>
 
  <function name="SQLite3Result" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8"/>


### PR DESCRIPTION
Documents the PHP 8.5 additions of ext/sqlite3 and ext/sockets: `SQLite3Stmt::busy()`, the `SQLite3Stmt::EXPLAIN_MODE_*` constants together with the `SQLite3Stmt::explain()` and `SQLite3Stmt::setExplain()` methods they are used with, and the new socket constants.

Tracker items:
- [Sqlite] SQLite3Stmt::busy: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834838
- [Sqlite] SQLite3Stmt EXPLAIN_MODE_*: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834842
- [Sockets] IPPROTO_ICMP/IPPROTO_ICMPV6: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834711
- [Sockets] TCP_FUNCTION_BLK: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834716
- [Sockets] TCP_FUNCTION_ALIAS: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834721
- [Sockets] TCP_REUSPORT_LB_NUMA: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834724
- [Sockets] TCP_REUSPORT_LB_NUMA_NODOM: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834731
- [Sockets] TCP_REUSPORT_LB_NUMA_CURDOM: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834736
- [Sockets] TCP_BBR_ALGORITHM: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834742
- [Sockets] IP_BINDANY: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834751
- [Sockets] SO_BUSY_POLL: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834758
- [Sockets] UDP_SEGMENT: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834768
- [Sockets] SHUT_RD: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834774
- [Sockets] SHUT_WR: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834783
- [Sockets] SHUT_RDWR: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834788
