### PR TITLE
array_unique: explain what the 7.2 rebuild actually changes

### DIFF
--- a/appendices/migration72/incompatible.xml
+++ b/appendices/migration72/incompatible.xml
@@ -269,12 +269,16 @@ int(2)
  <sect2 xml:id="migration72.incompatible.array-unique">
   <title><function>array_unique</function> with <constant>SORT_STRING</constant></title>
 
-  <para>
-   While <function>array_unique</function> with <constant>SORT_STRING</constant>
-   formerly copied the array and removed non-unique elements (without packing
-   the array afterwards), now a new array is built by adding the
-   unique elements. This can result in different numeric indexes.
-  </para>
+  <simpara>
+   <function>array_unique</function> with <constant>SORT_STRING</constant>
+   builds the returned array by adding the unique elements to a new array;
+   formerly, it was a copy of the input from which the non-unique elements
+   were removed.
+   Both hold the same elements under the same keys, but if the element with
+   the largest integer key is among those removed, the index generated for an
+   element appended to the returned array differs from the one the input
+   would have generated.
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration72.incompatible.bcmod-and-floats">

--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -108,10 +108,13 @@
        <entry>7.2.0</entry>
        <entry>
         If <parameter>flags</parameter> is <constant>SORT_STRING</constant>,
-        formerly <parameter>array</parameter> has been copied and non-unique
-        elements have been removed (without packing the array afterwards), but
-        now a new array is built by adding the unique elements. This can result
-        in different numeric indexes.
+        the returned array is built by adding the unique elements to a new
+        array; formerly, it was a copy of <parameter>array</parameter> from
+        which the non-unique elements were removed.
+        Both hold the same elements under the same keys, but if the element
+        with the largest integer key is among those removed, the index
+        generated for an element appended to the returned array differs from
+        the one <parameter>array</parameter> would have generated.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
The 7.2.0 changelog entry mentioned array packing, an engine detail, and left "different numeric indexes" unexplained. The 7.2 migration guide carried the same sentence, so both are updated.

The keys of the returned elements are the same before and after 7.2: the old implementation copied the array and removed the non-unique elements, the current one adds them to a new array with `zend_hash_index_add_new`, keeping the original key either way.

What differs is the index generated when an element is appended to the result afterwards, and only when the element carrying the largest integer key was among the removed duplicates. The counter behind `$a[] =` is never lowered by a deletion, so the old copy kept the value inherited from the input.

Fixes: #4370