### PR TITLE
Document the PHP 8.5 backward incompatible changes

### DIFF
--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -17,6 +17,22 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Changed: A method that returns <type>static</type> may now be overridden
+       in a <modifier>final</modifier> class to declare <type>self</type> or the
+       class's own type as its return type, as these are equivalent to
+       <type>static</type> in a class that cannot be extended further.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Changed: <link linkend="language.oop5.traits">Traits</link> are now bound
+       to a class before its parent class.
+      </entry>
+     </row>
+     <row>
       <entry>8.4.0</entry>
       <entry>
        Added: Support for <link linkend="language.oop5.property-hooks">Property Hooks</link>.

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -71,6 +71,19 @@ Hello World!
     by a Trait. The precedence order is that members from the current class
     override Trait methods, which in turn override inherited methods.
    </para>
+   <note>
+    <simpara>
+     As of PHP 8.5.0, traits are bound to a class before its parent class;
+     previously they were bound after. This more closely reflects the copy and
+     paste semantics of traits. In particular, when a trait and the parent class
+     both declare a property or constant of the same name, the trait's
+     definition now takes precedence over the inherited one, whereas earlier
+     versions raised a fatal error about an incompatible composition. Method
+     resolution is unaffected. See
+     <link linkend="migration85.incompatible.core.trait-binding">the migration
+     guide</link> for details.
+    </simpara>
+   </note>
    <example xml:id="language.oop5.traits.precedence.examples.ex1">
     <title>Precedence Order Example</title>
     <para>

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -136,6 +136,17 @@ Mavrick barks
 ]]>
    </screen>
   </informalexample>
+  <note>
+   <simpara>
+    As of PHP 8.5.0, when a parent method declares <type>static</type> as its
+    return type, an overriding method in a <modifier>final</modifier> class may
+    declare <type>self</type> or the class's own type as its return type
+    instead, since these are equivalent to <type>static</type> in a class that
+    cannot be extended further. See
+    <link linkend="migration85.incompatible.core.substitute-final-subclasses">the
+    migration guide</link> for details.
+   </simpara>
+  </note>
  </sect2>
 
  <sect2 xml:id="language.oop5.variance.contravariance">

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -347,6 +347,21 @@ function standard_array_compare($op1, $op2)
    applied to comparable values. The result of comparing incomparable values is
    undefined, and should not be relied upon.
   </simpara>
+  <note>
+   <simpara>
+    As of PHP 8.5.0, loosely comparing an <type>object</type> that is not
+    comparable (such as an enum, <classname>CurlHandle</classname>, or another
+    internal class) against a <type>bool</type> using <literal>==</literal> or
+    <literal>!=</literal> consistently evaluates as if the object were cast to
+    <type>bool</type>, that is <literal>(bool) $object</literal>. Because such an
+    object always casts to &true;, it is equal to &true; and not equal to
+    &false;. Prior to PHP 8.5.0, this only applied when comparing against a
+    boolean literal (<literal>$object == true</literal>); comparing against a
+    boolean value held in a variable always returned &false;. See
+    <link linkend="migration85.incompatible.core.loosely-comparing-object">the
+    migration guide</link> for details.
+   </simpara>
+  </note>
  </sect2>
 
  <sect2 role="seealso">

--- a/language/predefined/attributes/attribute.xml
+++ b/language/predefined/attributes/attribute.xml
@@ -182,6 +182,10 @@
        <entry>8.5.0</entry>
        <entry>
         Added <constant>Attribute::TARGET_CONSTANT</constant>.
+        Applying <code>#[\Attribute]</code> to an abstract class, enum,
+        interface, or trait now triggers a compile-time error (previously
+        it was only reported at runtime when
+        <methodname>ReflectionAttribute::newInstance</methodname> was called).
        </entry>
       </row>
      </tbody>

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -216,16 +216,17 @@ var_dump(intval(8.1)); // 8 in both cases
     <literal>+/- 9.22e+18 = 2^63</literal> on 64-bit platforms),
     the result is undefined, since the <type>float</type> doesn't
     have enough precision to give an exact <type>int</type> result.
