### PR TITLE
Clarify Locale::getKeywords() return values and empty string argument

### DIFF
--- a/reference/intl/locale/get-keywords.xml
+++ b/reference/intl/locale/get-keywords.xml
@@ -35,9 +35,11 @@
     <varlistentry>
      <term><parameter>locale</parameter></term>
      <listitem>
-      <para>
-       The locale to extract the keywords from
-      </para>
+      <simpara>
+       The locale to extract the keywords from. If an empty string is
+       passed, the value returned by <function>locale_get_default</function>
+       is used instead.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -47,9 +49,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Associative <type>array</type> containing the keyword-value pairs for this locale
-  </para>
+  <simpara>
+   Associative <type>array</type> containing the keyword-value pairs for this locale,
+   &null; if the locale has no keywords, or &false; on failure.
+  </simpara>
   &intl.locale-len.return;
  </refsect1>
 
@@ -61,7 +64,7 @@
 <![CDATA[
 <?php
 $keywords_arr = locale_get_keywords('de_DE@currency=EUR;collation=PHONEBOOK');
-if ($keywords_arr) {
+if (is_array($keywords_arr)) {
     foreach ($keywords_arr as $key => $value) {
         echo "$key = $value\n";
     }
@@ -76,7 +79,7 @@ if ($keywords_arr) {
 <![CDATA[
 <?php
 $keywords_arr = Locale::getKeywords('de_DE@currency=EUR;collation=PHONEBOOK');
-if ($keywords_arr) {
+if (is_array($keywords_arr)) {
     foreach ($keywords_arr as $key => $value) {
         echo "$key = $value\n";
     }
@@ -99,6 +102,8 @@ currency = EUR
   <para>
    <simplelist>
     <member><function>locale_get_all_variants</function></member>
+    <member><function>locale_get_default</function></member>
+    <member><function>locale_set_default</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Closes #5596.

- Document that `null` is returned when the locale has no keywords (not only when the locale length exceeds `INTL_MAX_LOCALE_LEN`)
- Document that `false` is returned on failure
- Document that passing an empty string uses the default locale (`locale_get_default()`)
- Update examples to use `is_array()` to properly distinguish the three return cases (`array`, `null`, `false`)
- Add `locale_get_default` and `locale_set_default` to See Also