### PR TITLE
Fixes the "Display full permissions" example using `fileperms`.

### DIFF
--- a/reference/filesystem/functions/fileperms.xml
+++ b/reference/filesystem/functions/fileperms.xml
@@ -103,19 +103,19 @@ switch ($perms & 0xF000) {
 }
 
 // Owner
-$setuid  = $perms & 0x0800;
+$setuid = $perms & 0x0800;
 $info .= (($perms & 0x0100) ? 'r' : '-');
 $info .= (($perms & 0x0080) ? 'w' : '-');
 $info .= (($perms & 0x0040) ? ($setuid ? 's' : 'x') : ($setuid ? 'S' : '-'));
 
 // Group
-$setgid  = $perms & 0x0400;
+$setgid = $perms & 0x0400;
 $info .= (($perms & 0x0020) ? 'r' : '-');
 $info .= (($perms & 0x0010) ? 'w' : '-');
 $info .= (($perms & 0x0008) ? ($setgid ? 's' : 'x') : ($setgid ? 'S' : '-'));
 
 // World
-$sticky  = $perms & 0x0200;
+$sticky = $perms & 0x0200;
 $info .= (($perms & 0x0004) ? 'r' : '-');
 $info .= (($perms & 0x0002) ? 'w' : '-');
 $info .= (($perms & 0x0001) ? ($sticky ? 't' : 'x') : ($sticky ? 'T' : '-'));

--- a/reference/filesystem/functions/fileperms.xml
+++ b/reference/filesystem/functions/fileperms.xml
@@ -90,51 +90,35 @@ echo substr(sprintf('%o', fileperms('/etc/passwd')), -4);
 $perms = fileperms('/etc/passwd');
 
 switch ($perms & 0xF000) {
-    case 0xC000: // socket
-        $info = 's';
-        break;
-    case 0xA000: // symbolic link
-        $info = 'l';
-        break;
-    case 0x8000: // regular
-        $info = 'r';
-        break;
-    case 0x6000: // block special
-        $info = 'b';
-        break;
-    case 0x4000: // directory
-        $info = 'd';
-        break;
-    case 0x2000: // character special
-        $info = 'c';
-        break;
-    case 0x1000: // FIFO pipe
-        $info = 'p';
-        break;
-    default: // unknown
-        $info = 'u';
+    case 0x1000: $info = 'p'; break; // FIFO pipe
+    case 0x2000: $info = 'c'; break; // character special
+    case 0x4000: $info = 'd'; break; // directory
+    case 0x6000: $info = 'b'; break; // block special
+    case 0x8000: $info = '-'; break; // regular
+    case 0xA000: $info = 'l'; break; // symbolic link (reachable when using lstat function)
+    case 0xC000: $info = 's'; break; // socket
+
+    // unknown
+    default: $info = 'u';
 }
 
 // Owner
+$setuid  = $perms & 0x0800;
 $info .= (($perms & 0x0100) ? 'r' : '-');
 $info .= (($perms & 0x0080) ? 'w' : '-');
-$info .= (($perms & 0x0040) ?
-            (($perms & 0x0800) ? 's' : 'x' ) :
-            (($perms & 0x0800) ? 'S' : '-'));
+$info .= (($perms & 0x0040) ? ($setuid ? 's' : 'x') : ($setuid ? 'S' : '-'));
 
 // Group
+$setgid  = $perms & 0x0400;
 $info .= (($perms & 0x0020) ? 'r' : '-');
 $info .= (($perms & 0x0010) ? 'w' : '-');
-$info .= (($perms & 0x0008) ?
-            (($perms & 0x0400) ? 's' : 'x' ) :
-            (($perms & 0x0400) ? 'S' : '-'));
+$info .= (($perms & 0x0008) ? ($setgid ? 's' : 'x') : ($setgid ? 'S' : '-'));
 
 // World
+$sticky  = $perms & 0x0200;
 $info .= (($perms & 0x0004) ? 'r' : '-');
 $info .= (($perms & 0x0002) ? 'w' : '-');
-$info .= (($perms & 0x0001) ?
-            (($perms & 0x0200) ? 't' : 'x' ) :
-            (($perms & 0x0200) ? 'T' : '-'));
+$info .= (($perms & 0x0001) ? ($sticky ? 't' : 'x') : ($sticky ? 'T' : '-'));
 
 echo $info;
 ?>


### PR DESCRIPTION
In the *regular file* example, you are using `r`, when you should be using `-`:

```php
case 0x8000: // regular
    $info = 'r';
```

This is according to `ls -l`:

| Character | Description |
| --- | --- |
| `-` | regular |
| `d` | directory |
| `l` | symbolic link |
| `c` | character device |
| `b` | block device |
| `p` | FIFO |
| `s` | socket |

The page states that the output of the code for `/etc/passwd` is:

```
-rw-r--r--
```

However, I obtained this:

<img width="476" height="106" alt="Image" src="https://github.com/user-attachments/assets/903f045f-6d96-45f0-9142-9fa601ccf924" />

Another problem is that the use of `fileperms()` will never utilize this:

```php
case 0xA000: // symbolic link
    $info = 'l';
```

Test:

```bash
$ ln -s sample.txt samplelnk.txt
$ ls -l samplelnk.txt
lrwxrwxrwx 1 Brcontainer Brcontainer 10 Sep  7 16:46 samplelnk.txt -> sample.txt
```
Whereas in PHP (`$perms = fileperms('samplelnk.txt');`), I got this: `-rw-r--r--`.

Therefore, the snippet for the example is essentially _dead code_. I don't think this section needs to be removed, but it would be important to document it to avoid confusion.

> Note: In the code, I kept the parentheses solely to aid readability and understanding.