### PR TITLE
Add ENT_SUBSTITUTE example with invalid UTF-8 bytes to htmlspecialchars()

### DIFF
--- a/reference/strings/functions/htmlspecialchars.xml
+++ b/reference/strings/functions/htmlspecialchars.xml
@@ -251,6 +251,27 @@ echo $new; // &lt;a href=&#039;test&#039;&gt;Test&lt;/a&gt;
     </programlisting>
    </example>
   </para>
+  <para>
+   <example>
+    <title><constant>ENT_IGNORE</constant> and <constant>ENT_SUBSTITUTE</constant> with invalid UTF-8 sequences</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// "\x80" is not a valid UTF-8 byte sequence.
+$input = "atta\x80ck";
+
+// ENT_IGNORE silently drops the invalid byte - output: "attack"
+echo bin2hex(htmlspecialchars($input, ENT_QUOTES | ENT_IGNORE, 'UTF-8')), "\n";
+// 61747461636b
+
+// ENT_SUBSTITUTE replaces the invalid byte with U+FFFD - output: "atta" + replacement char + "ck"
+echo bin2hex(htmlspecialchars($input, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')), "\n";
+// 61747461efbfbd636b
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="notes">


### PR DESCRIPTION
Closes #5561.

The `ENT_SUBSTITUTE` flag is documented in the parameters table but has no usage example. This adds a second example to the Examples section showing how `ENT_SUBSTITUTE` and `ENT_IGNORE` handle invalid UTF-8 byte sequences differently.