### PR TITLE
Document that DateInterval addition depends on how the interval was created

### DIFF
--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -28,6 +28,17 @@
     is by calculating the difference between two date/time objects through
     <methodname>DateTimeInterface::diff</methodname>.
    </para>
+   <simpara>
+    How an interval is applied when it is added to, or subtracted from, a
+    date/time object depends on how the interval was created. An interval
+    created with <methodname>DateInterval::__construct</methodname> covers
+    elapsed time, whereas an interval created with
+    <methodname>DateInterval::createFromDateString</methodname>, or returned
+    by <methodname>DateTimeInterface::diff</methodname>, increments or
+    decrements the individual component values. The two only give a different
+    result when a timezone transition falls within the interval; see
+    <link linkend="datetime.examples-arithmetic">Date/Time Arithmetic</link>.
+   </simpara>
    <para>
     Since there is no well defined way to compare date intervals,
     <classname>DateInterval</classname> instances are

--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -37,8 +37,8 @@
     <methodname>DateInterval::createFromDateString</methodname>, or returned
     by <methodname>DateTimeInterface::diff</methodname>, it increments or
     decrements the individual component values. The date part, that is years,
-    months, weeks and days, always increments or decrements the individual
-    component values. The two therefore only give a different result when a
+    months and days, always increments or decrements the individual component
+    values. The two therefore only give a different result when a
     timezone transition falls within the time part of the interval; see
     <link linkend="datetime.examples-arithmetic">Date/Time Arithmetic</link>.
    </simpara>

--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -29,14 +29,17 @@
     <methodname>DateTimeInterface::diff</methodname>.
    </para>
    <simpara>
-    How an interval is applied when it is added to, or subtracted from, a
-    date/time object depends on how the interval was created. An interval
-    created with <methodname>DateInterval::__construct</methodname> covers
-    elapsed time, whereas an interval created with
+    How the time part of an interval, that is hours, minutes, seconds and
+    microseconds, is applied when the interval is added to, or subtracted
+    from, a date/time object depends on how the interval was created. For an
+    interval created with <methodname>DateInterval::__construct</methodname>
+    the time part covers elapsed time, whereas for an interval created with
     <methodname>DateInterval::createFromDateString</methodname>, or returned
-    by <methodname>DateTimeInterface::diff</methodname>, increments or
-    decrements the individual component values. The two only give a different
-    result when a timezone transition falls within the interval; see
+    by <methodname>DateTimeInterface::diff</methodname>, it increments or
+    decrements the individual component values. The date part, that is years,
+    months, weeks and days, always increments or decrements the individual
+    component values. The two therefore only give a different result when a
+    timezone transition falls within the time part of the interval; see
     <link linkend="datetime.examples-arithmetic">Date/Time Arithmetic</link>.
    </simpara>
    <para>

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -28,26 +28,24 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>datetime</parameter></term>
-     <listitem>
-      <para>
-       A date with relative parts. Specifically, the
-       <link linkend="datetime.formats.relative">relative formats</link> supported
-       by the parser used for <classname>DateTimeImmutable</classname>,
-       <classname>DateTime</classname>, and <function>strtotime</function>
-       will be used to construct the DateInterval.
-      </para>
-      <para>
-       To use an ISO-8601 format string like <literal>P7D</literal>, you must
-       use the <methodname>DateInterval::__construct</methodname>.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>datetime</parameter></term>
+    <listitem>
+     <para>
+      A date with relative parts. Specifically, the
+      <link linkend="datetime.formats.relative">relative formats</link> supported
+      by the parser used for <classname>DateTimeImmutable</classname>,
+      <classname>DateTime</classname>, and <function>strtotime</function>
+      will be used to construct the DateInterval.
+     </para>
+     <para>
+      To use an ISO-8601 format string like <literal>P7D</literal>, you must
+      use the <methodname>DateInterval::__construct</methodname>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
@@ -110,10 +108,9 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Parsing valid date intervals</title>
-    <programlisting role="php" annotations="non-interactive">
+  <example>
+   <title>Parsing valid date intervals</title>
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Each set of intervals is equal.
@@ -138,13 +135,11 @@ $i = DateInterval::createFromDateString('1 day + 12 hours');
 $i = new DateInterval('PT3600S');
 $i = DateInterval::createFromDateString('3600 seconds');
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Parsing combinations and negative intervals</title>
-    <programlisting role="php">
+   </programlisting>
+  </example>
+  <example>
+   <title>Parsing combinations and negative intervals</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $i = DateInterval::createFromDateString('62 weeks + 1 day + 2 weeks + 2 hours + 70 minutes');
@@ -153,20 +148,18 @@ echo $i->format('%d %h %i'), "\n";
 $i = DateInterval::createFromDateString('1 year - 10 days');
 echo $i->format('%y %d'), "\n";
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 449 2 70
 1 -10
 ]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Parsing special relative date intervals</title>
