### PR TITLE
Document the PHP 8.5 core deprecations and max_memory_limit

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -438,6 +438,12 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
+       <row>
+        <entry><link linkend="ini.max-memory-limit">max_memory_limit</link></entry>
+        <entry>"-1"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry>Available as of PHP 8.5.0</entry>
+       </row>
       </tbody>
      </tgroup>
     </table>
@@ -459,9 +465,30 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         scripts for eating up all available memory on a server. Note that
         to have no memory limit, set this directive to <literal>-1</literal>.
        </para>
-       
+
        &ini.shorthandbytes;
-       
+
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="ini.max-memory-limit">
+      <term>
+       <parameter>max_memory_limit</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        Available as of PHP 8.5.0. This startup-only setting controls the
+        maximum value that <link linkend="ini.memory-limit">memory_limit</link>
+        may be configured to, either at startup or at runtime (e.g. via
+        <function>ini_set</function>). Setting
+        <link linkend="ini.memory-limit">memory_limit</link> to a value
+        exceeding <parameter>max_memory_limit</parameter> results in a
+        warning and the value being capped. Set to <literal>-1</literal>
+        (the default) to impose no upper bound.
+       </simpara>
+
+       &ini.shorthandbytes;
+
       </listitem>
      </varlistentry>
     </variablelist>

--- a/language/constants.xml
+++ b/language/constants.xml
@@ -19,6 +19,12 @@
    </para>
   </note>
 
+  <note>
+   <simpara>
+    As of PHP 8.5.0, redeclaring an already-defined constant is deprecated.
+   </simpara>
+  </note>
+
   <para>
    The name of a constant follows the same rules as any label in PHP. A 
    valid constant name starts with a letter or underscore, followed

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -568,6 +568,10 @@ object(A)#2 (2) {
     defined on an object, then all public, protected and private properties
     will be shown.
    </para>
+   <simpara>
+    As of PHP 8.5.0, returning &null; from <link linkend="object.debuginfo">__debugInfo()</link>
+    is deprecated. Return an empty <type>array</type> instead.
+   </simpara>
    <example>
     <title>Using <link linkend="object.debuginfo">__debugInfo()</link></title>
     <programlisting role="php">

--- a/language/operators/increment.xml
+++ b/language/operators/increment.xml
@@ -123,6 +123,7 @@ int(4)
    <simpara>
     This feature is soft-deprecated as of PHP 8.3.0.
     The <function>str_increment</function> function should be used instead.
+    As of PHP 8.5.0, incrementing non-numeric strings emits a deprecation warning.
    </simpara>
   </warning>
 

--- a/language/predefined/closure/bind.xml
+++ b/language/predefined/closure/bind.xml
@@ -65,6 +65,30 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Binding an instance to a static closure, or binding a method from an
+       incompatible class hierarchy, is now deprecated (these cases already
+       emitted an <constant>E_WARNING</constant>).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -89,6 +89,30 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Binding an instance to a static closure, or binding a method from an
+       incompatible class hierarchy, is now deprecated (these cases already
+       emitted an <constant>E_WARNING</constant>).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -198,6 +198,30 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Trying to produce output (e.g. with <function>echo</function>) within
+       the user output handler callback is now deprecated. The deprecation
+       warning bypasses the handler and is output directly.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Documents six PHP 8.5 core changes still marked Todo on the 8.5 documentation tracker.

- max_memory_limit INI setting — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833365
- Constant redeclaration deprecated — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833338
- Increment on non-numeric strings deprecated — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833342
- Returning null from __debugInfo() deprecated — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833327
- Closure binding deprecations on Closure::bind() and Closure::bindTo() — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833346
- Producing output within a user output handler deprecated — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833305

Wording follows the PHP 8.5 UPGRADING notes; each entry was checked against PHP 8.5.4.
