### PR TITLE
Document the PHP 8.5 new warnings and exceptions

### DIFF
--- a/reference/bzip2/functions/bzcompress.xml
+++ b/reference/bzip2/functions/bzcompress.xml
@@ -113,6 +113,8 @@ echo $bzstr;
   &reftitle.seealso;
   <simplelist>
    <member><function>bzdecompress</function></member>
+   <member><function>bzopen</function></member>
+   <member><function>gzcompress</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/bzip2/functions/bzcompress.xml
+++ b/reference/bzip2/functions/bzcompress.xml
@@ -61,6 +61,39 @@
    The compressed string, or an error number if an error occurred.
   </simpara>
  </refsect1>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   As of PHP 8.5.0, a <exceptionname>ValueError</exceptionname> is thrown if
+   <parameter>block_size</parameter> is not between 1 and 9, or if
+   <parameter>work_factor</parameter> is not between 0 and 250.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       A <exceptionname>ValueError</exceptionname> is now thrown if
+       <parameter>block_size</parameter> is not between 1 and 9, or if
+       <parameter>work_factor</parameter> is not between 0 and 250.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>

--- a/reference/fileinfo/functions/finfo-file.xml
+++ b/reference/fileinfo/functions/finfo-file.xml
@@ -85,6 +85,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       A <exceptionname>ValueError</exceptionname> is now thrown instead of a
+       <exceptionname>TypeError</exceptionname> when <parameter>filename</parameter>
+       contains null bytes.
+      </entry>
+     </row>
      &fileinfo.changelog.finfo-object;
      <row>
       <entry>8.0.0</entry>

--- a/reference/fileinfo/functions/finfo-file.xml
+++ b/reference/fileinfo/functions/finfo-file.xml
@@ -74,6 +74,16 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Throws a <exceptionname>ValueError</exceptionname> if
+   <parameter>filename</parameter> contains any null bytes.
+   Prior to PHP 8.5.0, a <exceptionname>TypeError</exceptionname> was thrown
+   instead.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -156,6 +156,13 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Calling the constructor on an already-constructed object now throws
+        an <exceptionname>Error</exceptionname>.
+       </entry>
+      </row>
+      <row>
        <entry>8.1.0</entry>
        <entry>
         <methodname>mysqli::connect</methodname> now returns &true; instead of &null; on success.

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -141,6 +141,10 @@
  <refsect1 role="errors">
   &reftitle.errors;
   &mysqli.conditionalexception;
+  <simpara>
+   As of PHP 8.5.0, calling the constructor on an already-constructed object
+   throws an <exceptionname>Error</exceptionname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -99,6 +99,16 @@
   </informaltable>
  </refsect1>
 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_fork</function></member>
+   <member><function>pcntl_waitpid</function></member>
+   <member><function>exec</function></member>
+   <member><function>proc_open</function></member>
+  </simplelist>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -66,6 +66,39 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   As of PHP 8.5.0, a <exceptionname>ValueError</exceptionname> is thrown if any
+   entry of <parameter>args</parameter> contains a null byte, or if any
+   entry or key of <parameter>env_vars</parameter> contains a null byte.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       A <exceptionname>ValueError</exceptionname> is now thrown if any entry of
+       <parameter>args</parameter> contains a null byte, or if any entry or
+       key of <parameter>env_vars</parameter> contains a null byte.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/session/functions/session-start.xml
+++ b/reference/session/functions/session-start.xml
@@ -76,6 +76,20 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   As of PHP 8.5.0, throws a <exceptionname>ValueError</exceptionname> if
+   <parameter>options</parameter> has any non-string key.
+  </simpara>
+  <simpara>
+   As of PHP 8.5.0, throws a <exceptionname>TypeError</exceptionname> if the
+   <literal>read_and_close</literal> option is not of type <type>string</type>,
+   <type>int</type> or <type>bool</type>, or if its value cannot be interpreted
+   as an <type>int</type>.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>

--- a/reference/session/functions/session-start.xml
+++ b/reference/session/functions/session-start.xml
@@ -89,6 +89,16 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Now throws a <exceptionname>ValueError</exceptionname> if the
+        <parameter>options</parameter> array has non-string keys, and a
+        <exceptionname>TypeError</exceptionname> if the
+        <literal>read_and_close</literal> value is not compatible with
+        <type>int</type>.
+       </entry>
+      </row>
+      <row>
        <entry>7.1.0</entry>
        <entry>
         <function>session_start</function> now returns &false; and no longer

--- a/reference/session/functions/session-write-close.xml
+++ b/reference/session/functions/session-write-close.xml
@@ -50,6 +50,14 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       If <varname>$_SESSION</varname> contains a key with a pipe character
+       (<literal>|</literal>), a warning is now emitted. Previously this
+       would silently fail to write the session data.
+      </entry>
+     </row>
+     <row>
       <entry>7.2.0</entry>
       <entry>
        The return type of this function is <type>bool</type> now.

