### PR TITLE
Describe how non-ASCII variable names behave instead of asserting they are unsupported

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -29,9 +29,10 @@
     </simpara>
     <simpara>
      One consequence is that names written in UTF-8 work, because every byte of
-     a UTF-8 multi-byte sequence falls inside the accepted range. So do names
-     written in other encodings, and so do byte sequences that are not valid
-     text in any encoding.
+     a UTF-8 multi-byte sequence falls inside the accepted range. The same holds
+     for any encoding whose non-ASCII bytes all fall in that range, and for byte
+     sequences that are not valid text in any encoding. Encodings that use bytes
+     below 128 within a multi-byte sequence, such as Shift-JIS or UTF-16, do not.
     </simpara>
     <simpara>
      Another is that two names which display identically may be distinct.

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -23,10 +23,21 @@
 
    <note>
     <simpara>
-     PHP doesn't support Unicode variable names, however, some character
-     encodings (such as UTF-8) encode characters in such a way that all bytes
-     of a multi-byte character fall within the allowed range, thus making it a
-     valid variable name.
+     Variable names are compared as bytes, not as characters. PHP does not
+     interpret or validate the encoding of the bytes from 128 through 255, and
+     two names refer to the same variable only when their bytes are identical.
+    </simpara>
+    <simpara>
+     One consequence is that names written in UTF-8 work, because every byte of
+     a UTF-8 multi-byte sequence falls inside the accepted range. So do names
+     written in other encodings, and so do byte sequences that are not valid
+     text in any encoding.
+    </simpara>
+    <simpara>
+     Another is that two names which display identically may be distinct.
+     <literal>ä</literal> encoded as U+00E4 and as <literal>a</literal>
+     followed by the combining diaeresis U+0308 are different variables, as are
+     a name with and without a trailing U+00A0 NO-BREAK SPACE.
     </simpara>
    </note>
 


### PR DESCRIPTION
The current note says PHP "doesn't support Unicode variable names" and then
explains that they work anyway. That leaves a reader with `$größe` in their
codebase unable to tell what the language actually guarantees.

This replaces the assertion with a description of the observable behaviour:
names are compared as bytes, the encoding is neither interpreted nor
validated, and two names that render identically can be distinct. All three
statements are checkable against the engine today.

It deliberately makes no claim about whether non-ASCII names are a *supported
feature*. That question is currently open on internals and the manual should
not pre-empt it in either direction:
https://news-web.php.net/php.internals/132344

The look-alike hazard is not hypothetical. In a survey of the 5,000
most-downloaded Packagist packages (520,802 files), 68 identifiers contain an
invisible character. One live example is the Alipay OpenAPI SDK, which assigns
to `$chrtext` with a trailing U+00A0 and then passes that variable by
reference, so anyone typing the name without the no-break space gets a
silently different variable. Data and tooling: https://github.com/Otzie2023/PHP