-    <programlisting role="php">
+   </screen>
+  </example>
+  <example>
+   <title>Parsing special relative date intervals</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $i = DateInterval::createFromDateString('last day of next month');
@@ -175,9 +168,9 @@ var_dump($i);
 $i = DateInterval::createFromDateString('last weekday');
 var_dump($i);
 ]]>
-    </programlisting>
-    &example.outputs.82;
-    <screen role="php">
+   </programlisting>
+   &example.outputs.82;
+   <screen role="php">
 <![CDATA[
 object(DateInterval)#1 (2) {
   ["from_string"]=>
@@ -192,9 +185,9 @@ object(DateInterval)#2 (2) {
   string(12) "last weekday"
 }
 ]]>
-    </screen>
-    &example.outputs.8.similar;
-    <screen role="php">
+   </screen>
+   &example.outputs.8.similar;
+   <screen role="php">
 <![CDATA[
 object(DateInterval)#1 (16) {
   ["y"]=>
@@ -265,9 +258,8 @@ object(DateInterval)#2 (16) {
   int(1)
 }
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
 </refentry>

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -32,17 +32,17 @@
    <varlistentry>
     <term><parameter>datetime</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       A date with relative parts. Specifically, the
       <link linkend="datetime.formats.relative">relative formats</link> supported
       by the parser used for <classname>DateTimeImmutable</classname>,
       <classname>DateTime</classname>, and <function>strtotime</function>
       will be used to construct the DateInterval.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       To use an ISO-8601 format string like <literal>P7D</literal>, you must
       use the <methodname>DateInterval::__construct</methodname>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -113,7 +113,7 @@
    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-// Each set of intervals is equal.
+// Each set of intervals describes the same duration.
 $i = new DateInterval('P1D');
 $i = DateInterval::createFromDateString('1 day');
 
@@ -137,6 +137,16 @@ $i = DateInterval::createFromDateString('3600 seconds');
 ]]>
    </programlisting>
   </example>
+  <note>
+   <simpara>
+    Intervals in a set are not interchangeable when they are added to a
+    date/time object across a timezone transition: an interval created with
+    <methodname>DateInterval::__construct</methodname> covers elapsed time,
+    whereas an interval created with this method increments or decrements the
+    individual component values. See
+    <link linkend="datetime.examples-arithmetic">Date/Time Arithmetic</link>.
+   </simpara>
+  </note>
   <example>
    <title>Parsing combinations and negative intervals</title>
    <programlisting role="php">

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -139,11 +139,13 @@ $i = DateInterval::createFromDateString('3600 seconds');
   </example>
   <note>
    <simpara>
-    Intervals in a set are not interchangeable when they are added to a
-    date/time object across a timezone transition: an interval created with
-    <methodname>DateInterval::__construct</methodname> covers elapsed time,
-    whereas an interval created with this method increments or decrements the
-    individual component values. See
+    The intervals in a set that have a time part, such as
+    <literal>P1DT12H</literal> and <literal>1 day + 12 hours</literal>, are
+    not interchangeable when they are added to a date/time object and a
+    timezone transition falls within that time part: for an interval created
+    with <methodname>DateInterval::__construct</methodname> the time part
+    covers elapsed time, whereas for an interval created with this method it
+    increments or decrements the individual component values. See
     <link linkend="datetime.examples-arithmetic">Date/Time Arithmetic</link>.
    </simpara>
   </note>

