### PR TITLE
[open_basedir] Document that Unix domain sockets bypass the restriction

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1338,6 +1338,15 @@ include_path = ".:${USER}/pear/php"
          to <literal>0</literal> and thus <emphasis>disable</emphasis> the realpath cache.
         </para>
        </note>
+       <warning>
+        <simpara>
+         <option>open_basedir</option> does not restrict access to Unix domain sockets.
+         PHP socket functions such as <function>stream_socket_client</function> and
+         <function>fsockopen</function> can connect to a Unix socket path
+         (e.g. <filename>unix:///var/run/docker.sock</filename>)
+         regardless of the <option>open_basedir</option> setting.
+        </simpara>
+       </warning>
        <caution>
         <para>
          <literal>open_basedir</literal> is just an extra safety net, that is in no way


### PR DESCRIPTION
Closes #5644

`open_basedir` does not restrict access to Unix domain sockets. A script can connect to a socket such as `/var/run/docker.sock` via `stream_socket_client()` even when `open_basedir` is active.

Add a `<warning>` block to make this limitation explicit, placed just before the existing `<caution>` that already notes `open_basedir` is not a comprehensive security boundary.