### PR TITLE
[fpm] Document PHP 8.5 FPM changes: fastcgi.script_path_encoded and access log limit

### DIFF
--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -67,9 +67,10 @@
    <title>FPM</title>
 
    <simpara>
-    FPM with httpd ProxyPass optionally decodes the full script path. Added
-    <!-- <link linkend="ini.fastcgi.script_path_encoded"-->fastcgi.script_path_encoded<!-- </link> -->
-    INI setting to prevent this new behavior.
+    FPM with httpd ProxyPass can optionally decode the full script path as of PHP 8.5.0.
+    The new <link linkend="ini.fastcgi.script-path-encoded">fastcgi.script_path_encoded</link>
+    INI setting controls this behavior; it defaults to <literal>1</literal> to preserve
+    the previous behavior of not decoding the path.
    </simpara>
 
    <simpara>

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -806,10 +806,30 @@
        <type>string</type>
       </term>
       <listitem>
-       <para>
+       <simpara>
         The access log file.
-        Default value: not set
-       </para>
+        Default value: not set.
+       </simpara>
+       <simpara>
+        As of PHP 8.5.0, the access log line length limit respects the
+        global <link linkend="log-limit">log_limit</link> setting.
+       </simpara>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="ini.fastcgi.script-path-encoded">
+      <term>
+       <parameter>fastcgi.script_path_encoded</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <simpara>
+        When enabled (<literal>1</literal>, the default as of PHP 8.5.0),
+        FPM does not URL-decode the <literal>SCRIPT_FILENAME</literal> sent
+        by httpd <literal>ProxyPass</literal>, preserving the previous behavior.
+        Set to <literal>0</literal> to opt into the new behavior where FPM
+        URL-decodes the full script path.
+        Available as of PHP 8.5.0.
+       </simpara>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="access-format">


### PR DESCRIPTION
- `install/fpm/configuration.xml`: document `fastcgi.script_path_encoded` INI setting and `access.log` respecting `log_limit` as of PHP 8.5.0 ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833815))
- `appendices/migration85/other-changes.xml`: fix commented-out link to `fastcgi.script_path_encoded` ([PHP 8.5 Documentation Tracker](https://github.com/orgs/php/projects/13?pane=issue&itemId=199833824))