### PR TITLE
ext/pgsql, ext/enchant: document the functions added in PHP 8.5

### DIFF
--- a/reference/enchant/functions/enchant-dict-remove-from-session.xml
+++ b/reference/enchant/functions/enchant-dict-remove-from-session.xml
@@ -45,6 +45,7 @@
   <simplelist>
    <member><function>enchant_dict_add_to_session</function></member>
    <member><function>enchant_dict_remove</function></member>
+   <member><function>enchant_dict_is_added_to_session</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/enchant/functions/enchant-dict-remove-from-session.xml
+++ b/reference/enchant/functions/enchant-dict-remove-from-session.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.enchant-dict-remove-from-session" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>enchant_dict_remove_from_session</refname>
+  <refpurpose>Remove a word from the session dictionary</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>enchant_dict_remove_from_session</methodname>
+   <methodparam><type>EnchantDictionary</type><parameter>dictionary</parameter></methodparam>
+   <methodparam><type>string</type><parameter>word</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Removes a word that was previously added to the current spell-checking
+   session via <function>enchant_dict_add_to_session</function>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &enchant.param.dictionary;
+   <varlistentry>
+    <term><parameter>word</parameter></term>
+    <listitem>
+     <simpara>
+      The word to remove from the session.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>enchant_dict_add_to_session</function></member>
+   <member><function>enchant_dict_remove</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/enchant/functions/enchant-dict-remove.xml
+++ b/reference/enchant/functions/enchant-dict-remove.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.enchant-dict-remove" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>enchant_dict_remove</refname>
+  <refpurpose>Add a word to the exclusion list and remove it from the personal dictionary</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>enchant_dict_remove</methodname>
+   <methodparam><type>EnchantDictionary</type><parameter>dictionary</parameter></methodparam>
+   <methodparam><type>string</type><parameter>word</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Adds a word to the exclusion list of the given dictionary, preventing it
+   from being accepted as correctly spelled. If the word was previously added
+   to the personal dictionary, it is also removed from there.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &enchant.param.dictionary;
+   <varlistentry>
+    <term><parameter>word</parameter></term>
+    <listitem>
+     <simpara>
+      The word to exclude.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>enchant_dict_add</function></member>
+   <member><function>enchant_dict_remove_from_session</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/enchant/functions/enchant-dict-remove.xml
+++ b/reference/enchant/functions/enchant-dict-remove.xml
@@ -46,6 +46,7 @@
   <simplelist>
    <member><function>enchant_dict_add</function></member>
    <member><function>enchant_dict_remove_from_session</function></member>
+   <member><function>enchant_dict_is_added</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/enchant/versions.xml
+++ b/reference/enchant/versions.xml
@@ -17,6 +17,8 @@
  <function name="enchant_dict_add_to_personal" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 " deprecated="PHP 8.0.0"/>
  <function name="enchant_dict_add" from="PHP 8"/>
  <function name="enchant_dict_add_to_session" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
+ <function name="enchant_dict_remove" from="PHP 8 &gt;= 8.5.0"/>
+ <function name="enchant_dict_remove_from_session" from="PHP 8 &gt;= 8.5.0"/>
  <function name="enchant_dict_check" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
  <function name="enchant_dict_describe" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>
  <function name="enchant_dict_get_error" from="PHP 5 &gt;= 5.3.0, PHP 7, PHP 8, PECL enchant &gt;= 0.1.0 "/>

--- a/reference/pgsql/functions/pg-close-stmt.xml
+++ b/reference/pgsql/functions/pg-close-stmt.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.pg-close-stmt" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_close_stmt</refname>
+  <refpurpose>Closes a prepared statement</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>PgSql\Result</type><type>false</type></type><methodname>pg_close_stmt</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>statement_name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Closes a prepared statement on the server, freeing its resources and making
+   its name available for reuse. It is an alternative to issuing a
+   <literal>DEALLOCATE</literal> SQL command, which does not allow the statement
+   name to be reused afterwards.
+  </simpara>
+  <simpara>
+   This function is only available if PHP has been built against libpq 17 or
+   later.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>statement_name</parameter></term>
+    <listitem>
+     <simpara>
+      The name of the prepared statement to close.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   A <classname>PgSql\Result</classname> instance on success, or &false; on
+   failure.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Throws a <exceptionname>ValueError</exceptionname> if
+   <parameter>statement_name</parameter> is empty or contains any null bytes.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_prepare</function></member>
+   <member><function>pg_execute</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-connect.xml
+++ b/reference/pgsql/functions/pg-connect.xml
@@ -105,6 +105,13 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       A <exceptionname>ValueError</exceptionname> is now thrown if
+       <parameter>connection_string</parameter> contains null bytes.
+      </entry>
+     </row>
+     <row>
       <entry>8.1.0</entry>
       <entry>
        Returns an <classname>PgSql\Connection</classname> instance now;

--- a/reference/pgsql/functions/pg-service.xml
+++ b/reference/pgsql/functions/pg-service.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.pg-service" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_service</refname>
+  <refpurpose>Gets the service name of the connection</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>pg_service</methodname>
+   <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Returns the name of the connection service used to establish the connection,
+   as defined in the connection service file.
+  </simpara>
+  <simpara>
+   This function is only available if PHP has been built against libpq 18 or
+   later.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection-with-nullable-default;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   A <type>string</type> containing the service name of the connection, or an
+   empty <type>string</type> if no service was used.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_connect</function></member>
+   <member><function>pg_dbname</function></member>
+   <member><function>pg_host</function></member>
+   <member><function>pg_port</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/versions.xml
+++ b/reference/pgsql/versions.xml
@@ -7,6 +7,7 @@
  <function name="pg_change_password" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pg_client_encoding" from="PHP 4 &gt;= 4.0.3, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_close" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
+ <function name="pg_close_stmt" from="PHP 8 &gt;= 8.5.0"/>
  <function name="pg_connect" from="PHP 4, PHP 5, PHP 7, PHP 8"/>
  <function name="pg_connect_poll" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
  <function name="pg_connection_busy" from="PHP 4 &gt;= 4.2.0, PHP 5, PHP 7, PHP 8"/>
@@ -91,6 +92,7 @@
  <function name="pg_set_error_context_visibility" from="PHP 8 &gt;= 8.3.0"/>
  <function name="pg_set_error_verbosity" from="PHP 5 &gt;= 5.1.0, PHP 7, PHP 8"/>
  <function name="pg_set_chunked_rows_size" from="PHP 8 &gt;= 8.4.0"/>
+ <function name="pg_service" from="PHP 8 &gt;= 8.5.0"/>
  <function name="pg_socket" from="PHP 5 &gt;= 5.6.0, PHP 7, PHP 8"/>
  <function name="pg_socket_poll" from="PHP 8 &gt;= 8.4.0"/>
  <function name="pg_trace" from="PHP 4 &gt;= 4.0.1, PHP 5, PHP 7, PHP 8"/>


### PR DESCRIPTION
Documents the functions added in PHP 8.5 to ext/pgsql and ext/enchant: `pg_close_stmt()`, `pg_service()`, `enchant_dict_remove()` and `enchant_dict_remove_from_session()`, plus the null byte check of `pg_connect()`.

Tracker items:
- [PGSQL] pg_close_stmt: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834583
- [PGSQL] pg_service: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834588
- [PGSQL] pg_connect null byte check: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834597
- [PGSQL] pg_close_stmt null byte check: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834604
- [Enchant] enchant_dict_remove_from_session: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834084
- [Enchant] enchant_dict_remove: https://github.com/orgs/php/projects/13/views/1?pane=issue&itemId=199834090
