### PR TITLE
cloning: visibility applies to all properties, readonly is orthogonal

### DIFF
--- a/language/oop5/cloning.xml
+++ b/language/oop5/cloning.xml
@@ -168,10 +168,11 @@ echo (clone $dateTime)->format('Y');
    <simpara>
     The overrides are applied after
     <link linkend="object.clone">__clone()</link> has run, and they honour the
-    visibility of the properties: a
-    <link linkend="language.oop5.properties.readonly-properties">readonly</link>
-    property can only be overridden from a scope that is allowed to write it,
-    which makes the function suited to methods returning a modified copy.
+    visibility of all properties.
+    <link linkend="language.oop5.properties.readonly-properties">Readonly</link>
+    properties can be updated on the copy even if they were already set on the
+    original object, which makes the function suited to methods returning a
+    modified copy.
    </simpara>
 
    <example>


### PR DESCRIPTION
- `language/oop5/cloning.xml`: visibility is checked for all properties (not just `readonly`); `readonly` is a separate orthogonal constraint