--- a/reference/session/functions/session-write-close.xml
+++ b/reference/session/functions/session-write-close.xml
@@ -53,7 +53,7 @@
       <entry>8.5.0</entry>
       <entry>
        If <varname>$_SESSION</varname> contains a key with a pipe character
-       (<literal>|</literal>), a warning is now emitted. Previously this
+       (<literal>|</literal>), an <constant>E_WARNING</constant> is now emitted. Previously, this
        would silently fail to write the session data.
       </entry>
      </row>

--- a/reference/session/functions/session-write-close.xml
+++ b/reference/session/functions/session-write-close.xml
@@ -71,13 +71,11 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member>
-     The <function>session_register_shutdown</function>
-    </member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>session_register_shutdown</function></member>
+   <member><function>session_start</function></member>
+   <member><function>session_abort</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/simplexml/simplexmlelement/xpath.xml
+++ b/reference/simplexml/simplexmlelement/xpath.xml
@@ -40,6 +40,35 @@
    Returns an <type>array</type> of SimpleXMLElement objects on success; or &null; or &false; in
    case of an error.
   </para>
+  <simpara>
+   As of PHP 8.5.0, if the XPath expression returns something other than a node set
+   (e.g. a boolean or number), a <constant>E_WARNING</constant> is emitted and
+   &false; is returned instead of silently returning an empty array.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       If the XPath expression returns a non-node-set result, an
+       <constant>E_WARNING</constant> is now emitted and &false; is returned.
+       Previously, an empty array was returned silently.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/simplexml/simplexmlelement/xpath.xml
+++ b/reference/simplexml/simplexmlelement/xpath.xml
@@ -61,7 +61,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       If the XPath expression returns a non-node-set result, an
+       If the XPath expression returns something other than a node set, an
        <constant>E_WARNING</constant> is now emitted and &false; is returned.
        Previously, an empty array was returned silently.
       </entry>

--- a/reference/simplexml/simplexmlelement/xpath.xml
+++ b/reference/simplexml/simplexmlelement/xpath.xml
@@ -42,7 +42,7 @@
   </para>
   <simpara>
    As of PHP 8.5.0, if the XPath expression returns something other than a node set
-   (e.g. a boolean or number), a <constant>E_WARNING</constant> is emitted and
+   (e.g. a boolean or number), an <constant>E_WARNING</constant> is emitted and
    &false; is returned instead of silently returning an empty array.
   </simpara>
  </refsect1>

--- a/reference/tidy/tidy/construct.xml
+++ b/reference/tidy/tidy/construct.xml
@@ -93,6 +93,16 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> if
+       <parameter>config</parameter> contains an unknown option or attempts to
+       set a read-only one, and a <exceptionname>TypeError</exceptionname> if a
+       configuration key is not a string, or if an option does not accept the
+       given value.
+      </entry>
+     </row>
+     <row>
       <entry>8.4.0</entry>
       <entry>
        Failures when executing the constructor now throw instead of silently

--- a/reference/tidy/tidy/parsefile.xml
+++ b/reference/tidy/tidy/parsefile.xml
@@ -106,6 +106,16 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> if
+       <parameter>config</parameter> contains an unknown option or attempts to
+       set a read-only one, and a <exceptionname>TypeError</exceptionname> if a
+       configuration key is not a string, or if an option does not accept the
+       given value.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        <parameter>config</parameter> and <parameter>encoding</parameter> are nullable now.

--- a/reference/tidy/tidy/parsestring.xml
+++ b/reference/tidy/tidy/parsestring.xml
@@ -93,6 +93,16 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Now throws a <exceptionname>ValueError</exceptionname> if
+       <parameter>config</parameter> contains an unknown option or attempts to
+       set a read-only one, and a <exceptionname>TypeError</exceptionname> if a
+       configuration key is not a string, or if an option does not accept the
+       given value.
+      </entry>
+     </row>
+     <row>
       <entry>8.0.0</entry>
       <entry>
        <parameter>config</parameter> and <parameter>encoding</parameter> are nullable now.


### PR DESCRIPTION
Documents the PHP 8.5 new warnings and exceptions on the reference pages concerned.

- `bzcompress()`: `ValueError` on out-of-range `$block_size` or `$work_factor` ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833464), [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833469))
- `pcntl_exec()`: `ValueError` on null bytes in `$args` or `$env_vars` ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833507), [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833513))
- `finfo_file()`: `ValueError` instead of `TypeError` on null bytes in `$filename` ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833476))
- `mysqli::__construct()`: `Error` when the object is already constructed ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833503))
- `session_start()`: `ValueError` on non-string option keys, `TypeError` on an incompatible `read_and_close` value ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833622))
- `session_write_close()`: warning when a `$_SESSION` key contains a pipe character ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833612))
- `SimpleXMLElement::xpath()`: warning and `false` on a non-node-set result ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833627))
- `tidy::__construct()`, `tidy::parseFile()`, `tidy::parseString()`: `ValueError` and `TypeError` on invalid configuration entries ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833678))