### PR TITLE
Document http context option uri_parser_class (PHP 8.5)

### DIFF
--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -194,8 +194,48 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="context.http.uri-parser-class">
+     <term>
+      <parameter>uri_parser_class</parameter>
+      <type>string</type> or <type>null</type>
+     </term>
+     <listitem>
+      <simpara>
+       The class to use for parsing URIs. When &null;, the legacy behavior
+       based on <function>parse_url</function> is used. Accepted values are
+       <classname>Uri\Rfc3986\Uri</classname> (RFC 3986 compliant parser) and
+       <classname>Uri\WhatWg\Url</classname> (WHATWG URL Standard parser).
+       Custom userland implementations are not supported.
+      </simpara>
+      <simpara>
+       Defaults to &null;.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The <parameter>uri_parser_class</parameter> option was added.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Closes #5833.

The `uri_parser_class` stream context option introduced in PHP 8.5 was not documented. This adds the option to the HTTP context options page, including accepted values (`Uri\Rfc3986\Uri` and `Uri\WhatWg\Url`) and a changelog entry.