### PR TITLE
Document the PHP 8.5 core language features

### DIFF
--- a/language/constants.xml
+++ b/language/constants.xml
@@ -222,6 +222,33 @@ echo ANIMALS_DEF[1] . "\n"; // outputs "cat"
     </para>
    </note>
 
+   <sect2 role="changelog">
+    &reftitle.changelog;
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>8.5.0</entry>
+        <entry>
+         Added support for type casts (e.g. <code>(int)</code>,
+         <code>(string)</code>) in constant expressions.
+         Also added support for
+         <link linkend="functions.anonymous">Closures</link> and
+         <link linkend="functions.first_class_callable_syntax">first-class
+         callables</link> in constant expressions.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
+
    <sect2 role="seealso">
     &reftitle.seealso;
     <para>

--- a/language/errors/basics.xml
+++ b/language/errors/basics.xml
@@ -75,6 +75,30 @@
    as by sending an e-mail.
   </para>
  </sect2>
+
+ <sect2 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Fatal errors (such as an exceeded maximum execution time) now include
+       a stack trace in their error message.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </sect2>
+
 </sect1>
  
 <!-- Keep this comment at the end of the file

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1409,6 +1409,13 @@ Stack trace:
        </thead>
        <tbody>
         <row>
+         <entry>8.5.0</entry>
+         <entry>
+          Closures can now be used in constant expressions (e.g. default
+          property values, attribute parameters, constants).
+         </entry>
+        </row>
+        <row>
          <entry>8.3.0</entry>
          <entry>
           Closures created from <link linkend="language.oop5.magic">magic
@@ -1715,6 +1722,29 @@ $obj?->prop->method(...);
      </informalexample>
     </para>
    </note>
+
+   <sect2 role="changelog">
+    &reftitle.changelog;
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>8.5.0</entry>
+        <entry>
+         First-class callables can now be used in constant expressions
+         (e.g. default property values, attribute parameters, constants).
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
   </sect1>
 
  </chapter>

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -160,6 +160,8 @@ print implode(' ', $new_numbers);
    scope-independent and can always be invoked, whereas a callable type may be
    scope-dependent and may not be directly invoked.
    <classname>Closure</classname> is the preferred way to create callables.
+   As of PHP 8.5.0, <classname>Closure</classname> is a proper subtype of
+   <type>callable</type>.
   </simpara>
 
   <note>


### PR DESCRIPTION
Documents four PHP 8.5 core features still marked Todo on the 8.5 documentation tracker.

- Closures and first-class callables in constant expressions — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833395
- Casts in constant expressions — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833422
- Closure is now a proper subtype of callable — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833392
- Fatal errors now include a backtrace — https://github.com/orgs/php/projects/13/views/1?pane=item&itemId=199833402

Wording follows the PHP 8.5 UPGRADING notes; each entry was checked against PHP 8.5.4.
