### PR TITLE
strpos: document that an empty needle matches at every position and returns the offset

### DIFF
--- a/reference/strings/functions/strpos.xml
+++ b/reference/strings/functions/strpos.xml
@@ -35,9 +35,15 @@
     <varlistentry>
      <term><parameter>needle</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        The string to search for.
-      </para>
+      </simpara>
+      <simpara>
+       Passing an empty string as <parameter>needle</parameter> matches at
+       every position. <function>strpos</function> returns
+       <parameter>offset</parameter> when it is specified, or
+       <literal>0</literal> otherwise.
+      </simpara>
       &strings.parameter.needle.non-string;
      </listitem>
     </varlistentry>


### PR DESCRIPTION
- `reference/strings/functions/strpos.xml`: document that passing an empty string as `$needle` matches at every position and returns `$offset` (or `0` if unspecified) (closes #4783)