### PR TITLE
[curl] Document PHP 8.5 curl changes

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -806,6 +806,13 @@
      is enabled.
      Available as of cURL 7.1.0.
     </para>
+    <simpara>
+     As of PHP 8.5.0, the value is treated as an integer.
+     <constant>CURLFOLLOW_ALL</constant> is equivalent to setting this option to &true;.
+     <constant>CURLFOLLOW_OBEYCODE</constant> follows redirects more strictly regarding
+     allowed redirect codes.
+     <constant>CURLFOLLOW_FIRSTONLY</constant> follows only the first redirect.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-forbid-reuse">
@@ -3804,6 +3811,18 @@
      &true; to enable and &false; to disable verification of the certificate's status.
      Available as of PHP 7.0.7 and cURL 7.41.0.
     </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-signature-algorithms">
+   <term>
+    <constant>CURLOPT_SSL_SIGNATURE_ALGORITHMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     A colon-separated list of signature algorithms to use for TLS authentication.
+     Available as of PHP 8.5.0 and cURL 7.89.0.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-stderr">

--- a/reference/curl/curlsharepersistenthandle.xml
+++ b/reference/curl/curlsharepersistenthandle.xml
@@ -10,7 +10,11 @@
   <section xml:id="curlsharepersistenthandle.intro">
    &reftitle.intro;
    <simpara>
-    Represents a persistent cURL "share" handle.
+    Represents a persistent cURL "share" handle, created by
+    <function>curl_share_init_persistent</function>.
+    Unlike <classname>CurlShareHandle</classname> (created with
+    <function>curl_share_init</function>), this handle persists across requests.
+    Use <function>curl_share_setopt</function> to configure what data is shared.
    </simpara>
   </section>
   <!-- }}} -->
@@ -51,6 +55,28 @@
   </section>
   <!-- }}} -->
 
+
+  <section role="changelog" xml:id="curlsharepersistenthandle.changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        The class was added.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/curl/functions/curl-multi-get-handles.xml
+++ b/reference/curl/functions/curl-multi-get-handles.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<refentry xml:id="function.curl-multi-get-handles" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>curl_multi_get_handles</refname>
+  <refpurpose>Return an array of CurlHandle objects currently attached to a CurlMultiHandle</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>curl_multi_get_handles</methodname>
+   <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Returns all <classname>CurlHandle</classname> objects currently attached to the given
+   <classname>CurlMultiHandle</classname>. This includes both handles added using
+   <function>curl_multi_add_handle</function> and handles accepted by a
+   <constant>CURLMOPT_PUSHFUNCTION</constant> callback.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    &curl.mh.description;
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Returns an array of <classname>CurlHandle</classname> objects.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       The function was added.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>curl_multi_add_handle</function></member>
+    <member><function>curl_multi_remove_handle</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Documents the following PHP 8.5 curl changes:

- [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833851)
- [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833941)
- [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833977)
- [PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833999)