--- a/reference/datetime/datetimeimmutable/add.xml
+++ b/reference/datetime/datetimeimmutable/add.xml
@@ -117,6 +117,7 @@ echo $newDate2->format('Y-m-d') . "\n";
    <member><function>DateTimeImmutable::sub</function></member>
    <member><function>DateTimeImmutable::diff</function></member>
    <member><function>DateTimeImmutable::modify</function></member>
+   <member><link linkend="datetime.examples-arithmetic">Date/Time Arithmetic</link></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -155,6 +155,7 @@ echo $newDate2->format('Y-m-d') . "\n";
    <member><function>DateTimeImmutable::add</function></member>
    <member><function>DateTimeImmutable::diff</function></member>
    <member><function>DateTimeImmutable::modify</function></member>
+   <member><link linkend="datetime.examples-arithmetic">Date/Time Arithmetic</link></member>
   </simplelist>
  </refsect1>
 

--- a/reference/datetime/examples.xml
+++ b/reference/datetime/examples.xml
@@ -10,14 +10,13 @@
    The following examples show some pitfalls of Date/Time arithmetic with regard
    to DST transitions and months having different numbers of days.
   </para>
-  <para>
-   <example>
-    <title>DateTimeImmutable::add/sub add intervals which cover elapsed time</title>
-    <simpara>
-     Adding PT24H over a DST transition will appear to add 23/25 hours (for
-     most timezones).
-    </simpara>
-    <programlisting role="php">
+  <example>
+   <title>DateTimeImmutable::add/sub add intervals which cover elapsed time</title>
+   <simpara>
+    Adding PT24H over a DST transition will appear to add 23/25 hours (for
+    most timezones).
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New_York"));
@@ -25,25 +24,23 @@ echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->add(new DateInterval("PT3H"));
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Start: 2015-11-01 00:00:00 -04:00
 End:   2015-11-01 02:00:00 -05:00
 ]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>DateTimeImmutable::modify and strtotime increment or decrement individual component values</title>
-    <simpara>
-     Adding +24 hours over a DST transition will add exactly 24 hours as seen in
-     the date/time string (unless the start or end time is on a transition
-     point).
-    </simpara>
-    <programlisting role="php">
+   </screen>
+  </example>
+  <example>
+   <title>DateTimeImmutable::modify and strtotime increment or decrement individual component values</title>
+   <simpara>
+    Adding +24 hours over a DST transition will add exactly 24 hours as seen in
+    the date/time string (unless the start or end time is on a transition
+    point).
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New_York"));
@@ -51,24 +48,22 @@ echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+24 hours");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Start: 2015-11-01 00:00:00 -04:00
 End:   2015-11-02 00:00:00 -05:00
 ]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Adding or subtracting times can over- or underflow dates</title>
-    <simpara>
-     Like where January 31st + 1 month will result in March 2nd (leap year) or
-     3rd (normal year).
-    </simpara>
-    <programlisting role="php">
+   </screen>
+  </example>
+  <example>
+   <title>Adding or subtracting times can over- or underflow dates</title>
+   <simpara>
+    Like where January 31st + 1 month will result in March 2nd (leap year) or
+    3rd (normal year).
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 echo "Normal year:\n"; // February has 28 days
@@ -83,9 +78,9 @@ echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+1 month");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Normal year:
 Start: 2015-01-31 00:00:00 -05:00
@@ -94,12 +89,12 @@ Leap year:
 Start: 2016-01-31 00:00:00 -05:00
 End:   2016-03-02 00:00:00 -05:00
 ]]>
-    </screen>
-    <simpara>
-     To get the last day of the next month (i.e. to prevent the overflow),
-     the <literal>last day of</literal> format is available.
-    </simpara>
-    <programlisting role="php">
+   </screen>
+   <simpara>
+    To get the last day of the next month (i.e. to prevent the overflow),
+    the <literal>last day of</literal> format is available.
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 echo "Normal year:\n"; // February has 28 days
@@ -114,9 +109,9 @@ echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("last day of next month");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Normal year:
 Start: 2015-01-31 00:00:00 -05:00
@@ -125,9 +120,8 @@ Leap year:
 Start: 2016-01-31 00:00:00 -05:00
 End:   2016-02-29 00:00:00 -05:00
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </section>
 
 </chapter>

