### PR TITLE
doc-extensions: phase 1 - add migration notices for selected extensions

### DIFF
--- a/reference/apcu/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/apcu/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/cmark/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/cmark/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/componere/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/componere/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/cubrid/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/cubrid/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/dbase/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/dbase/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/dio/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/dio/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/ds/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/ds/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/eio/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/eio/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/ev/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/ev/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/event/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/event/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/expect/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/expect/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/fann/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/fann/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/fdf/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/fdf/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/gearman/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/gearman/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/gender/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/gender/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/geoip/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/geoip/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/gmagick/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/gmagick/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/gnupg/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/gnupg/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/hrtime/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/hrtime/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/ibase/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/ibase/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/ibm_db2/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/ibm_db2/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/igbinary/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/igbinary/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/imagick/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/imagick/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/inotify/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/inotify/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/lua/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/lua/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/luasandbox/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/luasandbox/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/lzf/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/lzf/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/mailparse/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/mailparse/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/mcrypt/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/mcrypt/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/memcache/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/memcache/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/memcached/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/memcached/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/mongodb/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/mongodb/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/mqseries/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/mqseries/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/mysql/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/mysql/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/mysql_xdevapi/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/mysql_xdevapi/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/oauth/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/oauth/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/openal/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/openal/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/operator/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/operator/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/parallel/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/parallel/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/parle/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/parle/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/pdo_cubrid/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/pdo_cubrid/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/pdo_ibm/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/pdo_ibm/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/pdo_informix/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/pdo_informix/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/pdo_sqlsrv/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/pdo_sqlsrv/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/ps/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/ps/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/pthreads/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/pthreads/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/quickhash/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/quickhash/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/radius/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/radius/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/rar/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/rar/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/recode/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/recode/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/rnp/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/rnp/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/rpminfo/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/rpminfo/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/rrd/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/rrd/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/runkit7/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/runkit7/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/scoutapm/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/scoutapm/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/seaslog/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/seaslog/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/simdjson/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/simdjson/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/solr/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/solr/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/sqlsrv/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/sqlsrv/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/ssdeep/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/ssdeep/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/ssh2/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/ssh2/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/stats/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/stats/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/stomp/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/stomp/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/svm/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/svm/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/svn/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/svn/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/swoole/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/swoole/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/sync/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/sync/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/taint/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/taint/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/tcpwrap/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/tcpwrap/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/trader/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/trader/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/ui/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/ui/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/uopz/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/uopz/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/v8js/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/v8js/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/var_representation/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/var_representation/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/varnish/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/varnish/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/wddx/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/wddx/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/win32service/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/win32service/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/wincache/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/wincache/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/wkhtmltox/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/wkhtmltox/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/xattr/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/xattr/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/xdiff/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/xdiff/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/xhprof/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/xhprof/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/xlswriter/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/xlswriter/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/xmldiff/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/xmldiff/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/xmlrpc/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/xmlrpc/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/xpass/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/xpass/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/yac/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/yac/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/yaconf/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/yaconf/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/yaf/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/yaf/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/yaml/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/yaml/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/yar/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/yar/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/yaz/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/yaz/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/zmq/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/zmq/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).

--- a/reference/zookeeper/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
+++ b/reference/zookeeper/MOVING_TO_DOC_EXTENSIONS_DO_NOT_CHANGE_HERE.md
@@ -1,0 +1,11 @@
+# This extension is moving to php/doc-extensions
+
+Per [the RFC on separation of third-party extension documentation](https://wiki.php.net/rfc/third_party_ext_documentation),
+the documentation for this extension is being migrated to the [php/doc-extensions](https://github.com/php/doc-extensions) repository.
+
+**Do not make changes to this extension's documentation in doc-en.**
+Any changes made here after this file was added will be discarded during the migration.
+Please direct all contributions to [php/doc-extensions](https://github.com/php/doc-extensions) instead.
+
+The migration plan and progress are tracked in [php/doc-extensions#13](https://github.com/php/doc-extensions/issues/13),
+and the final list of migrated extensions in [php/doc-extensions#12](https://github.com/php/doc-extensions/issues/12).


### PR DESCRIPTION
This is work for phase 1 of the doc-extensions migration ([see RFC](https://wiki.php.net/rfc/third_party_ext_documentation)) which has been discussed at https://github.com/php/doc-extensions/issues/13