-    As of PHP 8.5.0, a warning is emitted when a <type>float</type> that is
-    not representable as an <type>int</type> is cast to one. Prior to PHP
-    8.5.0, no warning, not even a notice, was issued.
+    As of PHP 8.5.0, an <constant>E_WARNING</constant> is emitted when a
+    <type>float</type> that is not representable as an <type>int</type> is
+    cast to one. Prior to PHP 8.5.0, no diagnostic at all was issued.
    </simpara>
 
    <note>
     <simpara>
      <literal>NaN</literal>, <literal>Inf</literal> and <literal>-Inf</literal> will always be zero when cast to <type>int</type>.
-     As of PHP 8.5.0, casting them to <type>int</type> emits a warning, as
-     does casting <constant>NAN</constant> to any other type.
+     As of PHP 8.5.0, casting them to <type>int</type> emits an
+     <constant>E_WARNING</constant>, as does casting <constant>NAN</constant>
+     to any other type.
     </simpara>
    </note>
 

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -210,19 +210,23 @@ var_dump(intval(8.1)); // 8 in both cases
     </programlisting>
    </example>
 
-   <para>
+   <simpara>
     If the float is beyond the boundaries of <type>int</type> (usually
     <literal>+/- 2.15e+9 = 2^31</literal> on 32-bit platforms and
     <literal>+/- 9.22e+18 = 2^63</literal> on 64-bit platforms),
     the result is undefined, since the <type>float</type> doesn't
     have enough precision to give an exact <type>int</type> result.
-    No warning, not even a notice will be issued when this happens!
-   </para>
+    As of PHP 8.5.0, a warning is emitted when a <type>float</type> that is
+    not representable as an <type>int</type> is cast to one. Prior to PHP
+    8.5.0, no warning, not even a notice, was issued.
+   </simpara>
 
    <note>
-    <para>
+    <simpara>
      <literal>NaN</literal>, <literal>Inf</literal> and <literal>-Inf</literal> will always be zero when cast to <type>int</type>.
-    </para>
+     As of PHP 8.5.0, casting them to <type>int</type> emits a warning, as
+     does casting <constant>NAN</constant> to any other type.
+    </simpara>
    </note>
 
    <warning>

--- a/reference/array/functions/list.xml
+++ b/reference/array/functions/list.xml
@@ -88,6 +88,12 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Destructuring a non-array value (other than &null;) now emits a warning.
+       </entry>
+      </row>
+      <row>
        <entry>7.3.0</entry>
        <entry>
         Support for reference assignments in array destructuring was added.

--- a/reference/array/functions/list.xml
+++ b/reference/array/functions/list.xml
@@ -90,7 +90,8 @@
       <row>
        <entry>8.5.0</entry>
        <entry>
-        Destructuring a non-array value (other than &null;) now emits a warning.
+        Destructuring a non-array value (other than &null;) now emits an
+        <constant>E_WARNING</constant>.
        </entry>
       </row>
       <row>

--- a/reference/funchand/functions/register-tick-function.xml
+++ b/reference/funchand/functions/register-tick-function.xml
@@ -49,6 +49,34 @@
   </para>
  </refsect1>
 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Tick handlers are now deactivated later during request shutdown: after
+       all shutdown functions and destructors have run, and after the output
+       handlers have been cleaned up. Previously they were deactivated at the
+       very beginning of request shutdown, so tick functions were no longer
+       called during shutdown functions, destructors, or output handling. See
+       <link linkend="migration85.incompatible.core.tick-handlers">the
+       migration guide</link> for details.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/spl/arrayiterator/construct.xml
+++ b/reference/spl/arrayiterator/construct.xml
@@ -28,9 +28,10 @@
     <varlistentry>
      <term><parameter>array</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The array or object to be iterated on.
