### PR TITLE
Document that Locale::parseLocale() uses the default locale on empty string

### DIFF
--- a/reference/intl/locale/parse-locale.xml
+++ b/reference/intl/locale/parse-locale.xml
@@ -35,11 +35,12 @@
     <varlistentry>
      <term><parameter>locale</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The locale to extract the subtag array from. Note: The 'variant' and
        'private' subtags can take maximum 15 values whereas 'extlang' can take
-       maximum 3 values.
-      </para>
+       maximum 3 values. If an empty string is passed, the value returned by
+       <function>locale_get_default</function> is used instead.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,18 +49,15 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Returns an array containing a list of key-value pairs, where the keys
    identify the particular locale ID subtags, and the values are the
    associated subtag values. The array will be ordered as the locale id
-   subtags e.g. in the locale id if variants are '-varX-varY-varZ' then the
-   returned array will have variant0=&gt;varX , variant1=&gt;varY ,
-   variant2=&gt;varZ
-  </para>
-  <para>
-   Returns &null; when the length of <parameter>locale</parameter> exceeds
-   <constant>INTL_MAX_LOCALE_LEN</constant>.
-  </para>
+   subtags e.g. in the locale id if variants are <literal>-varX-varY-varZ</literal> then the
+   returned array will have <literal>variant0=varX</literal>,
+   <literal>variant1=varY</literal>, <literal>variant2=varZ</literal>.
+  </simpara>
+  &intl.locale-len.return;
  </refsect1>
 
  <refsect1 role="examples">
@@ -107,6 +105,8 @@ language : sl , script : Latn , region : IT , variant0 : NEDIS ,
   <para>
    <simplelist>
     <member><function>locale_compose</function></member>
+    <member><function>locale_get_default</function></member>
+    <member><function>locale_set_default</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/intl/locale/parse-locale.xml
+++ b/reference/intl/locale/parse-locale.xml
@@ -98,6 +98,28 @@ if ($arr) {
 language : sl , script : Latn , region : IT , variant0 : NEDIS ,
 ]]>
   </screen>
+  <example>
+   <title>Empty string uses the default locale</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+locale_set_default('fr-Latn-FR');
+$arr = locale_parse('');
+if ($arr) {
+    foreach ($arr as $key => $value) {
+        echo "$key : $value , ";
+    }
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+language : fr , script : Latn , region : FR ,
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/intl/locale/parse-locale.xml
+++ b/reference/intl/locale/parse-locale.xml
@@ -113,13 +113,13 @@ if ($arr) {
 ?>
 ]]>
    </programlisting>
-   &example.outputs;
-   <screen>
+  </example>
+  &example.outputs;
+  <screen>
 <![CDATA[
 language : fr , script : Latn , region : FR ,
 ]]>
-   </screen>
-  </example>
+  </screen>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/intl/locale/parse-locale.xml
+++ b/reference/intl/locale/parse-locale.xml
@@ -54,8 +54,8 @@
    identify the particular locale ID subtags, and the values are the
    associated subtag values. The array will be ordered as the locale id
    subtags e.g. in the locale id if variants are <literal>-varX-varY-varZ</literal> then the
-   returned array will have <literal>variant0=varX</literal>,
-   <literal>variant1=varY</literal>, <literal>variant2=varZ</literal>.
+   returned array will have <literal>variant0=&gt;varX</literal>,
+   <literal>variant1=&gt;varY</literal>, <literal>variant2=&gt;varZ</literal>.
   </simpara>
   &intl.locale-len.return;
  </refsect1>


### PR DESCRIPTION
- `reference/intl/locale/parse-locale.xml`: document that passing an empty string uses the default locale (via `locale_get_default()`); use `&intl.locale-len.return;` entity; fix `<para>` → `<simpara>`

Closes #5597