### PR TITLE
Correct the documented default of the http follow_location option

### DIFF
--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -128,9 +128,14 @@
        Follow <literal>Location</literal> header redirects. Set to
        <literal>0</literal> to disable.
       </para>
-      <para>
-       Defaults to <literal>1</literal>.
-      </para>
+      <simpara>
+       When this option is not set, redirects are only followed for the
+       <literal>300</literal>, <literal>301</literal>, <literal>302</literal>,
+       <literal>303</literal>, <literal>307</literal> and <literal>308</literal>
+       response codes. Setting it to <literal>1</literal> is not equivalent:
+       any response carrying a <literal>Location</literal> header is then
+       followed, whatever its response code.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="context.http.max-redirects">


### PR DESCRIPTION
Setting `follow_location` and leaving it unset are not equivalent, so documenting `1` as the default is misleading. When the option is absent, redirects are only followed for the 300, 301, 302, 303, 307 and 308 response codes. When it is set, any response carrying a `Location` header is followed, whatever its response code.

Fixes: #5832