--- a/reference/datetime/examples.xml
+++ b/reference/datetime/examples.xml
@@ -58,6 +58,33 @@ End:   2015-11-02 00:00:00 -05:00
    </screen>
   </example>
   <example>
+   <title>DateInterval::createFromDateString creates intervals which increment or decrement component values</title>
+   <simpara>
+    <methodname>DateInterval::createFromDateString</methodname> uses the
+    date/time parser, and the resulting interval increments or decrements the
+    individual component values. Only an interval created with
+    <methodname>DateInterval::__construct</methodname> covers elapsed time, so
+    the two are not interchangeable across a timezone transition.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New_York"));
+echo "Start:    ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "PT24H:    ", $dt->add(new DateInterval("PT24H"))->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "24 hours: ", $dt->add(DateInterval::createFromDateString("24 hours"))->format("Y-m-d H:i:s P"), PHP_EOL;
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Start:    2015-11-01 00:00:00 -04:00
+PT24H:    2015-11-01 23:00:00 -05:00
+24 hours: 2015-11-02 00:00:00 -05:00
+]]>
+   </screen>
+  </example>
+  <example>
    <title>Adding or subtracting times can over- or underflow dates</title>
    <simpara>
     Like where January 31st + 1 month will result in March 2nd (leap year) or

--- a/reference/datetime/examples.xml
+++ b/reference/datetime/examples.xml
@@ -61,10 +61,13 @@ End:   2015-11-02 00:00:00 -05:00
    <title>DateInterval::createFromDateString creates intervals which increment or decrement component values</title>
    <simpara>
     <methodname>DateInterval::createFromDateString</methodname> uses the
-    date/time parser, and the resulting interval increments or decrements the
-    individual component values. Only an interval created with
-    <methodname>DateInterval::__construct</methodname> covers elapsed time, so
-    the two are not interchangeable across a timezone transition.
+    date/time parser, and the time part of the resulting interval increments
+    or decrements the individual component values. For an interval created
+    with <methodname>DateInterval::__construct</methodname> the time part
+    covers elapsed time instead, so the two are not interchangeable when a
+    timezone transition falls within that time part. The date part is applied
+    the same way by both, so <literal>P1D</literal> and
+    <literal>1 day</literal> always give the same result.
    </simpara>
    <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
Fixes: #5653

`DateTimeImmutable::add()` applies the **time part** of an interval, that is hours, minutes, seconds and microseconds, in one of two ways, and it picks based on how the interval was created rather than on what the interval holds:

| Created by | Time part applied as |
| --- | --- |
| `new DateInterval('PT24H')` | elapsed time |
| `DateInterval::createFromDateString('24 hours')` | component values, like `modify()` |
| `DateTimeInterface::diff()` | component values |

The **date part**, that is years, months and days, always increments or decrements the individual component values, whichever way the interval was created: `P1D` and `'1 day'` never diverge. The two therefore only give a different result when a timezone transition falls within the time part, `PT24H` versus `'24 hours'` across a DST transition being the canonical case.

Nothing documented this, and the first example on the `DateInterval::createFromDateString` page claimed the opposite ("Each set of intervals is equal."), for sets that mostly cannot diverge at all.

The first commit unwraps the examples and lists of the two files it touches from their surrounding `para`; the others are the change itself. Example output verified on PHP 8.5.4.

Sources (line numbers as of php-src `3c6a57189e`):

- `add()`/`sub()` branch on `civil_or_wall`: `ext/date/php_date.c:3432` and `:3497`
- `DateInterval::__construct` sets `PHP_DATE_WALL`: `ext/date/php_date.c:4646`
- `DateInterval::createFromDateString` sets `PHP_DATE_CIVIL`: `ext/date/php_date.c:4890`
- `DateTimeInterface::diff` sets `PHP_DATE_CIVIL`: `ext/date/php_date.c:4021`
- only `h`/`i`/`s`/`us` are added to `sse` in wall mode, `y`/`m`/`d` go through the same `timelib_update_ts` as in civil mode: `ext/date/lib/interval.c`, `timelib_add_wall` versus `timelib_add`