-      </para>
+       Passing an <type>object</type> is deprecated as of PHP 8.5.0.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -44,6 +45,35 @@
     </varlistentry>
    </variablelist>
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Passing an enum as <parameter>array</parameter> now throws an
+       <exceptionname>InvalidArgumentException</exceptionname>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Passing an <type>object</type> as <parameter>array</parameter> is deprecated.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/spl/arrayiterator/construct.xml
+++ b/reference/spl/arrayiterator/construct.xml
@@ -78,11 +78,11 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>ArrayIterator::getArrayCopy</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>ArrayIterator::getArrayCopy</methodname></member>
+   <member><methodname>ArrayIterator::setFlags</methodname></member>
+   <member><methodname>ArrayObject::__construct</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/arrayiterator/construct.xml
+++ b/reference/spl/arrayiterator/construct.xml
@@ -47,6 +47,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   As of PHP 8.5.0, throws an
+   <exceptionname>InvalidArgumentException</exceptionname> if
+   <parameter>array</parameter> is an enum.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>

--- a/reference/spl/arrayobject/construct.xml
+++ b/reference/spl/arrayobject/construct.xml
@@ -136,11 +136,11 @@ object(ArrayObject)#1 (1) {
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><methodname>ArrayObject::setflags</methodname></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><methodname>ArrayObject::setFlags</methodname></member>
+   <member><methodname>ArrayObject::getArrayCopy</methodname></member>
+   <member><methodname>ArrayIterator::__construct</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/arrayobject/construct.xml
+++ b/reference/spl/arrayobject/construct.xml
@@ -17,6 +17,14 @@
   <para>
    This constructs a new array <type>object</type>.
   </para>
+  <warning>
+   <simpara>
+    As of PHP 8.5.0, passing an enum as the <parameter>array</parameter>
+    parameter throws an <exceptionname>InvalidArgumentException</exceptionname>.
+    Modifying the <literal>$name</literal> or <literal>$value</literal>
+    properties of an enum would break engine assumptions.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +34,11 @@
     <varlistentry>
      <term><parameter>array</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The <parameter>array</parameter> parameter accepts an
-       <type>array</type> or an <type>Object</type>.
-      </para>
+       <type>array</type> or an <type>object</type>.
+       Passing an <type>object</type> is deprecated as of PHP 8.5.0.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -52,6 +61,35 @@
     </varlistentry>
    </variablelist>
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Passing an enum as <parameter>array</parameter> now throws an
+       <exceptionname>InvalidArgumentException</exceptionname>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Passing an <type>object</type> as <parameter>array</parameter> is deprecated.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/spl/arrayobject/construct.xml
+++ b/reference/spl/arrayobject/construct.xml
@@ -63,6 +63,15 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   As of PHP 8.5.0, throws an
+   <exceptionname>InvalidArgumentException</exceptionname> if
+   <parameter>array</parameter> is an enum.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>


### PR DESCRIPTION
Documents PHP 8.5 core backward incompatible changes.

- `language/types/integer.xml`: warning when a float that is not representable as an int is cast to one, and when `NAN` is coerced to another type ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833290), [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833295))
- `reference/array/functions/list.xml`: destructuring a non-array value other than `null` now emits a warning ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833286))
- `language/predefined/attributes/attribute.xml`: applying `#[\Attribute]` to an abstract class, enum, interface or trait is now a compile-time error ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833277))
- `language/oop5/traits.xml`, `language/oop5/changelog.xml`: traits are now bound to a class before its parent ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833263))
- `language/oop5/variance.xml`: a `static` return type may now be substituted with `self` or the class name in a final class ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833250))
- `language/operators/comparison.xml`: loosely comparing an uncomparable object against a bool is now consistent ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833237))
- `reference/funchand/functions/register-tick-function.xml`: tick handlers are now deactivated after shutdown functions and destructors ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833257))
- `reference/spl/arrayobject/construct.xml`, `reference/spl/arrayiterator/construct.xml`: enums are refused, and passing an object is deprecated ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199834805), [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199834832))